### PR TITLE
use opm client from stable 4.13 release for fbc_catalog

### DIFF
--- a/roles/fbc_catalog/tasks/main.yml
+++ b/roles/fbc_catalog/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: "Download stable opm client"
   vars:
-    ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/opm-linux.tar.gz"
+    ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.13/opm-linux.tar.gz"
   unarchive:
     src: "{{ ocp_clients_url }}"
     dest: "{{ fbc_tmp_dir }}"


### PR DESCRIPTION
build-depends: 30006

the opm client in 4.14 is not returning olm.bundle.object property from operator images, required by fbc_catalog role to generate the catalog and be able to install operators