### PR TITLE
Crucible | Rename cluster output to avoid conflicts with cluster variable

### DIFF
--- a/roles/add_day2_node/tasks/main.yml
+++ b/roles/add_day2_node/tasks/main.yml
@@ -57,7 +57,7 @@
         patch_host_config_cluster_id: "{{ add_host_cluster_id }}"
         patch_host_config_discovered_host: "{{ discovered_host_reply.json }}"
 
-    - name: "Wait for up to 20 minutes to be ready - {{ inventory_hostname }}"
+    - name: "Wait for up to 20 minutes host to be ready - {{ inventory_hostname }}"
       ansible.builtin.uri:
         url: "{{ URL_ASSISTED_INSTALLER_INFRA_ENV }}/hosts/{{ discovered_host.id }}"
         method: GET

--- a/roles/add_day2_node/tasks/main.yml
+++ b/roles/add_day2_node/tasks/main.yml
@@ -10,7 +10,21 @@
       register: cluster_output
       until:
         - ("json" in cluster_output)
-        - (hostvars[inventory_hostname]['mac'] | upper) in (cluster_output.json.hosts | map(attribute='inventory') | map('from_json') | map(attribute='interfaces') | flatten | map(attribute='mac_address') | map('upper') | list)
+        - >
+          (
+            hostvars[inventory_hostname]['mac'] | upper
+          )
+          in
+          (
+            cluster_output.json.hosts |
+            map(attribute='inventory') |
+            map('from_json') |
+            map(attribute='interfaces') |
+            flatten |
+            map(attribute='mac_address') |
+            map('upper') |
+            list
+          )
       retries: 20
       delay: 60
 
@@ -19,18 +33,18 @@
         discovered_host: "{{ item }}"
       when: (mac | upper) in ((item.inventory | from_json).interfaces | flatten | map(attribute='mac_address') | map('upper') | list )
       loop: "{{ cluster_output.json.hosts }}"
-      no_log: True
+      no_log: true
 
     - debug: # noqa unnamed-task
         var: discovered_host
         verbosity: 1
 
-    - name: "Wait for up to 20 minutes for requirement checks on {{ inventory_hostname }} "
+    - name: "Wait for up to 20 minutes for requirement checks on {{ inventory_hostname }}"
       ansible.builtin.uri:
         url: "{{ URL_ASSISTED_INSTALLER_INFRA_ENV }}/hosts/{{ discovered_host.id }}"
         method: GET
         status_code: [200, 201]
-        return_content: True
+        return_content: true
       register: discovered_host_reply
       until: "'status' in discovered_host_reply.json and discovered_host_reply.json.status in day2_states"
       retries: 20
@@ -40,17 +54,15 @@
       ansible.builtin.import_role:
         name: redhatci.ocp.patch_host_config
       vars:
-        patch_cluster_id: "{{ add_host_cluster_id }}"
-        discovered_host: "{{ discovered_host_reply.json }}"
-        inventory_nodes:
-          - "{{ inventory_hostname }}"
+        patch_host_config_cluster_id: "{{ add_host_cluster_id }}"
+        patch_host_config_discovered_host: "{{ discovered_host_reply.json }}"
 
-    - name: "Wait for up to 20 minutes for {{ inventory_hostname }} to be ready"
+    - name: "Wait for up to 20 minutes to be ready - {{ inventory_hostname }}"
       ansible.builtin.uri:
         url: "{{ URL_ASSISTED_INSTALLER_INFRA_ENV }}/hosts/{{ discovered_host.id }}"
         method: GET
         status_code: [200, 201]
-        return_content: True
+        return_content: true
       register: discovered_host_reply
       until: "'status' in discovered_host_reply.json and discovered_host_reply.json.status in day2_states[1:]"
       retries: 20
@@ -65,7 +77,7 @@
         url: "{{ URL_ASSISTED_INSTALLER_INFRA_ENV }}/hosts/{{ discovered_host.id }}/actions/install"
         method: POST
         status_code: [202]
-        return_content: True
+        return_content: true
         body_format: json
         body: {}
       register: http_reply
@@ -74,8 +86,8 @@
       ansible.builtin.import_role:
         name: redhatci.ocp.monitor_host
       vars:
-        monitor_cluster_id: "{{ add_host_cluster_id }}"
-        current_host: "{{ discovered_host_reply.json }}"
-        waiting_termination_states:
+        monitor_host_cluster_id: "{{ add_host_cluster_id }}"
+        monitor_host_current_host: "{{ discovered_host_reply.json }}"
+        monitor_host_waiting_termination_states:
           - "added-to-existing-cluster"
           - "installing-pending-user-action"

--- a/roles/add_day2_node/tasks/main.yml
+++ b/roles/add_day2_node/tasks/main.yml
@@ -7,10 +7,10 @@
         method: GET
         status_code: [200, 201]
         return_content: True
-      register: cluster
+      register: cluster_output
       until:
-        - ("json" in cluster)
-        - (hostvars[inventory_hostname]['mac'] | upper) in (cluster.json.hosts | map(attribute='inventory') | map('from_json') | map(attribute='interfaces') | flatten | map(attribute='mac_address') | map('upper') | list)
+        - ("json" in cluster_output)
+        - (hostvars[inventory_hostname]['mac'] | upper) in (cluster_output.json.hosts | map(attribute='inventory') | map('from_json') | map(attribute='interfaces') | flatten | map(attribute='mac_address') | map('upper') | list)
       retries: 20
       delay: 60
 
@@ -18,7 +18,7 @@
       ansible.builtin.set_fact:
         discovered_host: "{{ item }}"
       when: (mac | upper) in ((item.inventory | from_json).interfaces | flatten | map(attribute='mac_address') | map('upper') | list )
-      loop: "{{ cluster.json.hosts }}"
+      loop: "{{ cluster_output.json.hosts }}"
       no_log: True
 
     - debug: # noqa unnamed-task

--- a/roles/install_cluster/tasks/main.yml
+++ b/roles/install_cluster/tasks/main.yml
@@ -13,10 +13,10 @@
     method: GET
     status_code: [200, 201]
     return_content: True
-  register: cluster
+  register: cluster_output
   until:
-    - (cluster.json.hosts | length) == (inventory_nodes | length)
-    - cluster.json.status in host_discovery_states
+    - (cluster_output.json.hosts | length) == (inventory_nodes | length)
+    - cluster_output.json.status in host_discovery_states
   retries: "{{ hosts_discovery_minutes }}"
   delay: 60
   when: install | bool == True
@@ -25,7 +25,7 @@
   ansible.builtin.include_role:
     name: redhatci.ocp.patch_host_config
   with_items:
-    - "{{ cluster.json.hosts }}"
+    - "{{ cluster_output.json.hosts }}"
   loop_control:
     loop_var: discovered_host
   no_log: True
@@ -172,8 +172,8 @@
     method: GET
     status_code: [200, 201]
     return_content: True
-  register: cluster
-  until: "cluster.json.status == 'ready'"
+  register: cluster_output
+  until: "cluster_output.json.status == 'ready'"
   retries: 20
   delay: 60
   when: install | bool == True
@@ -206,8 +206,8 @@
     body_format: json
     body: {}
   when: install | bool == True
-  register: cluster
-  until: cluster.json.status in cluster_installation_states
+  register: cluster_output
+  until: cluster_output.json.status in cluster_installation_states
   retries: 5
   delay: 60
 ...

--- a/roles/install_cluster/tasks/main.yml
+++ b/roles/install_cluster/tasks/main.yml
@@ -27,7 +27,7 @@
   with_items:
     - "{{ cluster_output.json.hosts }}"
   loop_control:
-    loop_var: discovered_host
+    loop_var: patch_host_config_discovered_host
   no_log: True
   when: install | bool == True
 

--- a/roles/monitor_cluster/tasks/main.yml
+++ b/roles/monitor_cluster/tasks/main.yml
@@ -8,8 +8,8 @@
     method: GET
     status_code: [200, 201]
     return_content: True
-  register: cluster
-  until: cluster.json.status in ['installed', 'error', 'cancelled']
+  register: cluster_output
+  until: cluster_output.json.status in ['installed', 'error', 'cancelled']
   retries: 60
   delay: 60
   delegate_to: bastion
@@ -17,11 +17,11 @@
 - name: "Fail installation because of cluster error (ERROR)"
   fail:
     msg: "Cluster installation failed - Reset the installation process to return to the configuration and try again"
-  when: cluster.json.status == 'error'
+  when: cluster_output.json.status == 'error'
   delegate_to: bastion
 
 - name: "Fail installation because user cancelled (CANCELLED)"
   fail:
     msg: "Installation was canceled by user - Reset the installation process to return to the configuration and try again"
-  when: cluster.json.status == 'cancelled'
+  when: cluster_output.json.status == 'cancelled'
   delegate_to: bastion

--- a/roles/monitor_host/defaults/main.yml
+++ b/roles/monitor_host/defaults/main.yml
@@ -4,16 +4,16 @@
 monitor: True
 secure: False
 
-monitor_cluster_id: "{{ cluster_id | default(hostvars['bastion']['cluster_id']) }}"
+monitor_host_cluster_id: "{{ cluster_id | default(hostvars['bastion']['cluster_id']) }}"
 ASSISTED_INSTALLER_HOST: "{{ hostvars['assisted_installer']['host'] | default(ansible_default_ipv4.address | default(ansible_all_ipv4_addresses[0])) }}"
 ASSISTED_INSTALLER_PORT: "{{ hostvars['assisted_installer']['port'] | default(8090) }}"
 ASSISTED_INSTALLER_BASE_URL: "{{ secure | ternary('https', 'http') }}://{{ ASSISTED_INSTALLER_HOST }}:{{ ASSISTED_INSTALLER_PORT }}/api/assisted-install/v2"
-URL_ASSISTED_INSTALLER_CLUSTER: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ monitor_cluster_id }}"
+URL_ASSISTED_INSTALLER_CLUSTER: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ monitor_host_cluster_id }}"
 URL_ASSISTED_INSTALLER_INFRA_ENV: "{{ ASSISTED_INSTALLER_BASE_URL }}/infra-envs/{{ infra_env_id }}"
 
 # HTTP Basic Authentication
 HTTP_AUTH_USERNAME: "none"
 HTTP_AUTH_PASSWORD: "none"
 
-waiting_termination_states:
+monitor_host_waiting_termination_states:
   - "installing-pending-user-action"

--- a/roles/monitor_host/tasks/hosts_monitoring.yml
+++ b/roles/monitor_host/tasks/hosts_monitoring.yml
@@ -6,7 +6,7 @@
     url: "{{ URL_ASSISTED_INSTALLER_INFRA_ENV }}/hosts/{{ host_id }}"
     method: GET
     status_code: [200, 201]
-    return_content: True
+    return_content: true
   register: host
 
 - debug:  # noqa unnamed-task
@@ -19,10 +19,10 @@
     url: "{{ URL_ASSISTED_INSTALLER_INFRA_ENV }}/hosts/{{ host_id }}"
     method: GET
     status_code: [200, 201]
-    return_content: True
+    return_content: true
   register: host
   until:
-    (host.json.status | default(False)) in waiting_termination_states
+    (host.json.status | default(False)) in monitor_host_waiting_termination_states
     or
     (host.json.status | default(False)) in ['installed', 'error']
   retries: 60

--- a/roles/monitor_host/tasks/main.yml
+++ b/roles/monitor_host/tasks/main.yml
@@ -7,20 +7,20 @@
     method: GET
     status_code: [200, 201]
     return_content: True
-  register: cluster
+  register: cluster_output
   delegate_to: bastion
-  until: cluster is successful
+  until: cluster_output is successful
   retries: 4
   delay: 30
 
 - debug: # noqa unnamed-task
-    msg: "{{ cluster.json.hosts }}"
+    msg: "{{ cluster_output.json.hosts }}"
     verbosity: 1
 
 - name: Identify the host
   set_fact:
     current_host: "{{ item }}"
-  loop: "{{ cluster.json.hosts }}"
+  loop: "{{ cluster_output.json.hosts }}"
   when: item.requested_hostname == inventory_hostname
   no_log: True
 

--- a/roles/monitor_host/tasks/main.yml
+++ b/roles/monitor_host/tasks/main.yml
@@ -19,14 +19,14 @@
 
 - name: Identify the host
   set_fact:
-    current_host: "{{ item }}"
+    monitor_host_current_host: "{{ item }}"
   loop: "{{ cluster_output.json.hosts }}"
   when: item.requested_hostname == inventory_hostname
-  no_log: True
+  no_log: true
 
 
 - debug: # noqa unnamed-task
-    msg: "{{ current_host }}"
+    msg: "{{ monitor_host_current_host }}"
     verbosity: 1
 
 - name: Start host monitoring
@@ -35,6 +35,6 @@
     apply:
       delegate_to: bastion
   vars:
-    host_id: "{{ current_host.id }}"
-    host_name: "{{ current_host.requested_hostname }}"
-  no_log: True
+    host_id: "{{ monitor_host_current_host.id }}"
+    host_name: "{{ monitor_host_current_host.requested_hostname }}"
+  no_log: true

--- a/roles/patch_host_config/defaults/main.yml
+++ b/roles/patch_host_config/defaults/main.yml
@@ -1,10 +1,10 @@
 ASSISTED_INSTALLER_HOST: "{{ hostvars['assisted_installer']['host'] | default(ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0])) }}"
 ASSISTED_INSTALLER_PORT: "{{ hostvars['assisted_installer']['port'] | default(8090) }}"
 ASSISTED_INSTALLER_BASE_URL: "{{ secure | ternary('https', 'http') }}://{{ ASSISTED_INSTALLER_HOST }}:{{ ASSISTED_INSTALLER_PORT }}/api/assisted-install/v2"
-URL_ASSISTED_INSTALLER_CLUSTER: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ patch_cluster_id }}"
+URL_ASSISTED_INSTALLER_CLUSTER: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/{{ patch_host_config_cluster_id }}"
 URL_ASSISTED_INSTALLER_INFRA_ENV: "{{ ASSISTED_INSTALLER_BASE_URL }}/infra-envs/{{ patch_infra_env_id }}"
 
-patch_cluster_id: "{{ cluster_id }}"
+patch_host_config_cluster_id: "{{ cluster_id }}"
 patch_infra_env_id: "{{ infra_env_id }}"
 single_node_openshift_enabled: "{{ is_valid_single_node_openshift_config | default(false) }}"
 disks_rhcos_root: # Required rhcos_partion

--- a/roles/patch_host_config/tasks/main.yml
+++ b/roles/patch_host_config/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
-# tasks file for install_cluster/hosts_discovery
+# tasks file for patch_host_config
 
 - name: Ensure host has inventory
-  when: discovered_host.inventory is not defined
+  when: patch_host_config_discovered_host.inventory is not defined
   block:
-    - name: "Wait for up to 10 minutes for node discovery - {{ discovered_host.id }}"
+    - name: "Wait for up to 10 minutes for node discovery - {{ patch_host_config_discovered_host.id }}"
       uri:
-        url: "{{ URL_ASSISTED_INSTALLER_INFRA_ENV }}/hosts/{{ discovered_host.id }}"
+        url: "{{ URL_ASSISTED_INSTALLER_INFRA_ENV }}/hosts/{{ patch_host_config_discovered_host.id }}"
         method: GET
         status_code: [200, 201]
         return_content: True
@@ -15,16 +15,16 @@
       retries: 10
       delay: 60
 
-    - name: Identify the discovered host {{ discovered_host.id }}
+    - name: Identify the discovered host {{ patch_host_config_discovered_host.id }}
       set_fact:
         host: "{{ host.json }}"
 
-- name: Identify the discovered host {{ discovered_host.id }}
+- name: Identify the discovered host {{ patch_host_config_discovered_host.id }}
   set_fact:
-    host: "{{ discovered_host }}"
-  when: discovered_host.inventory is defined
+    host: "{{ patch_host_config_discovered_host }}"
+  when: patch_host_config_discovered_host.inventory is defined
 
-- name: Get inventory hostname for {{ discovered_host.id }}
+- name: Get inventory hostname for {{ patch_host_config_discovered_host.id }}
   vars:
     host_mac_addresses: "{{
         (host.inventory | from_json).interfaces | map(attribute='mac_address') | map('upper') | list


### PR DESCRIPTION
Test-Hints: assisted-abi

- While testing https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/92 in a disconnected environment, we could see there were conflicts with cluster variable and the output registered from some tasks, which was also called cluster. Renaming the output to avoid these conflicts.
- Fixing Ansible lint issues with some calls to roles that are made in the modified files.