### PR TITLE
Apply Hugepages configuration to search pods

### DIFF
--- a/roles/acm_setup/README.md
+++ b/roles/acm_setup/README.md
@@ -19,12 +19,15 @@ The configuration of the ACM hub can be customized by using the following variab
 |hub_instance                        |multiclusterhub                |No           |Name of the multiclusterhub instance to be created (fail if already exists) |
 |hub_disconnected                    |false                          |No           |If true, it will create custom ClusterImageSets and remove the Channel subscriptions |
 |hub_sc                              |Undefined                      |If no default StorageClass is available | Desired storage class for ACM resources. If undefined, the default SC will be used |
+|hub_hugepages_2Mi                   |1024Mi                         |No           |Request of `hugepages-2Mi` to be configured for Postgres search pods|
 
 ## Requirements
 1. An Openshift Cluster with a subscription for the ACM operator.
 1. On air-gapped environments, the multicluster-engine operator must be available in the mirrored catalog
 
 It is highly recommended to provision a storage class with enough space available for volumes of the Assisted Service Config before starting deploying clusters. See [acm_sno](../acm_sno/README.md) for more details.
+
+In clusters configured with hugepages, the Postgres deployment requires hugepages to be configured too. Please allocate `hugepages-2Mi` to cover the Postgres' search requirement and other workload needs.
 
 ## Usage example
 

--- a/roles/acm_setup/README.md
+++ b/roles/acm_setup/README.md
@@ -19,7 +19,8 @@ The configuration of the ACM hub can be customized by using the following variab
 |hub_instance                        |multiclusterhub                |No           |Name of the multiclusterhub instance to be created (fail if already exists) |
 |hub_disconnected                    |false                          |No           |If true, it will create custom ClusterImageSets and remove the Channel subscriptions |
 |hub_sc                              |Undefined                      |If no default StorageClass is available | Desired storage class for ACM resources. If undefined, the default SC will be used |
-|hub_hugepages_2Mi                   |1024Mi                         |No           |Request of `hugepages-2Mi` to be configured for Postgres search pods|
+|hub_hugepages_type                  |hugepages-2Mi                  |No           |Hugepages type to be configured for Postgres search pods. x86_64 support hugepages-2Mi and hugepages-1Gi |
+|hub_hugepages_size                  |1024Mi                         |No           |Hugepages `hub_hugepages_type` size              |
 
 ## Requirements
 1. An Openshift Cluster with a subscription for the ACM operator.

--- a/roles/acm_setup/README.md
+++ b/roles/acm_setup/README.md
@@ -28,7 +28,7 @@ The configuration of the ACM hub can be customized by using the following variab
 
 It is highly recommended to provision a storage class with enough space available for volumes of the Assisted Service Config before starting deploying clusters. See [acm_sno](../acm_sno/README.md) for more details.
 
-In clusters configured with hugepages, the Postgres deployment requires hugepages to be configured too. Please allocate `hugepages-2Mi` to cover the Postgres' search requirement and other workload needs.
+In clusters configured with hugepages, the Postgres deployment requires hugepages to be configured too. Please allocate `hub_hugepages_type` and hub_hugepages_size according to the your cluster configuration.
 
 ## Usage example
 

--- a/roles/acm_setup/defaults/main.yml
+++ b/roles/acm_setup/defaults/main.yml
@@ -4,5 +4,6 @@ hub_availability: High
 hub_instance: multiclusterhub
 hub_namespace: open-cluster-management
 hub_disconnected: false
-hub_hugepages_2Mi: 1024Mi
+hub_hugepages_type: hugepages-2Mi
+hub_hugepages_size: 1024Mi
 ...

--- a/roles/acm_setup/defaults/main.yml
+++ b/roles/acm_setup/defaults/main.yml
@@ -4,4 +4,5 @@ hub_availability: High
 hub_instance: multiclusterhub
 hub_namespace: open-cluster-management
 hub_disconnected: false
+hub_hugepages_2Mi: 1024Mi
 ...

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -63,18 +63,7 @@
   retries: 180
   delay: 10
 
-- name: "Get workers information"
-  community.kubernetes.k8s_info:
-    kind: Node
-  register: node_info
-  no_log: true
-
 - name: "Configure hugepages on postgres containers"
-  vars:
-    has_hugepages: "{{ node_info.resources |
-                    selectattr('status.allocatable.hugepages-1Gi', 'match', '^[1-9]') |
-                    selectattr('status.allocatable.hugepages-2Mi', 'match', '^[1-9]') |
-                    list | length > 0 }}"
   block:
     - name: "Annotate the Search Object"
       community.kubernetes.k8s:

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -112,8 +112,6 @@
 - name: "Get workers information"
   community.kubernetes.k8s_info:
     kind: Node
-    label_selectors:
-      - "node-role.kubernetes.io/worker"
   register: node_info
   no_log: true
 
@@ -157,11 +155,10 @@
                     limits:
                       hugepages-2Mi: 1024Mi
   when:
-      - node_info is defined
       - node_info.resources | length > 0
       - has_hugepages | bool
 
-- name: "Wait ACM pods to be Running"
+- name: "Wait for ACM pods to be Running"
   community.kubernetes.k8s_info:
     api_version: v1
     kind: Pod

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -153,7 +153,7 @@
                 - name: search-postgres
                   resources:
                     limits:
-                      hugepages-2Mi: 1024Mi
+                      hugepages-2Mi: "{{ hub_hugepages_2Mi }}"
   when:
       - node_info.resources | length > 0
       - has_hugepages | bool

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -1,52 +1,6 @@
 ---
-- name: "Get Storage Classes"
-  community.kubernetes.k8s_info:
-    api_version: v1
-    kind: StorageClass
-  register: storage_class
-
-- name: "Fail when there is no storage class available"
-  fail:
-    msg: "A storage class does not exists"
-  when:
-    - storage_class.resources | length == 0
-
-- name: "Fail when defined storage class does not exists"
-  vars:
-    query_sc_name: 'resources[*].metadata.name'
-    query_results: "{{ storage_class | json_query(query_sc_name) }}"
-  fail:
-    msg: "Defined storage class do not exists"
-  when:
-    - hub_sc is defined
-    - hub_sc not in query_results
-
-- name: "Fail when no default storage class"
-  vars:
-    query_default_sc: 'resources[*].metadata.annotations."storageclass.kubernetes.io/is-default-class"'
-    query_results: "{{ storage_class | json_query(query_default_sc) }}"
-  fail:
-    msg: "No default storage class was found"
-  when:
-    - storage_class is defined
-    - "not('true' in query_results)"
-    - hub_sc is undefined
-
-- name: "Get available CSVs"
-  community.kubernetes.k8s_info:
-    api: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-  register: current_csvs
-  retries: 5
-  delay: 5
-
-- name: "Fail if ACM csv is not present"
-  vars:
-    csv_details: "resources[*].metadata.name"
-    csvs: "{{ current_csvs | json_query(csv_details) }}"
-  fail:
-    msg: "No CSV for advanced-cluster-management are present"
-  when: not csvs is search('advanced-cluster-management')
+- name: "Build index image in temporary directory"
+  include_tasks: validation.yml
 
 - name: Get multicluster-engine package manifest
   community.kubernetes.k8s_info:
@@ -134,8 +88,8 @@
               search-pause: "true"
 
     - name: "Patch postgres deployment"
-      community.kubernetes.k8s:
-        definition:
+      vars:
+        dep_definition: |
           kind: Deployment
           apiVersion: apps/v1
           metadata:
@@ -153,20 +107,23 @@
                 - name: search-postgres
                   resources:
                     limits:
-                      hugepages-2Mi: "{{ hub_hugepages_2Mi }}"
+                      {{ hub_hugepages_type }}: {{ hub_hugepages_size }}
+      community.kubernetes.k8s:
+        state: present
+        definition: "{{ dep_definition }}"
   when:
-      - node_info.resources | length > 0
-      - has_hugepages | bool
+    - has_hugepages | default(false) | bool
+    - has_defined_hugepage | default(false) | bool
 
-- name: "Wait for ACM pods to be Running"
-  community.kubernetes.k8s_info:
-    api_version: v1
-    kind: Pod
-    namespace: "{{ hub_namespace }}"
-  register: pod_list
-  until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
-  retries: 20
-  delay: 15
+# - name: "Wait for ACM pods to be Running"
+#   community.kubernetes.k8s_info:
+#     api_version: v1
+#     kind: Pod
+#     namespace: "{{ hub_namespace }}"
+#   register: pod_list
+#   until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
+#   retries: 20
+#   delay: 15
 
 - name: "Wait up to 20 mins for MCH to be ready"
   community.kubernetes.k8s_info:
@@ -193,7 +150,7 @@
           kind: MultiClusterHub
           metadata:
             name: multiclusterhub
-            namespace: open-cluster-management
+            namespace: "{{ hub_namespace }}"
           spec:
             disableUpdateClusterImageSets: true
 

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Build index image in temporary directory"
+- name: "Validate requirements"
   include_tasks: validation.yml
 
 - name: Get multicluster-engine package manifest

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -115,15 +115,15 @@
     - has_hugepages | default(false) | bool
     - has_defined_hugepage | default(false) | bool
 
-# - name: "Wait for ACM pods to be Running"
-#   community.kubernetes.k8s_info:
-#     api_version: v1
-#     kind: Pod
-#     namespace: "{{ hub_namespace }}"
-#   register: pod_list
-#   until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
-#   retries: 20
-#   delay: 15
+- name: "Wait for ACM pods to be Running"
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ hub_namespace }}"
+  register: pod_list
+  until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
+  retries: 20
+  delay: 15
 
 - name: "Wait up to 20 mins for MCH to be ready"
   community.kubernetes.k8s_info:

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -96,7 +96,72 @@
         availabilityConfig: "{{ hub_availability }}"
         disableHubSelfManagement: "{{ hub_disable_selfmanagement }}"
 
-- name: "Wait for pods to be Running"
+- name: "Wait for search-postgres deployment"
+  k8s_info:
+    kind: Deployment
+    namespace: "{{ hub_namespace }}"
+    name: search-postgres
+  register: deployment_info
+  until:
+    - deployment_info is defined
+    - deployment_info.resources is defined
+    - deployment_info.resources | length > 0
+  retries: 180
+  delay: 10
+
+- name: "Get workers information"
+  community.kubernetes.k8s_info:
+    kind: Node
+    label_selectors:
+      - "node-role.kubernetes.io/worker"
+  register: node_info
+  no_log: true
+
+- name: "Configure hugepages on postgres containers"
+  vars:
+    has_hugepages: "{{ node_info.resources |
+                    selectattr('status.allocatable.hugepages-1Gi', 'match', '^[1-9]') |
+                    selectattr('status.allocatable.hugepages-2Mi', 'match', '^[1-9]') |
+                    list | length > 0 }}"
+  block:
+    - name: "Annotate the Search Object"
+      community.kubernetes.k8s:
+        definition:
+          kind: Search
+          apiVersion: search.open-cluster-management.io/v1alpha1
+          metadata:
+            name: search-v2-operator
+            namespace: "{{ hub_namespace }}"
+            annotations:
+              search-pause: "true"
+
+    - name: "Patch postgres deployment"
+      community.kubernetes.k8s:
+        definition:
+          kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            name: search-postgres
+            namespace: "{{ hub_namespace }}"
+          spec:
+            template:
+              metadata:
+                labels:
+                  app: search
+                  component: search-v2-operator
+                  name: search-postgres
+              spec:
+                containers:
+                - name: search-postgres
+                  resources:
+                    limits:
+                      hugepages-2Mi: 1024Mi
+  when:
+      - node_info is defined
+      - node_info.resources | length > 0
+      - has_hugepages | bool
+
+- name: "Wait ACM pods to be Running"
   community.kubernetes.k8s_info:
     api_version: v1
     kind: Pod

--- a/roles/acm_setup/tasks/validation.yml
+++ b/roles/acm_setup/tasks/validation.yml
@@ -62,6 +62,7 @@
                     node_info.resources |
                     selectattr('status.allocatable.hugepages-2Mi', 'ne', '0') |
                     list | length > 0 }}"
+
 - name: "Check if the hugepage type set is available"
   set_fact:
     has_defined_hugepage: "{{ node_info.resources |
@@ -70,6 +71,7 @@
                             list | unique |
                             selectattr('key', 'equalto', hub_hugepages_type) |
                             selectattr('value', 'match', '^[1-9]') |
+                            list |
                             length > 0 }}"
 
 - name: "Fail if the Hugepages set is not available"

--- a/roles/acm_setup/tasks/validation.yml
+++ b/roles/acm_setup/tasks/validation.yml
@@ -1,0 +1,81 @@
+---
+- name: "Get Storage Classes"
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: StorageClass
+  register: storage_class
+
+- name: "Fail when there is no storage class available"
+  fail:
+    msg: "A storage class does not exists"
+  when:
+    - storage_class.resources | length == 0
+
+- name: "Fail when defined storage class does not exists"
+  vars:
+    query_sc_name: 'resources[*].metadata.name'
+    query_results: "{{ storage_class | json_query(query_sc_name) }}"
+  fail:
+    msg: "Defined storage class do not exists"
+  when:
+    - hub_sc is defined
+    - hub_sc not in query_results
+
+- name: "Fail when no default storage class"
+  vars:
+    query_default_sc: 'resources[*].metadata.annotations."storageclass.kubernetes.io/is-default-class"'
+    query_results: "{{ storage_class | json_query(query_default_sc) }}"
+  fail:
+    msg: "No default storage class was found"
+  when:
+    - storage_class is defined
+    - "not('true' in query_results)"
+    - hub_sc is undefined
+
+- name: "Get available CSVs"
+  community.kubernetes.k8s_info:
+    api: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+  register: current_csvs
+  retries: 5
+  delay: 5
+
+- name: "Fail if ACM csv is not present"
+  vars:
+    csv_details: "resources[*].metadata.name"
+    csvs: "{{ current_csvs | json_query(csv_details) }}"
+  fail:
+    msg: "No CSV for advanced-cluster-management are present"
+  when: not csvs is search('advanced-cluster-management')
+
+- name: "Get workers information"
+  community.kubernetes.k8s_info:
+    kind: Node
+  register: node_info
+  no_log: true
+
+- name: "Check if nodes has allocatable hugepages"
+  set_fact:
+    has_hugepages: "{{ node_info.resources |
+                    selectattr('status.allocatable.hugepages-1Gi', 'ne', '0') |
+                    list | length > 0 or
+                    node_info.resources |
+                    selectattr('status.allocatable.hugepages-2Mi', 'ne', '0') |
+                    list | length > 0 }}"
+- name: "Check if the hugepage type set is available"
+  set_fact:
+    has_defined_hugepage: "{{ node_info.resources |
+                            map(attribute='status.allocatable') |
+                            map('dict2items') | flatten |
+                            list | unique |
+                            selectattr('key', 'equalto', hub_hugepages_type) |
+                            selectattr('value', 'match', '^[1-9]') |
+                            length > 0 }}"
+
+- name: "Fail if the Hugepages set is not available"
+  fail:
+    msg: "Nodes have hugepages enabled, but the type defined for postgres is not available"
+  when:
+    - has_hugepages | default(false) | bool
+    - not has_defined_hugepage | default(false) | bool
+...

--- a/roles/acm_setup/tasks/validation.yml
+++ b/roles/acm_setup/tasks/validation.yml
@@ -54,7 +54,7 @@
   register: node_info
   no_log: true
 
-- name: "Check if nodes has allocatable hugepages"
+- name: "Setting hugepages facts"
   set_fact:
     has_hugepages: "{{ node_info.resources |
                     selectattr('status.allocatable.hugepages-1Gi', 'ne', '0') |
@@ -62,9 +62,6 @@
                     node_info.resources |
                     selectattr('status.allocatable.hugepages-2Mi', 'ne', '0') |
                     list | length > 0 }}"
-
-- name: "Check if the hugepage type set is available"
-  set_fact:
     has_defined_hugepage: "{{ node_info.resources |
                             map(attribute='status.allocatable') |
                             map('dict2items') | flatten |


### PR DESCRIPTION
Postgres pods require hugepages configured when the cluster nodes have Hugepages available.