### PR TITLE
Add sriov_config role

### DIFF
--- a/roles/sriov_config/README.md
+++ b/roles/sriov_config/README.md
@@ -1,0 +1,162 @@
+# sriov_config
+
+Configure SR-IOV node policies and/or networks
+
+## Requirements
+
+SR-IOV Operator needs to be installed already in the cluster for this role to interact with it.
+
+Nodes must have SR-IOV capable network interfaces.
+
+## Variables
+
+| Variable                      | Required  | Type    | Default   | Description
+| ----------------------------- | --------- | ------- | --------- | -----------
+| sriov_config_file             | Yes       | String  | Undefined | The configuration file for SR-IOV Node policy and/or network.
+| sriov_config_wait_node_policy | No        | Boolean | True      | Whether or not wait for node policies to apply
+
+### SR-IOV Network configs
+
+The `sriov_config_file` **must** meet the following requirements
+
+| Variable              | Required  | Type    | Description
+| --------------------- | --------- | ------- | -----------
+| sriov_network_configs | Yes       | String  | Single variable including the Resource name and the SR-IOV Node Policies and/or Network configurations.
+| resource              | Yes       | String  | The name of the resource created by SR-IOV Node Policy and the name to be consumed by the SR-IOV Network.
+| node_policy           | See Note  | String  | The SR-IOV Node Policy to create a resource consumed by the SR-IOV Network.
+| network               | See Note  | String  | The SR-IOV Network using the resource form the Node Policy.
+
+> NOTE:
+> - It's possible to omit a SR-IOV `network` when only a `node_policy` is applied.
+> - It's possible to omit a `node_policy` when the SR-IOV `network` to apply is mapped to an existing SR-IOV Network Node Policy
+
+#### SR-IOV Node Policy
+
+| Variable         | Required | Type    | Description
+| ---------------- | -------- | ------- | -----------
+| name             | Yes      | String  | Name of the SR-IOV Network Node Policy.
+| device_type      | No       | String  | The driver type for configured VFs. Allowed value "netdevice", "vfio-pci".
+| eswitch_mode     | No       | String  | NIC Device Mode. Allowed value "legacy","switchdev".
+| exclude_topology | No       | Boolean | Exclude device's NUMA node when advertising this resource by SR-IOV network device plugin.
+| is_rdma          | No       | Boolean | RDMA mode.
+| link_type        | No       | String  | NIC Link Type. Allowed value "eth", "ETH", "ib", and "IB"
+| mtu              | No       | Int     | MTU of VF.
+| need_vhost_net   | No       | Boolean | Mount vhost-net device
+| nic_selector     | Yes      | List    | List of NICs to configure, see table below
+| node_selector    | No       | Dict    | Selects the nodes to be configured. Default: `"node-role.kubernetes.io/worker": ""`
+| num_vfs          | Yes      | Int     | Number of VFs for each PF
+| priority         | No       | Int     | Priority of the policy, higher priority policies can override lower ones
+| vdpa_type        | No       | String  | VDPA device type. Allowed value "virtio", "vhost"
+
+#### NIC Selector
+
+| Variable     | Required | Type    | Description
+| ------------ | -------- | ------- | -----------
+| device_id    | Yes      | String  | The device hex code of SR-IoV device. Allowed value "0d58", "1572", "158b", "1013", "1015", "1017", "101b".
+| net_filter   | No       | String  | Infrastructure Networking selection filter. Allowed value "openstack/NekID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+| pf_names     | Yes      | List    | List of Names of SR-IoV PF.
+| root_devices | No       | List    | List of PCI address of SR-IoV PF.
+| vendor       | Yes      | String  | The vendor hex code of SR-IoV device. Allowed value "8086", "15b3".
+
+### SR-IOV Network
+
+| Variable          | Required | Type    | Description
+| ----------------- | -------- | ------- | -----------
+| name              | Yes      | String  | Name of the SR-IOV Network.
+| capabilities      | No       | String  | Capabilities to be configured for this network.
+| ipam              | No       | String  | IPAM configuration to be used for this network.
+| link_state        | No       | String  | VF link state (enable|disable|auto).
+| max_tx_rate       | No       | Int     | Maximum tx rate, in Mbps, for the VF.
+| meta_plugins      | No       | String  | MetaPluginsConfig configuration to be used in order to chain metaplugins to the sriov interface returned by the operator.
+| min_tx_rate       | No       | Int     | Minimum tx rate, in Mbps, for the VF, min_tx_rate should be <= max_tx_rate.
+| network_namespace | No       | String  | Namespace of the NetworkAttachmentDefinition custom resource
+| spoof_chk         | No       | String  | VF spoof check, (on|off)
+| trust             | No       | String  | VF trust mode (on|off)
+| vlan              | No       | Int     | VLAN ID to assign for the VF.
+| vlan_qos          | No       | Int     | VLAN QoS ID to assign for the VF.
+
+## Examples
+
+### Using the role
+
+```yaml
+- name: "Configure SR-IOV"
+  ansible.builtin.include_role:
+    name: redhatci.ocp.sriov_config
+  vars:
+    sriov_config_file: /path/to/sriov-config-file.yaml
+```
+
+### Configuration file
+
+#### SR-IOV Node policy and network
+
+A Node Policy and a Network configuration using the same resource `sriov_port0`:
+
+```YAML
+sriov_network_configs:
+  - resource: sriov_port0
+    node_policy:
+      name: sriov-policy0
+      device_type: vfio-pci
+      is_rdma: true
+      mtu: 9000
+      nic_selector:
+        device_id: "1017"
+        pf_names:
+          - ens2f1#0-15
+        root_devices:
+          - "0000:12:00.0"
+        vendor: "15b3"
+      node_selector:
+        node-role.kubernetes.io/worker: ""
+        node-role.kubernetes.io/infra: ""
+      num_vfs: 16
+      priority: 99
+    network:
+      name: sriov-net0
+      vlan: 10
+      network_namespace: my-app-namespace
+      spoof_chk: on
+      trust: on
+      capabilities: '{ "mac": true, "ips": true }'
+```
+
+#### SR-IOV Node Policy
+
+A singel Node Policy for a resource called `intel_port0`
+
+```YAML
+sriov_network_configs:
+  - resource: intel_port0
+    node_policy:
+      name: intel-i40e-p0
+      device_type: vfio-pci
+      mtu: 9000
+      nic_selector:
+        device_id: 1592
+        pf_names:
+          - ens3f0#0-8
+        vendor: 8086
+      num_vfs: 8
+```
+
+#### SR-IOV Networks
+
+Two network configurations tied to two node policies with the resources `sriov_port0` and `intel_port0`
+
+```YAML
+sriov_network_configs:
+  - resource: sriov_port0
+    network:
+      name: sriov-net1
+      vlan: 20
+      network_namespace: my-dev-namespace
+      trust: on
+  - resource: intel_port0
+    network:
+      name: intel-net1
+      vlan: 21
+      network_namespace: my-test-namespace
+      spoof_chk: on
+```

--- a/roles/sriov_config/README.md
+++ b/roles/sriov_config/README.md
@@ -14,6 +14,8 @@ Nodes must have SR-IOV capable network interfaces.
 | ----------------------------- | --------- | ------- | --------- | -----------
 | sriov_config_file             | Yes       | String  | Undefined | The configuration file for SR-IOV Node policy and/or network.
 | sriov_config_wait_node_policy | No        | Boolean | True      | Whether or not wait for node policies to apply
+| sriov_config_retries_per_node | No        | Int     | 60        | Number of retries for Node readiness
+| sriov_config_delay_per_node   | No        | Int     | 10        | Seconds to wait between retries for Node readiness
 
 ### SR-IOV Network configs
 
@@ -109,8 +111,7 @@ sriov_network_configs:
           - "0000:12:00.0"
         vendor: "15b3"
       node_selector:
-        node-role.kubernetes.io/worker: ""
-        node-role.kubernetes.io/infra: ""
+        node-role.kubernetes.io/sriov: ""
       num_vfs: 16
       priority: 99
     network:
@@ -121,6 +122,9 @@ sriov_network_configs:
       trust: on
       capabilities: '{ "mac": true, "ips": true }'
 ```
+
+> NOTE: SR-IOV operator requires nodes to use the `worker` role.
+> Additional tags are valid as long as those nodes are also `workers`
 
 #### SR-IOV Node Policy
 

--- a/roles/sriov_config/README.md
+++ b/roles/sriov_config/README.md
@@ -53,7 +53,7 @@ The `sriov_config_file` **must** meet the following requirements
 | Variable     | Required | Type    | Description
 | ------------ | -------- | ------- | -----------
 | device_id    | Yes      | String  | The device hex code of SR-IoV device. Allowed value "0d58", "1572", "158b", "1013", "1015", "1017", "101b".
-| net_filter   | No       | String  | Infrastructure Networking selection filter. Allowed value "openstack/NekID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+| net_filter   | No       | String  | Infrastructure Networking selection filter. Allowed value "openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 | pf_names     | Yes      | List    | List of Names of SR-IoV PF.
 | root_devices | No       | List    | List of PCI address of SR-IoV PF.
 | vendor       | Yes      | String  | The vendor hex code of SR-IoV device. Allowed value "8086", "15b3".

--- a/roles/sriov_config/README.md
+++ b/roles/sriov_config/README.md
@@ -36,7 +36,7 @@ The `sriov_config_file` **must** meet the following requirements
 | ---------------- | -------- | ------- | -----------
 | name             | Yes      | String  | Name of the SR-IOV Network Node Policy.
 | device_type      | No       | String  | The driver type for configured VFs. Allowed value "netdevice", "vfio-pci".
-| eswitch_mode     | No       | String  | NIC Device Mode. Allowed value "legacy","switchdev".
+| e_switch_mode     | No       | String  | NIC Device Mode. Allowed value "legacy","switchdev".
 | exclude_topology | No       | Boolean | Exclude device's NUMA node when advertising this resource by SR-IOV network device plugin.
 | is_rdma          | No       | Boolean | RDMA mode.
 | link_type        | No       | String  | NIC Link Type. Allowed value "eth", "ETH", "ib", and "IB"

--- a/roles/sriov_config/defaults/main.yml
+++ b/roles/sriov_config/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-sriov_network_retries_per_node: 60
-sriov_network_delay_per_node: 10
+sriov_config_retries_per_node: 60
+sriov_config_delay_per_node: 10

--- a/roles/sriov_config/defaults/main.yml
+++ b/roles/sriov_config/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+sriov_network_retries_per_node: 60
+sriov_network_delay_per_node: 10

--- a/roles/sriov_config/defaults/main.yml
+++ b/roles/sriov_config/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 sriov_config_retries_per_node: 60
-sriov_config_delay_per_node: 10
+sriov_config_delay_per_node: 20
+sriov_config_wait_node_policy: true

--- a/roles/sriov_config/tasks/check_sriov_node_policy.yml
+++ b/roles/sriov_config/tasks/check_sriov_node_policy.yml
@@ -1,0 +1,30 @@
+---
+- name: Get SR-IOV Selected Nodes for resource {{ sriov_conf.resource }}
+  community.kubernetes.k8s_info:
+    kind: Node
+    label_selectors: >-
+      {{ sriov_conf.node_policy.node_selector |
+         default({"node-role.kubernetes.io/worker": ""}) |
+         list }}
+  register: selected_nodes
+  no_log: true
+
+# "retries" variables require to be defined prior executing the task
+- name: Wait for selected nodes to have SR-IOV resource {{ sriov_conf.resource }}
+  vars:
+    sriov_filter: "{{ '[*].status.allocatable.\"openshift.io/' + sriov_conf.resource + '\".to_number(@)' }}"
+    nodes_with_sriov: "{{ nodes.resources | json_query(sriov_filter) }}"
+  community.kubernetes.k8s_info:
+    kind: Node
+    label_selectors: >-
+      {{ sriov_conf.node_policy.node_selector |
+         default({"node-role.kubernetes.io/worker": ""}) |
+         list }}
+  register: nodes
+  retries: "{{ selected_nodes.resources | length * sriov_config_retries_per_node | int }}"
+  delay: "{{ sriov_config_delay_per_node | int }}"
+  until:
+    - nodes_with_sriov | length == nodes.resources | length
+    - nodes_with_sriov | sort | unique | length == 1
+    - nodes_with_sriov | sort | unique | first | int == sriov_conf.node_policy.num_vfs
+  no_log: true

--- a/roles/sriov_config/tasks/create_networks.yml
+++ b/roles/sriov_config/tasks/create_networks.yml
@@ -1,0 +1,9 @@
+---
+- name: Create SriovNetwork
+  community.kubernetes.k8s:
+    definition: "{{ lookup('template', 'templates/sriov-network.yml.j2') }}"
+  loop: "{{ sriov_network_configs }}"
+  loop_control:
+    loop_var: sriov
+    label: "{{ sriov.resource }}"
+  when: sriov.network is defined

--- a/roles/sriov_config/tasks/create_node_policies.yml
+++ b/roles/sriov_config/tasks/create_node_policies.yml
@@ -8,30 +8,12 @@
     label: "{{ sriov.resource }}"
   when: sriov.node_policy is defined
 
-- name: Wait for the Nodes to be SR-IOV Ready
-  vars:
-    selected_nodes: "{{ nodes.resources | length }}"
-    sriov_nodes: >-
-      {{ nodes.resources |
-         map(attribute='status.allocatable') |
-         map('dict2items') | flatten | list |
-         selectattr('key', 'equalto', 'openshift.io/' + sriov.resource) |
-         list | length }}
-  community.kubernetes.k8s_info:
-    kind: Node
-    label_selectors: >-
-      {{ sriov.node_policy.node_selector |
-         default('node-role.kubernetes.io/worker') |
-         list }}
-  register: nodes
-  no_log: true
-  until: selected_nodes == sriov_nodes
-  retries: "{{ selected_nodes * sriov_config_retries_per_node | int }}"
-  delay: "{{ sriov_config_delay_per_node | int }}"
+- name: Check for SRIOV Node Policy
+  ansible.builtin.include_tasks: check_sriov_node_policy.yml
   loop: "{{ sriov_network_configs }}"
   loop_control:
-    loop_var: sriov
-    label: "{{ sriov.resource }}"
+    loop_var: sriov_conf
+    label: "{{ sriov_conf.resource }}"
   when:
-    - sriov.node_policy is defined
-    - sriov_config_wait_node_policy | default(true) | bool
+    - sriov_conf.node_policy is defined
+    - sriov_config_wait_node_policy | bool

--- a/roles/sriov_config/tasks/create_node_policies.yml
+++ b/roles/sriov_config/tasks/create_node_policies.yml
@@ -26,7 +26,7 @@
   register: nodes
   no_log: true
   until: selected_nodes == sriov_nodes
-  retries: 90
+  retries: "{{ selected_nodes * sriov_config_retries_per_node | int }}"
   delay: 10
   loop: "{{ sriov_network_configs }}"
   loop_control:

--- a/roles/sriov_config/tasks/create_node_policies.yml
+++ b/roles/sriov_config/tasks/create_node_policies.yml
@@ -27,7 +27,7 @@
   no_log: true
   until: selected_nodes == sriov_nodes
   retries: "{{ selected_nodes * sriov_config_retries_per_node | int }}"
-  delay: 10
+  delay: "{{ sriov_config_delay_per_node | int }}"
   loop: "{{ sriov_network_configs }}"
   loop_control:
     loop_var: sriov

--- a/roles/sriov_config/tasks/create_node_policies.yml
+++ b/roles/sriov_config/tasks/create_node_policies.yml
@@ -1,0 +1,37 @@
+---
+- name: Create SriovNetworkNodePolicy
+  community.kubernetes.k8s:
+    definition: "{{ lookup('template', 'templates/sriov-network-node-policy.yml.j2') }}"
+  loop: "{{ sriov_network_configs }}"
+  loop_control:
+    loop_var: sriov
+    label: "{{ sriov.resource }}"
+  when: sriov.node_policy is defined
+
+- name: Wait for the Nodes to be SR-IOV Ready
+  vars:
+    selected_nodes: "{{ nodes.resources | length }}"
+    sriov_nodes: >-
+      {{ nodes.resources |
+         map(attribute='status.allocatable') |
+         map('dict2items') | flatten | list |
+         selectattr('key', 'equalto', 'openshift.io/' + sriov.resource) |
+         list | length }}
+  community.kubernetes.k8s_info:
+    kind: Node
+    label_selectors: >-
+      {{ sriov.node_policy.node_selector |
+         default('node-role.kubernetes.io/worker') |
+         list }}
+  register: nodes
+  no_log: true
+  until: selected_nodes == sriov_nodes
+  retries: 90
+  delay: 10
+  loop: "{{ sriov_network_configs }}"
+  loop_control:
+    loop_var: sriov
+    label: "{{ sriov.resource }}"
+  when:
+    - sriov.node_policy is defined
+    - sriov_config_wait_node_policy | default(true) | bool

--- a/roles/sriov_config/tasks/main.yml
+++ b/roles/sriov_config/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Validate SR-IOV requirements
+  ansible.builtin.include_tasks: validation.yml
+
+- name: Create SriovNetworkNodePolicies
+  ansible.builtin.include_tasks: create_node_policies.yml
+  when: sriov_network_configs | json_query('[*].node_policy') | select('defined') | list | length
+
+- name: Create SriovNetworks
+  ansible.builtin.include_tasks: create_networks.yml
+  when: sriov_network_configs | json_query('[*].network') | select('defined') | list | length

--- a/roles/sriov_config/tasks/validation.yml
+++ b/roles/sriov_config/tasks/validation.yml
@@ -1,0 +1,52 @@
+---
+- name: Check SR-IOV config file
+  ansible.builtin.stat:
+    path: "{{ sriov_config_file }}"
+  register: sriov_config_file_stat
+
+- name: Fail if SR-IOV config file is not found
+  ansible.builtin.fail:
+    msg: "SR-IOV config file {{ sriov_config_file }} not found"
+  when: not sriov_config_file_stat.stat.exists
+
+- name: Fail if SR-IOV config file is empty
+  ansible.builtin.fail:
+    msg: "SR-IOV config file {{ sriov_config_file }} is empty"
+  when: sriov_config_file_stat.stat.size == 0
+
+- name: Load SR-IOV config file
+  ansible.builtin.include_vars:
+    file: "{{ sriov_config_file }}"
+  when: sriov_config_file_stat.stat.exists
+
+- name: Fail if SR-IOV config file does not contain sriov_network_configs
+  ansible.builtin.fail:
+    msg: "SR-IOV config file {{ sriov_config_file }} does not contain sriov_network_configs"
+  when: sriov_network_configs is not defined
+
+- name: Fail if SR-IOV does not include resource definition
+  ansible.builtin.fail:
+    msg: "SR-IOV config file {{ sriov_config_file }} does not include resource definition in each element of the sriov_network_configs"
+  when: sriov_network_configs | json_query('[*].resource') | select('undefined') | list | length > 0
+
+- name: Fail if SR-IOV does not include node_policy or network definition
+  ansible.builtin.fail:
+    msg: "SR-IOV config file {{ sriov_config_file }} does not include node_policy or network definition in each element of the sriov_network_configs"
+  when: sriov_network_configs | json_query('[*].node_policy') | select('undefined') | list | length > 0 or
+        sriov_network_configs | json_query('[*].network') | select('undefined') | list | length > 0
+
+- name: Check SR-IOV Operator
+  community.kubernetes.k8s_info:
+    api: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: openshift-sriov-network-operator
+  register: sriov_csv
+  retries: 5
+  delay: 5
+  until:
+    - sriov_csv is defined
+    - sriov_csv.resources is defined
+    - sriov_csv.resources | length
+    - sriov_csv.resources | json_query('[*].metadata.name') |
+      select('search', '^sriov-network-operator') |
+      list  | length

--- a/roles/sriov_config/tasks/validation.yml
+++ b/roles/sriov_config/tasks/validation.yml
@@ -50,3 +50,4 @@
     - sriov_csv.resources | json_query('[*].metadata.name') |
       select('search', '^sriov-network-operator') |
       list  | length
+  no_log: true

--- a/roles/sriov_config/templates/sriov-network-node-policy.yml.j2
+++ b/roles/sriov_config/templates/sriov-network-node-policy.yml.j2
@@ -1,0 +1,53 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: "{{ sriov.node_policy.name }}"
+  namespace: openshift-sriov-network-operator
+spec:
+{% if sriov.node_policy.device_type is defined %}
+  deviceType: "{{ sriov.node_policy.device_type }}"
+{% endif %}
+{% if sriov.node_policy.e_switch_mode is defined %}
+  eSwitchMode: "{{ sriov.node_policy.e_switch_mode }}"
+{% endif %}
+{% if sriov.node_policy.exclude_topology is defined %}
+  excludeTopology: {{ sriov.node_policy.exclude_topology | bool }}
+{% endif %}
+{% if sriov.node_policy.is_rdma is defined %}
+  isRdma: {{ sriov.node_policy.is_rdma | bool }}
+{% endif %}
+{% if sriov.node_policy.link_type is defined %}
+  linkType: "{{ sriov.node_policy.link_type }}"
+{% endif %}
+{% if sriov.node_policy.mtu is defined %}
+  mtu: "{{ sriov.node_policy.mtu }}"
+{% endif %}
+{% if sriov.node_policy.need_vhost_net is defined %}
+  needVhostNet: {{ sriov.node_policy.need_vhost_net | bool }}
+{% endif %}
+  nicSelector:
+    deviceID: "{{ sriov.node_policy.nic_selector.device_id }}"
+{% if sriov.node_policy.nic_selector.net_filter is defined %}
+    netFilter: "{{ sriov.node_policy.nic_selector.net_filter }}"
+{% endif %}
+    pfNames:
+{% for pf_name in sriov.node_policy.nic_selector.pf_names %}
+    - "{{ pf_name }}"
+{% endfor %}
+{% if sriov.node_policy.nic_selector.root_devices is defined %}
+    rootDevices:
+{% for root_device in sriov.node_policy.nic_selector.root_devices %}
+    - "{{ root_device }}"
+{% endfor %}
+{% endif %}
+    vendor: "{{ sriov.node_policy.nic_selector.vendor }}"
+  nodeSelector:
+    {{ sriov.node_policy.node_selector | default('"node-role.kubernetes.io/worker": ""') }}
+  numVfs: {{ sriov.node_policy.num_vfs | int }}
+{% if sriov.node_policy.priority is defined %}
+  priority: {{ sriov.node_policy.priority | int }}
+{% endif %}
+  resourceName: "{{ sriov.resource }}"
+{% if sriov.node_policy.vdpa_type is defined %}
+    vdpaType: "{{ sriov.node_policy.vdpa_type }}"
+{% endif %}

--- a/roles/sriov_config/templates/sriov-network-node-policy.yml.j2
+++ b/roles/sriov_config/templates/sriov-network-node-policy.yml.j2
@@ -20,7 +20,7 @@ spec:
   linkType: "{{ sriov.node_policy.link_type }}"
 {% endif %}
 {% if sriov.node_policy.mtu is defined %}
-  mtu: "{{ sriov.node_policy.mtu }}"
+  mtu: {{ sriov.node_policy.mtu | int }}
 {% endif %}
 {% if sriov.node_policy.need_vhost_net is defined %}
   needVhostNet: {{ sriov.node_policy.need_vhost_net | bool }}

--- a/roles/sriov_config/templates/sriov-network.yml.j2
+++ b/roles/sriov_config/templates/sriov-network.yml.j2
@@ -1,0 +1,40 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: "{{ sriov.network.name }}"
+  namespace: openshift-sriov-network-operator
+spec:
+{% if sriov.network.capabilities is defined %}
+  capabilities: "{{ sriov.network.capabilities }}"
+{% endif %}
+{% if sriov.network.ipam is defined %}
+  ipam: "{{ sriov.network.ipam }}"
+{% endif %}
+{% if sriov.network.link_state is defined %}
+  linkState: "{{ sriov.network.link_state }}"
+{% endif %}
+{% if sriov.network.max_tx_rate is defined %}
+  maxTxRate: "{{ sriov.network.max_tx_rate | int}}"
+{% endif %}
+{% if sriov.network.meta_plugins is defined %}
+  metaPlugins: "{{ sriov.network.meta_plugins }}"
+{% endif %}
+{% if sriov.network.min_tx_rate is defined %}
+  minTxRate: "{{ sriov.network.min_tx_rate | int}}"
+{% endif %}
+{% if sriov.network.network_namespace is defined %}
+  networkNamespace: "{{ sriov.network.network_namespace }}"
+{% endif %}
+  resourceName: "{{ sriov.resource }}"
+{% if sriov.network.spoof_chk is defined %}
+  spoofChk: "{{ sriov.network.spoof_chk }}"
+{% endif %}
+{% if sriov.network.trust is defined %}
+  trust: "{{ sriov.network.trust }}"
+{% endif %}
+{% if sriov.network.vlan is defined %}
+  vlan: {{ sriov.network.vlan | int }}
+{% endif %}
+{% if sriov.network.vlan_qos is defined %}
+  vlanQoS: {{ sriov.network.vlan_qos | int }}
+{% endif %}

--- a/roles/sriov_config/templates/sriov-network.yml.j2
+++ b/roles/sriov_config/templates/sriov-network.yml.j2
@@ -14,13 +14,13 @@ spec:
   linkState: "{{ sriov.network.link_state }}"
 {% endif %}
 {% if sriov.network.max_tx_rate is defined %}
-  maxTxRate: "{{ sriov.network.max_tx_rate | int}}"
+  maxTxRate: {{ sriov.network.max_tx_rate | int }}
 {% endif %}
 {% if sriov.network.meta_plugins is defined %}
   metaPlugins: "{{ sriov.network.meta_plugins }}"
 {% endif %}
 {% if sriov.network.min_tx_rate is defined %}
-  minTxRate: "{{ sriov.network.min_tx_rate | int}}"
+  minTxRate: {{ sriov.network.min_tx_rate | int }}
 {% endif %}
 {% if sriov.network.network_namespace is defined %}
   networkNamespace: "{{ sriov.network.network_namespace }}"


### PR DESCRIPTION
This role takes care of configuring sriov node policies and/or networks. Requires sriov operator installed in the cluster and sriov capable NICs.