### PR TITLE
Ignore error during image removal

### DIFF
--- a/roles/preflight/tasks/test_run_health_check.yml
+++ b/roles/preflight/tasks/test_run_health_check.yml
@@ -59,6 +59,7 @@
     cmd: >
       podman rmi
       --force
+      --ignore
       {{ current_operator_image }}
   become: true
 


### PR DESCRIPTION
- Should be safe to ignore errors. Sometimes this may fail if a contaner referencing the image is already removed.