### PR TITLE
Remove metadata from patch version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Add epoch from commit date as patch version and metadata in galaxy.yml
+      - name: Add epoch from commit date as patch version in galaxy.yml
         run: >
           z=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%s');
-          ts=$(TZ=UTC0 git show ${{ github.sha }} --no-patch --format=%cd --date=format-local:'%Y%m%d%H%M');
-          sha=$(echo "${{ github.sha }}" | cut -c1-7);
-          sed -i -r "s/^(version: .*)\.0$/\1.${z}+${ts}.git${sha}/" galaxy.yml;
+          sed -i -r "s/^(version: .*)\.0$/\1.${z}/" galaxy.yml;
           grep ^version galaxy.yml
 
       # Build and publish manually due to https://github.com/ansible/galaxy/issues/3287

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,8 +8,7 @@ name: ocp
 # The version of the collection. Must be compatible with semantic versioning
 # Always leave patch version as .0
 # Patch version is replaced from commit date in epoch format
-# Metadata is included to add commit date and git hash
-# example: 0.2.2147483647+203801190314.git0a1b2c3
+# example: 0.3.2147483647
 version: 0.3.0
 
 # The path to the Markdown (.md) readme file.


### PR DESCRIPTION
Metadata in the patch version is not supported by ansible galaxy client version 2.9[1].
While the metadata is supported in SemVer, the ansible galaxy client filters out and only allows strict versions to be installed. This is not an issue in 2.10+ but we provide support for ansible 2.9

[1] https://github.com/ansible/ansible/blob/stable-2.9/lib/ansible/galaxy/collection.py#L348-L350