### PR TITLE
Open ports referenced in new vars for assisted installer setup

### DIFF
--- a/roles/setup_assisted_installer/tasks/main.yml
+++ b/roles/setup_assisted_installer/tasks/main.yml
@@ -44,7 +44,7 @@
         immediate: yes
         state: enabled
         zone: "{{ item.0 }}"
-      loop: "{{ ['internal', 'public'] | product(['8000', '8090', '8080', '8888']) | list }}"
+      loop: "{{ ['internal', 'public'] | product(['8000', port, assisted_service_gui_port, assisted_service_image_service_port]) | list }}"
 
     - name: Create directories for assisted-installer
       file:


### PR DESCRIPTION
Test-Hints: assisted

This continues https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/151