### PR TITLE
Fail if sushy-tools service status.ActiveState is not active

### DIFF
--- a/roles/setup_sushy_tools/tasks/main.yml
+++ b/roles/setup_sushy_tools/tasks/main.yml
@@ -119,3 +119,11 @@
         name: sushy-tools
         state: restarted
         enabled: yes
+
+    - name: Check sushy-tools service is active
+      service:
+        name: sushy-tools
+      register: sushy_service_result
+      until: "'active' in sushy_service_result.status.ActiveState"
+      retries: 10
+      delay: 5


### PR DESCRIPTION
Currently, if sushy-tools service running but is in a failed state, the job does not catch the error and continues up to [unclear failure](https://www.distributed-ci.io/jobs/e0078c3e-e828-4619-b6ac-446904591bcb/jobStates) `failure Failed at redhatci.ocp.validate_inventory : Record successful validation on all hosts`.

This fix is to immediately fail with a clear error. The change is tested:

1. [If sushy-tools is not active, status.ActiveState=failed, partner's lab](https://www.distributed-ci.io/jobs/3c6d0678-9897-4264-bc92-8045170e23eb/jobStates?sort=date&task=e846f058-8090-486a-a726-fc11d2e31e3a).
2. [If sushi-tools is started and has status.ActiveState=active, partner's lab](https://www.distributed-ci.io/jobs/71f2a9a4-e449-483d-95e4-3ec38c514604/jobStates?sort=date&task=472940ba-6389-4a1d-85ca-33bc268804fe).
3. [If everything is fine, libvirt](https://www.distributed-ci.io/jobs/7b9481b2-c6ad-429b-9e55-e73c5a183c40/jobStates?sort=date&task=5ded8600-ba17-4ea7-95c5-f0c806ac2e26).