### PR TITLE
Change RHCOS URL path for pre 4.8 installs

### DIFF
--- a/roles/installer/tasks/23_rhcos_image_paths.yml
+++ b/roles/installer/tasks/23_rhcos_image_paths.yml
@@ -23,11 +23,16 @@
       delegate_to: "{{ disconnected_installer | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
       tags: rhcospath
 
+    # The baseURI for pre 4.8 is decomissioned, but old images are still available along newer ones
+    # only when cache_enabled is set to True
     - name: Set Facts for RHCOS_URI and RHCOS_PATH
+      vars:
+        base_version: "{{ release_version.split('.')[:2] | join('.') }}"
+        build_id: "{{ rhcos_json.json | json_query('buildid') }}"
       set_fact:
         rhcos_qemu_uri: "{{ rhcos_json.json | json_query('images.qemu.path') }}"
         rhcos_uri: "{{ rhcos_json.json | json_query('images.openstack.path') }}"
-        rhcos_path: "{{ rhcos_json.json | json_query('baseURI') }}"
+        rhcos_path: "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-{{ base_version }}/{{ build_id }}/x86_64/"
       tags: rhcospath
   when: (release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int <= 7)
 


### PR DESCRIPTION
The baseURI used in older (EOL) versions of OCP has been decomissioned some time ago. This change uses the same base URL than the newer RHCOS images currently supported where older images are still available.

Test-Args-Hints: -e dci_topic=OCP-4.7 -e dci_components_by_query=['version:4.7.55'] -e cache_enabled=True
Depends-On: https://softwarefactory-project.io/r/c/dci-openshift-agent/+/30310
Depends-On: https://softwarefactory-project.io/r/c/dci-pipeline/+/30311