### PR TITLE
verify_tests: restored file name in fail task

### DIFF
--- a/roles/verify_tests/tasks/parse_junit_file.yml
+++ b/roles/verify_tests/tasks/parse_junit_file.yml
@@ -34,7 +34,7 @@
       ansible.builtin.set_fact:
         actual_results: "{{ item | redhatci.ocp.junit2dict }}"
 
-    - name: Fail if not all test results are as expected
+    - name: "Fail if not all test results are as expected for {{ item | basename }}"
       vars:
         expectation_failed: "{{ t.expected_results | redhatci.ocp.regex_diff(actual_results) }}"
       ansible.builtin.fail:


### PR DESCRIPTION
The verify_tests task "Fail if not all test results are as expected" used to include the name of the affected file but it got removed in [this commit](https://github.com/redhatci/ansible-collection-redhatci-ocp/commit/848f809caf5edfccfd543dd82d74196b99560908#diff-d637e677ca97f8c3fc558dcf18c514027e2176b0c3a5808d8ca2c6eaecad6eae).

We need the name of the file in order to classify properly a failed job with the appropriate jira tag.