### PR TITLE
Remove README from ignore build

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -107,4 +107,3 @@ build_ignore:
   - '.gitignore'
   - '.github'
   - 'rpm'
-  - 'README.md'


### PR DESCRIPTION
A README is required to publish collections