### PR TITLE
Change the way we are retrieving the commitId for repos that come from PRs

### DIFF
--- a/roles/cnf_cert/tasks/pre-run.yml
+++ b/roles/cnf_cert/tasks/pre-run.yml
@@ -83,11 +83,12 @@
       mode: u+wx,g+wx
       recurse: true
 
-  # We need to check the SHA in this way, because extract-dependencies changes the
-  # commit id when creating the new branch based on the PR, but only if new PRs are merged
-  # in the repo and we have not included them in our change. In these cases, the original
-  # id is saved in .git/ORIG_HEAD file. Else, we can find it in the location called
-  # `.git/refs/heads/prXXX`
+  # Retrieve the SHA to use it when building the tnf image locally.
+  # Following the same method it is defined in include_components role,
+  # track_dev_git_repo.yml playbook.
+  # However, in this case, we don't need to create the component in this
+  # role, since it is already done in dci-openshift-app-agent through
+  # dev_gits_to_components variable.
   - name: "Check if .git/ORIG_HEAD file exists"
     stat:
       path: "{{ tnf_dir }}/.git/ORIG_HEAD"
@@ -134,35 +135,6 @@
       --build-arg OPENSHIFT_VERSION={{ ocp_version_full }} .
     args:
       chdir: "{{ tnf_dir }}"
-
-  # This is needed because the DCI component is not automatically created, as
-  # it is done in case the git repo is directly used, in whose case it is created.
-  # Doing this in the same way that is done in track_git_repo play but with
-  # the arguments obtained in previous tasks (e.g. commit SHA), as we cannot
-  # rely on the last commit id. For that reason, it is better to just do it
-  # here rather than changing pre-run and track_git_repo to be adapted to this
-  # casuistic
-  - name: Manually create the corresponding tnf component for DCI
-    ansible.legacy.dci_component:
-      display_name: "{{ test_network_function_project_name }} {{ tnf_version_image[:7] }}"
-      version: "{{ tnf_version_image }}"
-      team_id: "{{ job_info['job']['team_id'] }}"
-      topic_id: "{{ job_info['job']['topic_id'] }}"
-      type: "{{ test_network_function_project_name }}"
-      url: "https://github.com/test-network-function/cnf-certification-test/commit/{{ tnf_version_image }}"  # noqa 204
-      state: present
-    register: tnf_git_component
-    tags: [dci]
-
-  - name: Attach tnf component to the job
-    ansible.legacy.dci_job_component:
-      component_id: "{{ tnf_git_component.component.id }}"
-      job_id: "{{ job_id }}"
-    register: job_component_result
-    until: job_component_result is not failed
-    retries: 5
-    delay: 20
-    tags: [dci]
 
   when:
     - test_network_function_src_dir is defined
@@ -237,6 +209,17 @@
   - name: Create variable with tnf commit SHA
     set_fact:
       tnf_commit_sha: "{{ tnf_commit_sha_cmd.stdout }}"
+
+  - name: Create cnf-certification-test component calling to include_components role
+    vars:
+      gits_list:
+        - "{{ tnf_dir }}"
+      ic_gits: "{{ gits_list|flatten }}"
+      ic_rpms: []
+      ic_dev_gits: []
+    include_role:
+      name: redhatci.ocp.include_components
+
   when:
     - test_network_function_src_dir is not defined
 

--- a/roles/include_components/tasks/main.yml
+++ b/roles/include_components/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- include_tasks: track_git_repo.yml
+- include_tasks: track_dev_git_repo.yml
   loop: "{{ ic_dev_gits }}"
 
 - include_tasks: track_git_repo.yml

--- a/roles/include_components/tasks/track_dev_git_repo.yml
+++ b/roles/include_components/tasks/track_dev_git_repo.yml
@@ -36,6 +36,7 @@
   command: git -C {{ item }} config --get remote.origin.url
   register: repo_url
   when: last_commit_id.rc == 0
+  no_log: true
 
 # create the component the same way as in
 # dci-ansible/action_plugins/git.py
@@ -47,7 +48,7 @@
     team_id: "{{ job_info['job']['team_id'] }}"
     topic_id: "{{ job_info['job']['topic_id'] }}"
     type: "{{ repo_url.stdout| basename | regex_replace('[.]git$', '') }}"
-    url: "{{ repo_url.stdout | regex_replace('^(.*)@(.*):(.*)', 'https://\\2/\\3') | regex_replace('^ssh://(.*)@(.*)', 'https://\\2') | regex_replace('[.]git$', '') }}/commit/{{ last_commit_id.stdout }}"
+    url: "{{ repo_url.stdout | regex_replace('^(.*):(.*)@(.*)', 'https://\\3') | regex_replace('^ssh://(.*)@(.*)', 'https://\\2') | regex_replace('[.]git$', '') }}/commit/{{ last_commit_id.stdout }}"
     state: present
   register: git_component
   when: last_commit_id.rc == 0

--- a/roles/include_components/tasks/track_dev_git_repo.yml
+++ b/roles/include_components/tasks/track_dev_git_repo.yml
@@ -1,0 +1,57 @@
+---
+# We need to check the SHA in this way, because extract-dependencies changes the
+# commit id when creating the new branch based on the PR, but only if new PRs are merged
+# in the repo and we have not included them in our change. In these cases, the original
+# id is saved in .git/ORIG_HEAD file. Else, we can find it in the location called
+# `.git/refs/heads/prXXX`
+- name: "Check if .git/ORIG_HEAD file exists"
+  stat:
+    path: "{{ item }}/.git/ORIG_HEAD"
+  register: orig_head_file
+
+# Actions when .git/ORIG_HEAD file exists
+- name: Retrieve commit SHA from the downloaded repo - from ORIG_HEAD
+  shell: cat .git/ORIG_HEAD
+  register: last_commit_id
+  args:
+    chdir: "{{ item }}"
+  when: orig_head_file.stat.exists
+
+# Actions when .git/ORIG_HEAD file does not exist
+- name: Retrieve commit SHA from the downloaded repo - from refs
+  shell: cat .git/refs/heads/$(git rev-parse --abbrev-ref HEAD)
+  register: last_commit_id
+  args:
+    chdir: "{{ item }}"
+  when: not orig_head_file.stat.exists
+
+- name: get repo url
+  command: git -C {{ item }} config --get remote.origin.url
+  register: repo_url
+  when: last_commit_id.rc == 0
+
+# create the component the same way as in
+# dci-ansible/action_plugins/git.py
+- name: Create git repo component
+  ansible.legacy.dci_component:
+    display_name: "{{ repo_url.stdout| basename | regex_replace('[.]git$', '') }} {{ last_commit_id.stdout[:7] }}"
+    version: "{{ last_commit_id.stdout[:7] }}"
+    uid: "{{ last_commit_id.stdout }}"
+    team_id: "{{ job_info['job']['team_id'] }}"
+    topic_id: "{{ job_info['job']['topic_id'] }}"
+    type: "{{ repo_url.stdout| basename | regex_replace('[.]git$', '') }}"
+    url: "{{ repo_url.stdout | regex_replace('^(.*)@(.*):(.*)', 'https://\\2/\\3') | regex_replace('^ssh://(.*)@(.*)', 'https://\\2') | regex_replace('[.]git$', '') }}/commit/{{ last_commit_id.stdout }}"
+    state: present
+  register: git_component
+  when: last_commit_id.rc == 0
+
+- name: 'Attach git component to the job'
+  ansible.legacy.dci_job_component:
+    component_id: "{{ git_component.component.id }}"
+    job_id: " {{ job_id }} "
+  register : job_component_result
+  until: job_component_result is not failed
+  retries: 5
+  delay: 20
+  when: last_commit_id.rc == 0
+...

--- a/roles/include_components/tasks/track_dev_git_repo.yml
+++ b/roles/include_components/tasks/track_dev_git_repo.yml
@@ -12,7 +12,7 @@
 # Actions when .git/ORIG_HEAD file exists
 - name: Retrieve commit SHA from the downloaded repo - from ORIG_HEAD
   shell: cat .git/ORIG_HEAD
-  register: last_commit_id
+  register: last_commit_id_orig
   args:
     chdir: "{{ item }}"
   when: orig_head_file.stat.exists
@@ -20,10 +20,17 @@
 # Actions when .git/ORIG_HEAD file does not exist
 - name: Retrieve commit SHA from the downloaded repo - from refs
   shell: cat .git/refs/heads/$(git rev-parse --abbrev-ref HEAD)
-  register: last_commit_id
+  register: last_commit_id_refs
   args:
     chdir: "{{ item }}"
   when: not orig_head_file.stat.exists
+
+# We need to do this because, if .git/ORIG_HEAD file exists, first task
+# checking commitId works and second one is skipped, but the registered
+# variable is unset, causing an error in the execution of next tasks.
+- name: Set commit SHA retrieval result
+  set_fact:
+    last_commit_id: "{{ orig_head_file.stat.exists | ternary(last_commit_id_orig, last_commit_id_refs) }}"
 
 - name: get repo url
   command: git -C {{ item }} config --get remote.origin.url


### PR DESCRIPTION
Please check https://issues.redhat.com/browse/CILAB-1288 to understand this story.

This change does the following:

- Create a new play, reusing the logic already included in tnf, and use it for dev_gits_to_components cases, so that the component created has the correct commitId
- Remove this code from tnf to make it generally available
- In tnf, call to include_components when we're testing a stable version, following gits_to_components method.