### PR TITLE
Recreate Storage class

### DIFF
--- a/roles/nfs_external_storage/tasks/main.yml
+++ b/roles/nfs_external_storage/tasks/main.yml
@@ -56,6 +56,15 @@
         name: nfs-client-provisioner
         namespace: {{ nes_namespace }}
 
+- name: "Delete the managed-nfs-storage StorageClass"
+  community.kubernetes.k8s:
+    definition:
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
+      metadata:
+        name: managed-nfs-storage
+    state: absent
+
 - name: "Creating RBAC resources for nfs-client-provisioner"
   community.kubernetes.k8s:
     definition: |


### PR DESCRIPTION
- Storage class parameters are inmutable, removing the SC to be re-created with the new or the same parameters.
- That is the recommended practice, it does not affect the already provisioned volumes