### PR TITLE
Assisted on-prem | Wait until 90 minutes to report the cluster as installed

### DIFF
--- a/roles/monitor_cluster/tasks/main.yml
+++ b/roles/monitor_cluster/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for monitor_cluster
 
 # Monitor cluster installation
-- name: Wait for up to 60 minutes for the cluster to report as installed
+- name: Wait for up to 90 minutes for the cluster to report as installed
   uri:
     url: "{{ URL_ASSISTED_INSTALLER_CLUSTER }}"
     method: GET
@@ -10,7 +10,7 @@
     return_content: True
   register: cluster_output
   until: cluster_output.json.status in ['installed', 'error', 'cancelled']
-  retries: 60
+  retries: 90
   delay: 60
   delegate_to: bastion
 


### PR DESCRIPTION
Test-Hints: assisted

Please check cases like [this one](https://www.distributed-ci.io/jobs/3beee136-241f-4a81-b829-fca30e08c07d/jobStates?sort=date&task=4820ec42-f178-4d5f-a808-e5d21a40596b). All the nodes from the OCP cluster installed with Assisted on-prem are reporting the "installed" state, whereas the cluster reported "finishing" state, with this message: "Finalizing cluster installation".

This makes me think that maybe we need to wait a little bit more in this check to confirm the cluster is ready.