### PR TITLE
check_resource | Remove reference to OCPBUGS-17112 and generalize wait-mcp

### DIFF
--- a/roles/check_resource/tasks/wait-mcp.yml
+++ b/roles/check_resource/tasks/wait-mcp.yml
@@ -20,10 +20,6 @@
       retries: "{{ check_wait_retries }}"
       delay: "{{ check_wait_delay }}"
 
-    - name: Reset retry count
-      set_fact:
-        retry_count: 1
-
   # If the last check failed, let's do some more checks to confirm the real status of the nodes
   rescue:
     # If nodes are NotReady, we cannot do much more than failing at this point.

--- a/roles/check_resource/tasks/wait-mcp.yml
+++ b/roles/check_resource/tasks/wait-mcp.yml
@@ -20,14 +20,12 @@
       retries: "{{ check_wait_retries }}"
       delay: "{{ check_wait_delay }}"
 
-  # If the last check failed, then move to the workaround
-  rescue:
-    - name: "Check MCP application failed - no workaround applied"
-      fail:
-        msg: "No workaround is defined, so the job has to fail at this point"
-      when:
-        - '"OCPBUGS-17112" not in dci_workarounds|default([])'
+    - name: Reset retry count
+      set_fact:
+        retry_count: 1
 
+  # If the last check failed, let's do some more checks to confirm the real status of the nodes
+  rescue:
     # If nodes are NotReady, we cannot do much more than failing at this point.
     # There may be cases where it takes some time to move from NotReady to Ready,
     # so retrying this task during 10 minutes maximum.
@@ -53,7 +51,7 @@
 
     # If the previous checks passed because there were no nodes in NotReady or SchedulngDisabled
     # status, then let's retry the check.
-    # For OCPBUGS-17112, we will only allow one more attempt (num_repetitions = 2 by default)
+    # We will only allow one more attempt (num_repetitions = 2 by default)
     - name: Fail if the maximum number of retries have been reached
       fail:
         msg: Maximum number of retries without success have been reached ({{ num_repetitions }})


### PR DESCRIPTION
- OCPBUGS-17112 has been closed, so removing the references to that issue
- Running a new retry in case no nodes are in SchedulingDisabled status is not harmful, we can do it anyway.