### PR TITLE
Adding a retry to account for timeout errors when pulling container images

### DIFF
--- a/roles/preflight/tasks/test_preflight_check_container_one_image.yml
+++ b/roles/preflight/tasks/test_preflight_check_container_one_image.yml
@@ -80,7 +80,7 @@
           register: podman_rc
           retries: 2
           delay: 120
-          until: podman_rc.rc == 0
+          until: podman_rc is succeeded
       rescue:
         - name: Do not fail when preflight check container throws an error
           debug:

--- a/roles/preflight/tasks/test_preflight_check_container_one_image.yml
+++ b/roles/preflight/tasks/test_preflight_check_container_one_image.yml
@@ -77,8 +77,10 @@
             {% if cert_project_id | default('') | length %}
             --submit
             {% endif %}
+          register: podman_rc
           retries: 2
           delay: 120
+          until: podman_rc.rc == 0
       rescue:
         - name: Do not fail when preflight check container throws an error
           debug:

--- a/roles/preflight/tasks/test_preflight_check_container_one_image.yml
+++ b/roles/preflight/tasks/test_preflight_check_container_one_image.yml
@@ -77,6 +77,8 @@
             {% if cert_project_id | default('') | length %}
             --submit
             {% endif %}
+          retries: 2
+          delay: 120
       rescue:
         - name: Do not fail when preflight check container throws an error
           debug:


### PR DESCRIPTION
While doing container certification tests for container images stored in an artifactory repository - I've seen timeout errors when podman tries to pull the images. 

The same container check executes successfully on a retry. Hence, I think we should add a retry option to account for these errors.