### PR TITLE
Remove the use of wrapper script opm-auths

### DIFF
--- a/roles/create_pr/tasks/bundle_operator.yml
+++ b/roles/create_pr/tasks/bundle_operator.yml
@@ -20,10 +20,7 @@
     chdir: "{{ work_dir }}/{{ fork_name }}/operators/{{ product_name }}"
 
 - name: "Render bundle operator image"
-  vars:
-    opm_auths: "/usr/share/dci-openshift-agent/utils/opm-auths"
   ansible.builtin.command: >
-    {{ opm_auths }}
     {{ opm_tool_path }} render {{ operator.bundle_image }}
   register: rendered_bundle
   retries: 2

--- a/roles/fbc_catalog/README.md
+++ b/roles/fbc_catalog/README.md
@@ -15,7 +15,6 @@ fbc_bundles      | Yes      | undefined                                      | A
 fbc_expire       | No       | true                                           | Whether or not to set an expiration label on the catalog
 fbc_expire_time  | No       | 5h                                             | The amount of time to set for the expiration label
 fbc_index_image  | Yes      | undefined                                      | Full reference for the image <registry>/namespace/image:tag
-fbc_opm_auths    | No       | /usr/share/dci-openshift-agent/utils/opm-auths | Path to opm-auths a wrapper script to allow multi-regitsry auths in opm
 
 ## Requirements
 

--- a/roles/fbc_catalog/defaults/main.yml
+++ b/roles/fbc_catalog/defaults/main.yml
@@ -2,5 +2,4 @@
 fbc_opm_args: ""
 fbc_expire: true
 fbc_expire_time: 5h
-fbc_opm_auths: "/usr/share/dci-openshift-agent/utils/opm-auths"
 ...

--- a/roles/fbc_catalog/tasks/add-bundle.yml
+++ b/roles/fbc_catalog/tasks/add-bundle.yml
@@ -1,7 +1,6 @@
 ---
 - name: "Render bundle operator image"
   ansible.builtin.shell: >
-    {{ fbc_opm_auths }}
     {{ fbc_opm_cmd }} render {{ bundle }}
   args:
     chdir: "{{ fbc_tmp_dir }}"
@@ -52,7 +51,6 @@
 
 - name: "Render bundle for {{ fbc_short_name }}"
   ansible.builtin.shell: >
-    {{ fbc_opm_auths }}
     {{ fbc_opm_cmd }} render {{ bundle }}
     --output=yaml >> {{ fbc_tmp_dir }}/catalog/index.yml
   args:

--- a/roles/fbc_catalog/tasks/main.yml
+++ b/roles/fbc_catalog/tasks/main.yml
@@ -23,8 +23,8 @@
 
 - name: "Download stable opm client"
   vars:
-    ocp_clients_url: >-
-      https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/
+    ocp_clients_url:
+      "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/\
       opm-linux{{ ansible_distribution_major_version is version('9', '==') | ternary('-rhel9', '') }}.tar.gz"
   ansible.builtin.unarchive:
     src: "{{ ocp_clients_url }}"

--- a/roles/fbc_catalog/tasks/main.yml
+++ b/roles/fbc_catalog/tasks/main.yml
@@ -19,11 +19,13 @@
 
 - name: "Set opm cmd"
   ansible.builtin.set_fact:
-    fbc_opm_cmd: "{{ fbc_tmp_dir }}/opm {{ fbc_opm_args }}"
+    fbc_opm_cmd: "{{ fbc_tmp_dir }}/opm-rhel{{ ansible_distribution_major_version }} {{ fbc_opm_args }}"
 
 - name: "Download stable opm client"
   vars:
-    ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.14/opm-linux.tar.gz"
+    ocp_clients_url: >-
+      https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/
+      opm-linux{{ ansible_distribution_major_version is version('9', '==') | ternary('-rhel9', '') }}.tar.gz"
   ansible.builtin.unarchive:
     src: "{{ ocp_clients_url }}"
     dest: "{{ fbc_tmp_dir }}"

--- a/roles/preflight/tasks/prepare_operator_metadata.yml
+++ b/roles/preflight/tasks/prepare_operator_metadata.yml
@@ -1,12 +1,9 @@
 ---
 - name: "Render bundle operator image"
-  vars:
-    opm_auths: "/usr/share/dci-openshift-agent/utils/opm-auths"
   ansible.builtin.shell: >
     {% if partner_creds | length %}
     DOCKER_CONFIG={{ preflight_tmp_dir.path }}
     {% endif %}
-    {{ opm_auths }}
     {{ opm_tool_path }} render {{ operator.bundle_image }}
   register: rendered_bundle
   retries: 2

--- a/roles/prune_catalog/README.md
+++ b/roles/prune_catalog/README.md
@@ -10,7 +10,6 @@ pc_source_catalog      | Yes      |                                             
 pc_destination_catalog | Yes      |                                               | Catalog containing the required operators
 pc_operators           | Yes      |                                               | The set of operators to keep in the pruned catalog. See examples below
 pc_opm_args            | No       | ""                                            | Arguments for opm command. Those will be applied globally for all opm calls
-pc_opm_auths           | No       | /usr/share/dci-openshift-agent/utils/opm-auths| Path to opm-auths a wrapper script to allow multi-registry auths in opm
 pc_expire              | No       | false                                         | Whether or not to set an expiration label on the catalog
 pc_expire_time         | No       | 5h                                            | The amount of time to set for the expiration label
 pc_maintainer          | No       | redhatci.ocp                                  | Value for catalog's image maintainer label

--- a/roles/prune_catalog/defaults/main.yml
+++ b/roles/prune_catalog/defaults/main.yml
@@ -2,7 +2,6 @@
 pc_opm_args: ""
 pc_expire: false
 pc_expire_time: 5h
-pc_opm_auths: "/usr/share/dci-openshift-agent/utils/opm-auths"
 pc_maintainer: "redhatci.ocp"
 pc_ignore_pull_errors: false
 pc_allow_insecure_registry: true

--- a/roles/prune_catalog/tasks/main.yml
+++ b/roles/prune_catalog/tasks/main.yml
@@ -45,11 +45,13 @@
 
     - name: "Set opm cmd"
       ansible.builtin.set_fact:
-        pc_opm_cmd: "{{ pc_tmp_dir }}/opm {{ pc_opm_args }}"
+        pc_opm_cmd: "{{ pc_tmp_dir }}/opm-rhel{{ ansible_distribution_major_version }} {{ pc_opm_args }}"
 
     - name: "Download stable opm client"
       vars:
-        ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.14/opm-linux.tar.gz"
+        ocp_clients_url:
+          "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable\
+          /opm-linux{{ ansible_distribution_major_version is version('9', '==') | ternary('-rhel9', '') }}.tar.gz"
       ansible.builtin.unarchive:
         src: "{{ ocp_clients_url }}"
         dest: "{{ pc_tmp_dir }}"

--- a/roles/prune_catalog/tasks/main.yml
+++ b/roles/prune_catalog/tasks/main.yml
@@ -71,7 +71,6 @@
         chdir: "{{ pc_tmp_dir }}"
         cmd: >
           set -x;
-          {{ pc_opm_auths }}
           {{ pc_opm_cmd }} render {{ pc_source_catalog }} >
           index-packages
       register: prune_result


### PR DESCRIPTION
The opm-auths is a wrapper script provided by dci-openshift-agent that brings support for multi-entry registry authentication when using opm.

The opm client lacked the functionality as reported in: https://github.com/operator-framework/operator-registry/issues/935

But lately it was added in:
https://github.com/operator-framework/operator-registry/pull/1165

~Now~ it is ~not yet~ coming in the [candidate](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/candidate-4.16/) and soon will be available in the stable ocp clients:
https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/

---

Build-depends: https://softwarefactory-project.io/r/c/dci-openshift-agent/+/30506
Build-depends: https://softwarefactory-project.io/r/c/dci-openshift-app-agent/+/32118

---

- [x] TestDallas: ocp-4.16-vanilla preflight-green
  - [x] ocp-4.16-vanilla - https://www.distributed-ci.io/jobs/7986ce1e-3186-40fc-ac8b-a6fd18b472f3/jobStates
  - [x] preflight-green  - https://www.distributed-ci.io/jobs/bbc2f2b3-c9d6-45f3-8850-a85235785ddd/jobStates

---

Test-Hints: no-check

