### PR TITLE
Change versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Add release, date and commit hash to version in galaxy.yml
+      - name: Add epoch from commit date as patch version and metadata in galaxy.yml
         run: >
+          z=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%s')
           ts=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%Y%m%d%H%M')
           sha=$(echo "${{ github.sha }}" | cut -c1-7);
-          rel=$(grep ^Release ansible-collection-redhatci-ocp.spec | grep -Po '\d+\.');
-          sed -i -r "s/^(version: .*)$/&-${rel}${ts}git${sha}/" galaxy.yml;
+          sed -i -r "s/^(version: .*)\.0$/\1.${z}+${ts}.git${sha}/" galaxy.yml;
           grep ^version galaxy.yml
 
       - name: Ansible Publish to Galaxy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,35 @@ jobs:
 
       - name: Add epoch from commit date as patch version and metadata in galaxy.yml
         run: >
-          z=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%s')
-          ts=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%Y%m%d%H%M')
+          z=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%s');
+          ts=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%Y%m%d%H%M');
           sha=$(echo "${{ github.sha }}" | cut -c1-7);
           sed -i -r "s/^(version: .*)\.0$/\1.${z}+${ts}.git${sha}/" galaxy.yml;
           grep ^version galaxy.yml
 
-      - name: Ansible Publish to Galaxy
-        uses: ansible/ansible-publish-action@v1.0.0
-        with:
-          api_key: ${{ secrets.ANSIBLE_GALAXY_TOKEN }}
+      # Build and publish manually due to https://github.com/ansible/galaxy/issues/3287
+      # ansible/ansible-publish-action implements this
+      # https://github.com/ansible/creator-ee/blob/main/_build/devtools-publish
+      - name: Ansible Galaxy Collection Publish
+        run: >
+          rm -f ./*.tar.gz;
+          ansible-galaxy collection build -v --force "${SRC_PATH:-.}";
+          TARBALL=$(ls -1 ./*.tar.gz);
+          publish=$(ansible-galaxy collection publish -v \
+            --server "${API_SERVER:-https://galaxy.ansible.com/}" \
+            --api-key "${{ secrets.ANSIBLE_GALAXY_TOKEN }}" \
+            "${TARBALL}" 2>&1
+          );
+          if [[ $? -ne 0 ]]; then
+            err="Error when publishing collection to cmd_arg .*HTTP Code: 500, Message:";
+            err500="Internal Server Error Code: Unknown";
+            if grep -qP "${err} ${err500}" <<< "${publish}"; then
+              echo "Error found https://github.com/ansible/galaxy/issues/3287, Ignoring...";
+              echo "${publish}";
+              ec=0;
+            else
+              echo "${publish}";
+              ec=1;
+            fi;
+            exit ${ec}
+          fi;

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,6 +6,10 @@ namespace: redhatci
 name: ocp
 
 # The version of the collection. Must be compatible with semantic versioning
+# Always leave patch version as .0
+# Patch version is replaced from commit date in epoch format
+# Metadata is included to add commit date and git hash
+# example: 0.2.2147483647+203801190314.git0a1b2c3
 version: 0.2.0
 
 # The path to the Markdown (.md) readme file.


### PR DESCRIPTION
The current versioning is considered pre-release. Switching to use a slightly different format to make every release a patch release.

The version of the patch release is now the epoch of the latest commit date merged into main

Before: 0.2.1-{%Y%m%D%H%M}git{SHA}
Now: 0.2.{%s}+{%Y%m%D%H%M}.git{SHA}

The + delimits the version from metadata for the release

> NOTE: With this new version format I'm seeing 500/400 errors from galaxy when testing. Despite the errors the collection is published but this affects the state of the GHA. It has been reported in https://forum.ansible.com/t/http-500-400-errors-when-publishing-collections/2380

> NOTE: Issue opened for the 500 error https://github.com/ansible/galaxy/issues/3287