### PR TITLE
Update http_store container to use newer apache

### DIFF
--- a/roles/setup_http_store/defaults/main.yml
+++ b/roles/setup_http_store/defaults/main.yml
@@ -4,6 +4,6 @@ http_dir: /opt/http_store
 http_data_dir: "{{ http_dir }}/data"
 http_port: 80
 # Note if you change this you might have to change the env vars and volumes for podman task
-container_image: quay.io/centos7/httpd-24-centos7:latest
+container_image: quay.io/fedora/httpd-24:latest
 file_owner: "{{ ansible_env.USER }}"
 file_group: "{{ file_owner }}"


### PR DESCRIPTION
Current version of RHEL7 apache has a CVE sercurity issue.  We have been using this updated container image with the rhel-agent for over a month now with no issues.

Test-Hints: assisted-abi