### PR TITLE
Enable Preflight debugging for multi-operators certification

### DIFF
--- a/roles/preflight/tasks/test_async_logs_check_operator.yml
+++ b/roles/preflight/tasks/test_async_logs_check_operator.yml
@@ -1,5 +1,6 @@
 ---
-- name: Retrieve operator logs (global Preflight timeout = 180 seconds)
+# global Preflight timeout = 180 seconds
+- name: "Retrieve logs for operator {{ operator.name }}"
   vars:
     attempts:
       - one

--- a/roles/preflight/tasks/test_check_if_container_certified.yml
+++ b/roles/preflight/tasks/test_check_if_container_certified.yml
@@ -20,7 +20,7 @@
     image_repository: "{{ current_operator_image.split('/')[0] }}"
     image_id: "{{ sha.stdout }}"
 
-- name: Check with the API if operator is already certified
+- name: "Use Pyxis API to check if the image is certified {{ current_operator_image }}"
   ansible.builtin.uri:
     url: "{{ pyxis_url }}/images?\
           include=data.image_id&\
@@ -48,8 +48,13 @@
     - 'sha.stdout | length > 0'
 
 - name: Handle when previous certification exists
-  when: (pyxis_image_info.json.data[0] is defined and pyxis_image_info.json.data[0].certified|bool and preflight_test_certified_image|bool)
-        or "registry.redhat" in image_repository
+  when: >
+    (
+      pyxis_image_info.json.data[0] is defined
+      and pyxis_image_info.json.data[0].certified | bool
+      and preflight_test_certified_image | bool
+    )
+    or "registry.redhat" in image_repository
   block:
     - name: "Set the variable if the image is already certified"
       ansible.builtin.set_fact:

--- a/roles/preflight/tasks/test_preflight_check_container_one_image.yml
+++ b/roles/preflight/tasks/test_preflight_check_container_one_image.yml
@@ -3,10 +3,10 @@
   ansible.builtin.include_tasks: test_check_if_container_certified.yml
   when: not preflight_test_certified_image
 
-- name: Non-certified image or force test run
+- name: "Non-certified image or force test run for {{ current_operator_image }}"
   when: not (already_certified | default(false) | bool)
   block:
-    - name: Validate parameters for check container run
+    - name: "Validate parameters for check container run on {{ current_operator_image }}"
       ansible.builtin.assert:
         that:
           - operator.name is defined
@@ -20,7 +20,7 @@
           operator.name = {{ operator.name }}
           operator.version = {{ operator.version }}
 
-    - name: Fail if both create_container_project and pyxis_container_identifier are provided
+    - name: "Fail if submission setup is not consistent for {{ current_operator_image }}"
       ansible.builtin.fail:
         msg: |
           If you want to reuse the existing cert project, provide its ID pyxis_container_identifier.
@@ -52,7 +52,7 @@
 
     - name: Run preflight check
       block:
-        - name: Run preflight check container on operator image with podman
+        - name: "Run preflight check container on {{ current_operator_image }}"
           ansible.builtin.command: >
             podman run
             --rm
@@ -92,7 +92,7 @@
           ansible.builtin.include_tasks: test_run_health_check.yml
           when: preflight_run_health_check | bool
 
-        - name: Copy execution artifacts from image to DCI logs directory
+        - name: "Copy execution artifacts for {{ current_operator_image }}"
           vars:
             image_name: "{{ current_operator_image | regex_search('.*/([^@:]+).*$', '\\1') | join('') }}"
             preflight_prefix: "preflight_container_{{ operator.name }}_{{ image_name }}"

--- a/roles/preflight/tasks/tests_preflight_check_operator.yml
+++ b/roles/preflight/tasks/tests_preflight_check_operator.yml
@@ -1,5 +1,5 @@
 ---
-- name: Fail if both create_operator_project and pyxis_operator_identifier are provided
+- name: "Fail if submission setup is inconsistent for {{ operator.name }}"
   ansible.builtin.fail:
     msg: |
       If you want to reuse the existing cert project, provide its ID pyxis_operator_identifier.
@@ -51,7 +51,7 @@
   when:
     - '"github-867" in dci_workarounds|default([])'
 
-- name: Run preflight check operator tests
+- name: "Run preflight check operator on {{ operator.name }}"
   environment:
     OPENSHIFT_AUTH: "{{ partner_creds }}"
     OO_BUNDLE: "{{ operator.bundle_image }}"
@@ -88,7 +88,7 @@
   poll: 0
   register: preflight_exec
 
-- name: Retrieve async logs
+- name: "Retrieve async logs for {{ operator.name }}"
   ansible.builtin.include_tasks: test_async_logs_check_operator.yml
   ignore_errors: true
 


### PR DESCRIPTION
Re-enable debugging for massive certification with dozens of operators and multiple images per operator.