### PR TITLE
Add GHA to publish to galaxy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Add release, date and commit hash to version in galaxy.yml
         run: >
-          ts=$(date +%Y%m%d%H%M);
+          ts=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%Y%m%d%H%M')
           sha=$(echo "${{ github.sha }}" | cut -c1-7);
           rel=$(grep ^Release ansible-collection-redhatci-ocp.spec | grep -Po '\d+\.');
           sed -ir "s/^(version: .*)$/&-${rel}${ts}git${sha}/" galaxy.yml;

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Ansible Galaxy Publish
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Ansible Publish to Galaxy
+        uses: ansible/ansible-publish-action@v1.0.0
+        with:
+          api_key: ${{ secrets.ANSIBLE_GALAXY_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Ansible Galaxy Publish
 on:
-  release:
-    types:
-      - published
+  push:
+    branches:
+      - main
 
 jobs:
   publish:
@@ -10,6 +10,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Add release, date and commit hash to version in galaxy.yml
+        run: >
+          ts=$(date +%Y%m%d%H%M);
+          sha=$(echo "${{ github.sha }}" | cut -c1-7);
+          rel=$(grep ^Release ansible-collection-redhatci-ocp.spec | grep -Po '\d+\.');
+          sed -ir "s/^(version: .*)$/&-${rel}${ts}git${sha}/" galaxy.yml;
+          grep ^version galaxy.yml
 
       - name: Ansible Publish to Galaxy
         uses: ansible/ansible-publish-action@v1.0.0


### PR DESCRIPTION
This GitHub Action publishes the collections to ansible-galaxy when creating a release

This is a proposal to publish to galaxy whenever we create a release, we could do it on merge in main or with a particular tag, let me know what do you think