### PR TITLE
Remove depencencies on DCI var

### DIFF
--- a/roles/check_resource/README.md
+++ b/roles/check_resource/README.md
@@ -15,3 +15,33 @@ resource\_to\_check         | Yes       | MachineConfigPool      | Name of the r
 check\_wait\_retries        | Yes       | Undefined              | Number of times in which the wait task is performed.
 check\_wait\_delay          | Yes       | Undefined              | Time spent between wait tasks' iterations.
 check\_reason               | No        | Undefined              | Reason for the check to be done.
+
+## Requirements
+
+A running OpenShift cluster with the proper credentials is required, credentials must be passed as by setting the KUBECONFIG environment.
+
+## Example of usage
+
+Confirm that Machine Config Pools are not updating
+```
+- name: "Wait for updated MCP after applying ICSP"
+  include_role:
+    name: redhatci.ocp.check_resource
+  vars:
+    resource_to_check: "MachineConfigPool"
+    check_wait_retries: 120
+    check_wait_delay: 10
+    check_reason: "Apply ICSPs for mirrored catalogs"
+```
+
+Confirm that OVN pods are running
+```
+- name: "Wait for updated MCP after applying ICSP"
+  include_role:
+    name: redhatci.ocp.check_resource
+  vars:
+    resource_to_check: "SriovNetworkNodeState"
+    check_wait_retries: 120
+    check_wait_delay: 10
+    check_reason: "Apply ICSPs for mirrored catalogs"
+```

--- a/roles/check_resource/tasks/main.yml
+++ b/roles/check_resource/tasks/main.yml
@@ -7,18 +7,12 @@
     - name: Check MCP application
       include_tasks:
         file: wait-mcp.yml
-        apply:
-          environment:
-            KUBECONFIG: "{{ kubeconfig_path }}"
       when: resource_to_check == "MachineConfigPool"
 
     # Check SriovNetworkNodeState application
     - name: Check SriovNetworkNodeState application
       include_tasks:
         file: wait-sriov.yml
-        apply:
-          environment:
-            KUBECONFIG: "{{ kubeconfig_path }}"
       when: resource_to_check == "SriovNetworkNodeState"
   delegate_to: localhost
 

--- a/roles/storage_tester/README.md
+++ b/roles/storage_tester/README.md
@@ -1,7 +1,10 @@
 # Storage Service Tests During Upgrade
 ### Requirements
-A default storage class must be defined before running these tests. If the variable `tester_storage_class` is defined, it will use this one instead.
-Also, the provisioner associated with this storage class must implement the CSI `CLONE_VOLUME` [capability](https://kubernetes-csi.github.io/docs/developing.html).
+
+* A default storage class must be defined before running these tests. If the variable `tester_storage_class` is defined, it will use this one instead.
+* the provisioner associated with the storage class must implement the CSI `CLONE_VOLUME` [capability](https://kubernetes-csi.github.io/docs/developing.html).
+* A running OpenShift cluster with the proper credentials is required, credentials must be passed as by setting the KUBECONFIG environment.
+
 For more information on storage classes, see [the OCP documentation](https://docs.openshift.com/container-platform/4.11/post_installation_configuration/storage-configuration.html#defining-storage-classes_post-install-storage-configuration).
 
 ### Three scenarios of tests
@@ -36,4 +39,16 @@ job.batch/storage-volume-reader-rox-27742365            2/1 of 2      16s       
 > Time of the test: 124m
 > Number of failures during this time: 1            # Because of the gathering method, this is just an estimation, specially on the last tests could be seens as a failure whereas it was working fine
 > Estimated percentage of failure: .800             # 0.8% of down time during the 2h the upgrade was running
+```
+
+## Example of usage
+```
+- name: "Gathering results for storage service tester"
+  include_role:
+    name: redhatci.ocp.storage_tester
+    apply:
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+        REGISTRY: "registry.redhat.io"
+        OC_PATH: "/usr/bin/oc"
 ```

--- a/roles/storage_tester/tasks/main.yml
+++ b/roles/storage_tester/tasks/main.yml
@@ -13,11 +13,8 @@
     api_version: v1
     kind: Namespace
     name: storage-tester
-    kubeconfig: "{{ kubeconfig_path }}"
 
 - name: "Get oc version output"
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
   shell: |
     {{ oc_tool_path }} version
   register: oc_version_str

--- a/roles/storage_tester/tasks/teardown.yml
+++ b/roles/storage_tester/tasks/teardown.yml
@@ -1,6 +1,5 @@
 - name: "Delete PVC used for upgrade tests"
   community.kubernetes.k8s:
-    kubeconfig: "{{ kubeconfig_path }}"
     api_version: v1
     kind: PersistentVolumeClaim
     name: "{{ pvc_to_be_deleted }}"
@@ -16,7 +15,6 @@
 
 - name: "Delete storage-tester Namespace"
   community.kubernetes.k8s:
-    kubeconfig: "{{ kubeconfig_path }}"
     api_version: v1
     kind: Namespace
     name: storage-tester


### PR DESCRIPTION
- kubeconfig path is a variable from DOA, we apply the pass the KUBECONFIG using apply. This will allow to run the role independently
- Minor updates to the docs