### PR TITLE
Allow to create PRs if a sandbox repo is used

### DIFF
--- a/roles/chart_verifier/tasks/main.yml
+++ b/roles/chart_verifier/tasks/main.yml
@@ -22,6 +22,10 @@
   ansible.builtin.set_fact:
     logs_dir: "{{ job_logs.path | default('/tmp') }}"
 
+- name: "Set target repository"
+  ansible.builtin.set_fact:
+    target_repository: "{{ sandbox_repository | default('openshift-helm-charts/charts') }}"
+
 - name: "Render submission report header"
   vars:
     partner: "{{ partner_name | replace(' ', '_') }}"

--- a/roles/chart_verifier/tasks/main.yml
+++ b/roles/chart_verifier/tasks/main.yml
@@ -22,10 +22,6 @@
   ansible.builtin.set_fact:
     logs_dir: "{{ job_logs.path | default('/tmp') }}"
 
-- name: "Set target repository"
-  ansible.builtin.set_fact:
-    target_repository: "{{ sandbox_repository | default('openshift-helm-charts/charts') }}"
-
 - name: "Render submission report header"
   vars:
     partner: "{{ partner_name | replace(' ', '_') }}"

--- a/roles/chart_verifier/tasks/tests.yml
+++ b/roles/chart_verifier/tasks/tests.yml
@@ -190,8 +190,10 @@
     name: redhatci.ocp.create_pr
   vars:
     product_name: "{{ chart_name }}"
+    project_type: "helm"
     product_version: "{{ chart_version }}"
     fork_name: "charts-{{ chart_name }}-{{ chart_version }}"
+    target_repository: "{{ sandbox_repository | default('openshift-helm-charts/charts') }}"
     work_dir: "{{ work_chart_dir }}"
   when:
     - chart.create_pr | default(false) | bool

--- a/roles/chart_verifier/tasks/tests.yml
+++ b/roles/chart_verifier/tasks/tests.yml
@@ -190,7 +190,7 @@
     name: redhatci.ocp.create_pr
   vars:
     product_name: "{{ chart_name }}"
-    project_type: "helm"
+    product_type: "helm"
     product_version: "{{ chart_version }}"
     fork_name: "charts-{{ chart_name }}-{{ chart_version }}"
     work_dir: "{{ work_chart_dir }}"

--- a/roles/chart_verifier/tasks/tests.yml
+++ b/roles/chart_verifier/tasks/tests.yml
@@ -193,7 +193,6 @@
     project_type: "helm"
     product_version: "{{ chart_version }}"
     fork_name: "charts-{{ chart_name }}-{{ chart_version }}"
-    target_repository: "{{ sandbox_repository | default('openshift-helm-charts/charts') }}"
     work_dir: "{{ work_chart_dir }}"
   when:
     - chart.create_pr | default(false) | bool

--- a/roles/create_pr/README.md
+++ b/roles/create_pr/README.md
@@ -4,13 +4,14 @@ For now, it is used by the `chart_verifier` and `preflight` roles, to handle res
 
 Name                                | Default   | Required                    | Description
 ----------------------------------- |-----------|-----------------------------| -------------------------------------------------------------
-product_name                        | undefined | true                        | Name of the chart or the operator you want to certify
-product_version                     | undefined | true                        | Version of the product
+product_name                        | undefined | true                        | Name of the chart or the operator you want to certify.
+product_version                     | undefined | true                        | Version of the product.
 work_dir                            | /tmp      | false                       | Directory to store the tests results.
 github_token_path                   | undefined | true                        | GitHub token to be used to push the chart and the results to a repository.
 partner_name                        | undefined | true/false                  | Define this parameter only when opening PR for chart_verifier. Partner name to be used in the pull request title.
-partner_email                       | undefined | true/false                  | Define this parameter only when opening PR for chart_verifier. Email address to be used in the pull request
-target_repository                   | undefined | true                        | Either 'openshift-helm-charts/charts' or 'redhat-openshift-ecosystem/certified-operators'
+partner_email                       | undefined | true/false                  | Define this parameter only when opening PR for chart_verifier. Email address to be used in the pull request.
+target_repository                   | undefined | true                        | GitHub repository where the pull request will be created.
+product_type                        | undefined | true                        | Product type. Either "helm" or "operator".
 
 Those are the common variables used by both certification project.
 It includes tasks to generate an SSH key needed to push to Github repository and add it to the GitHub account.

--- a/roles/create_pr/tasks/main.yml
+++ b/roles/create_pr/tasks/main.yml
@@ -4,7 +4,7 @@
     that: "{{ item }} is defined"
     fail_msg: "The parameter {{ item }} is required"
   with_items:
-    - project_type
+    - product_type
     - product_name
     - product_version
     - fork_name
@@ -96,9 +96,9 @@
 
 - name: Create PR for Helm Chart Verifier
   ansible.builtin.include_tasks: helm_chart_verifier.yml
-  when: project_type == "helm"
+  when: product_type == "helm"
 
 - name: Create PR for Operator Bundle Certification
   ansible.builtin.include_tasks: bundle_operator.yml
-  when: project_type == "operator"
+  when: product_type == "operator"
 ...

--- a/roles/create_pr/tasks/main.yml
+++ b/roles/create_pr/tasks/main.yml
@@ -4,6 +4,7 @@
     that: "{{ item }} is defined"
     fail_msg: "The parameter {{ item }} is required"
   with_items:
+    - project_type
     - product_name
     - product_version
     - fork_name
@@ -95,9 +96,9 @@
 
 - name: Create PR for Helm Chart Verifier
   ansible.builtin.include_tasks: helm_chart_verifier.yml
-  when: target_repository == "openshift-helm-charts/charts"
+  when: project_type == "helm"
 
 - name: Create PR for Operator Bundle Certification
   ansible.builtin.include_tasks: bundle_operator.yml
-  when: target_repository == "redhat-openshift-ecosystem/certified-operators"
+  when: project_type == "operator"
 ...

--- a/roles/preflight/tasks/test_preflight_check_container_one_image.yml
+++ b/roles/preflight/tasks/test_preflight_check_container_one_image.yml
@@ -45,7 +45,7 @@
       ansible.builtin.include_role:
         name: redhatci.ocp.create_certification_project
       vars:
-        project_type: "container"
+        product_type: "container"
       when:
         - operator.create_container_project | default(false) | bool
         - operator.pyxis_container_identifier | default('') | length == 0

--- a/roles/preflight/tasks/tests_preflight_check_operator.yml
+++ b/roles/preflight/tasks/tests_preflight_check_operator.yml
@@ -175,24 +175,20 @@
     name: redhatci.ocp.pyxis
   when: cert_project_id | default('') | length > 0
 
-- name: Create certification PR
+- name: Create a PR for certification
+  ansible.builtin.include_role:
+    name: redhatci.ocp.create_pr
+    apply:
+      environment:
+        DOCKER_CONFIG: "{{ preflight_tmp_dir.path }}"
+  vars:
+    product_name: "{{ operator.name }}"
+    product_type: "operator"
+    product_version: "{{ operator.version }}"
+    fork_name: "certified-operator-{{ operator.name }}-{{ operator.version }}"
+    work_dir: "{{ preflight_operator_artifacts.path }}"
+    target_repository: "{{ sandbox_repository | default('redhat-openshift-ecosystem/certified-operators') }}"
   when: operator.create_pr | default(false) | bool
-  block:
-    - name: Set target repository
-      ansible.builtin.set_fact:
-        target_repository: "{{ sandbox_repository | default('redhat-openshift-ecosystem/certified-operators') }}"
-
-    - name: Create a PR for certification
-      ansible.builtin.include_role:
-        name: redhatci.ocp.create_pr
-        apply:
-          environment:
-            DOCKER_CONFIG: "{{ preflight_tmp_dir.path }}"
-      vars:
-        product_name: "{{ operator.name }}"
-        product_version: "{{ operator.version }}"
-        fork_name: "certified-operator-{{ operator.name }}-{{ operator.version }}"
-        work_dir: "{{ preflight_operator_artifacts.path }}"
 
 - name: Unset project ID to ensure no occasional reuse
   ansible.builtin.set_fact:

--- a/roles/preflight/tasks/tests_preflight_check_operator.yml
+++ b/roles/preflight/tasks/tests_preflight_check_operator.yml
@@ -160,7 +160,7 @@
   ansible.builtin.include_role:
     name: redhatci.ocp.create_certification_project
   vars:
-    project_type: "operator"
+    product_type: "operator"
   when:
     - operator.create_operator_project | default(false) | bool
     - operator.pyxis_operator_identifier | default('') | length == 0


### PR DESCRIPTION
- At this time the Role only allows creating PRs only to the official RH certification project. This allows to use the sandbox repo if defined.
