### PR TITLE
Allow port configuration for assisted installer setup

### DIFF
--- a/roles/setup_assisted_installer/defaults/main.yml
+++ b/roles/setup_assisted_installer/defaults/main.yml
@@ -5,6 +5,9 @@ assisted_service_image: "{{ assisted_service_image_repo_url }}/assisted-service@
 assisted_service_gui_image: "{{ assisted_service_image_repo_url }}/assisted-installer-ui@{{ image_hashes.gui }}"
 assisted_service_image_service_image: "{{ assisted_service_image_repo_url }}/assisted-image-service@{{ image_hashes.image_service }}"
 
+assisted_service_gui_port: 8080
+assisted_service_image_service_port: 8888
+
 assisted_service_controller_image: "{{ assisted_service_image_repo_url }}/assisted-installer-controller@{{ image_hashes.controller }}"
 assisted_service_installer_agent_image: "{{ assisted_service_image_repo_url }}/assisted-installer-agent@{{ image_hashes.installer_agent }}"
 assisted_service_installer_image: "{{ assisted_service_image_repo_url }}/assisted-installer@{{ image_hashes.installer }}"

--- a/roles/setup_assisted_installer/templates/configmap.yml.j2
+++ b/roles/setup_assisted_installer/templates/configmap.yml.j2
@@ -5,7 +5,7 @@ metadata:
   name: config
 data:
   ASSISTED_SERVICE_HOST: "{{ assisted_service_host }}:{{ port }}"
-  IMAGE_SERVICE_BASE_URL: http://{{ image_service_host }}:8888
+  IMAGE_SERVICE_BASE_URL: http://{{ image_service_host }}:{{ assisted_service_image_service_port }}
   SERVICE_BASE_URL: "http://{{ assisted_service_host }}:{{ port }}"
   ASSISTED_SERVICE_SCHEME: http
   AUTH_TYPE: none

--- a/roles/setup_assisted_installer/templates/pod.yml.j2
+++ b/roles/setup_assisted_installer/templates/pod.yml.j2
@@ -19,14 +19,14 @@ spec:
     - image: "{{ assisted_service_gui_image }}"
       name: ui
       ports:
-      - hostPort: 8080
+      - hostPort: {{ assisted_service_gui_port }}
       envFrom:
       - configMapRef:
           name: config
     - image: "{{ assisted_service_image_service_image }}"
       name: image-service
       ports:
-      - hostPort: 8888
+      - hostPort: {{ assisted_service_image_service_port }}
       envFrom:
       - configMapRef:
           name: config


### PR DESCRIPTION
Test-Hints: assisted

In this [issue](https://issues.redhat.com/browse/CILAB-1338), while testing Assisted on-prem in our labs, it was failing because the port used by `assisted_service_gui` was colliding with another service we run.

This change allows to provide the ports for `assisted_service_gui` and `assisted_service_image_service` externally with new variables.