### PR TITLE
Fix release name

### DIFF
--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -43,7 +43,7 @@
         set -o pipefail;
         echo -e "{{ result.stdout }}" |
         sed -n '/apiVersion/,$p' |
-        sed -e 's/name:.*/name: release-{{ version }}/'
+        sed -e 's/name:.*/name: release-{{ mor_version }}/'
       register: is_release
 
     - name: Write Image Source manifest


### PR DESCRIPTION
Using the local role variable that actually represents the release version that is been mirrored.