### PR TITLE
Do not use cache during image build

### DIFF
--- a/roles/cnf_cert/tasks/pre-run.yml
+++ b/roles/cnf_cert/tasks/pre-run.yml
@@ -130,6 +130,7 @@
     shell: |
       set -x
       podman build -t {{ tnf_image }} \
+      --no-cache \
       --build-arg TNF_VERSION={{ tnf_version_image }} \
       --build-arg TNF_SRC_URL=https://github.com/test-network-function/cnf-certification-test \
       --build-arg OPENSHIFT_VERSION={{ ocp_version_full }} .

--- a/roles/fbc_catalog/tasks/main.yml
+++ b/roles/fbc_catalog/tasks/main.yml
@@ -66,6 +66,8 @@
 - name: "Build the catalog"
   shell: >
     podman build .
+    --no-cache
+    --pull=always
     -f catalog.Dockerfile
     -t {{ fbc_index_image }}
   args:

--- a/roles/fbc_catalog/tasks/main.yml
+++ b/roles/fbc_catalog/tasks/main.yml
@@ -67,7 +67,6 @@
   shell: >
     podman build .
     --no-cache
-    --pull=always
     -f catalog.Dockerfile
     -t {{ fbc_index_image }}
   args:

--- a/roles/opcap_tool/tasks/build.yml
+++ b/roles/opcap_tool/tasks/build.yml
@@ -5,9 +5,7 @@
     repo: "{{ opcap_repo }}"
     dest: "{{ opcap_dir.path }}/opcap"
 
-# Launching a container to build the GO bin
-# Dir where the repo has been cloned is bound as a volume (with option Z for SELinux compatibility)
-- name: "run podman build"
+- name: "Use Golang container to build opcap"
   containers.podman.podman_container:
     name: go-builder
     image: "golang:1.19"

--- a/roles/operator_sdk/tasks/build_scorecard_image.yml
+++ b/roles/operator_sdk/tasks/build_scorecard_image.yml
@@ -31,6 +31,7 @@
       podman buildx build
       -t {{ operator_sdk_img }}
       --label quay.expires-after=1d
+      --no-cache
       -f ./images/operator-sdk/Dockerfile
       --load . &&
       podman push

--- a/roles/preflight/tasks/prepare_preflight_image.yml
+++ b/roles/preflight/tasks/prepare_preflight_image.yml
@@ -29,6 +29,7 @@
   shell:
     cmd: >
       podman build .
+      --no-cache
       -t {{ preflight_image }}
       --build-arg=release_tag={{ preflight_branch }} &&
       podman push


### PR DESCRIPTION
- No cached images and forcing to always pull to avoid working with outdated version of opm image