### PR TITLE
Use opm new stable release in fbc and preflight

### DIFF
--- a/roles/fbc_catalog/tasks/add-bundle.yml
+++ b/roles/fbc_catalog/tasks/add-bundle.yml
@@ -18,7 +18,6 @@
   vars:
     name_query: "properties[? type==`olm.package`].value.packageName"
     version_query: "properties[? type==`olm.package`].value.version"
-    data_query: "properties[? type==`olm.bundle.object`].value.data"
   set_fact:
     fbc_operator_name: "{{ bundle_data | json_query('name') | join('') }}"
     fbc_short_name: "{{ bundle_data | json_query(name_query) | join('') }}"

--- a/roles/fbc_catalog/tasks/main.yml
+++ b/roles/fbc_catalog/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: "Download stable opm client"
   vars:
-    ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.13/opm-linux.tar.gz"
+    ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/opm-linux.tar.gz"
   unarchive:
     src: "{{ ocp_clients_url }}"
     dest: "{{ fbc_tmp_dir }}"

--- a/roles/preflight/tasks/prepare_operator_metadata.yml
+++ b/roles/preflight/tasks/prepare_operator_metadata.yml
@@ -21,24 +21,12 @@
   vars:
     name_query: "properties[? type==`olm.package`].value.packageName"
     version_query: "properties[? type==`olm.package`].value.version"
-    data_query: "properties[? type==`olm.bundle.object`].value.data"
+    related_images: "{{ bundle_data | json_query('relatedImages[*].image') }}"
   set_fact:
     operator_name: "{{ bundle_data | json_query('name') | join('') }}"
     short_name: "{{ bundle_data | json_query(name_query) | join('') }}"
     operator_version: "{{ bundle_data | json_query(version_query) | join('') }}"
-    data_blobs: "{{ bundle_data | json_query(data_query) }}"
-
-- name: "Get operator image(s)"
-  vars:
-    image_query: "spec.install.spec.deployments[].spec.template.spec.containers[].image"
-    image_name: "{{ blob | b64decode | from_json | json_query(image_query) }}"
-  set_fact:
-    operator_images: "{{ image_name }}"
-  when: image_name | length
-  loop: "{{ data_blobs | reverse | list }}"
-  loop_control:
-    loop_var: blob
-    label: ""
+    operator_images: "{{ related_images | reject('search', operator.bundle_image) | list }}"
 
 - name: "Fail when cluster is disconnected and operator images are not using a digest"
   fail:


### PR DESCRIPTION
Remove the unused deprecated olm.bundle.object, is not used nor needed in FBC creation.

New render format deprecates olm.bundle.object but some another field could provide the list of images used (relatedImages), using that instead.

build-depends: 30017