### PR TITLE
Remove tested image form root account

### DIFF
--- a/roles/preflight/tasks/test_run_health_check.yml
+++ b/roles/preflight/tasks/test_run_health_check.yml
@@ -54,6 +54,14 @@
     chdir: "{{ preflight_container_artifacts.path }}"
   become: true
 
+- name: Remove the tested image
+  shell:
+    cmd: >
+      podman rmi
+      --force
+      {{ current_operator_image }}
+  become: true
+
 - name: Change the ownership of oval report
   ansible.builtin.file:
     path: "{{ file }}"


### PR DESCRIPTION
The images tested using oscap-podman aren't deleted, which can fill up the filesystem of the host used for the testing.