### PR TITLE
Fix issue with the tag used by tnf_image in changes that come from tnf PR

### DIFF
--- a/roles/cnf_cert/tasks/pre-run.yml
+++ b/roles/cnf_cert/tasks/pre-run.yml
@@ -84,7 +84,7 @@
 
         - name: Create variable with tnf version name
           ansible.builtin.set_fact:
-            tnf_version_image: "{{ tnf_repo_info_head['content'] | b64decode }}"
+            tnf_version_image: "{{ tnf_repo_info_head['content'] | b64decode | trim }}"
 
     - name: Actions when .git/ORIG_HEAD file does not exist
       when: not orig_head_file.stat.exists
@@ -100,9 +100,10 @@
             tnf_version_image: "{{ tnf_repo_info_branch.stdout }}"
 
     - name: Create variable with tnf image name
+      vars:
+        tnf_image_tag: "{{ tnf_version_image }}-{{ tnf_image_suffix }}"
       ansible.builtin.set_fact:
-        tnf_image: "{{ test_network_function_project_name }}:{{ tnf_version_image }}-\
-          {{ tnf_image_suffix }}"
+        tnf_image: "{{ test_network_function_project_name }}:{{ tnf_image_tag }}"
 
     # Steps from
     # https://test-network-function.github.io/cnf-certification-test/test-container/#build-locally
@@ -143,9 +144,10 @@
         tnf_version_image: "{{ (test_network_function_version | regex_search('HEAD')) | ternary('unstable', test_network_function_version) }}"
 
     - name: Create variable with tnf image name
+      vars:
+        tnf_image_tag: "{{ tnf_version_image }}-{{ tnf_image_suffix }}"
       ansible.builtin.set_fact:
-        tnf_image: "{{ test_network_function_project_name }}:{{ tnf_version_image }}-\
-        {{ tnf_image_suffix }}"
+        tnf_image: "{{ test_network_function_project_name }}:{{ tnf_image_tag }}"
 
     - name: Clone tnf repository
       ansible.builtin.git:


### PR DESCRIPTION
The thing is, this particular task is being affected: https://www.distributed-ci.io/jobs/a8cc248c-93e9-4b9e-b1eb-4543c2883ed5/jobStates?sort=date&task=204501a5-13ac-456b-8363-056a803251cf. When testing a tnf PR, due to the new break line included in the tnf_image variable, the value of the variable presents that break line.
We need to remove that break line.
Also, defining the tag in an auxiliary variable for a better reading.