### PR TITLE
Update num_repetitions and nodes to check for check_resource - wait-mcp

### DIFF
--- a/roles/check_resource/defaults/main.yml
+++ b/roles/check_resource/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-num_repetitions: 2
+num_repetitions: 1
 retry_count: 1
 resource_to_check: "MachineConfigPool"
 ...

--- a/roles/check_resource/tasks/wait-mcp.yml
+++ b/roles/check_resource/tasks/wait-mcp.yml
@@ -25,10 +25,10 @@
     # If nodes are NotReady, we cannot do much more than failing at this point.
     # There may be cases where it takes some time to move from NotReady to
     # Ready, so retrying this task during 10 minutes maximum.
-    - name: Check for workers with NotReady,SchedulingDisabled status
+    - name: Check for nodes with NotReady,SchedulingDisabled status
       ansible.builtin.shell: >
         {{ oc_tool_path }} get nodes --no-headers=true |
-        grep 'NotReady,SchedulingDisabled' | grep worker | awk '{ print $1 }'
+        grep 'NotReady,SchedulingDisabled' | awk '{ print $1 }'
       register: not_ready_disabled_nodes
       until: not_ready_disabled_nodes.stdout | length == 0
       retries: 30
@@ -36,18 +36,18 @@
 
     # If there is any node in SchedulingDisabled status, make the job to fail
     # Run this check during 3 minutes maximum.
-    - name: Check for workers with Ready,SchedulingDisabled status
+    - name: Check for nodes with Ready,SchedulingDisabled status
       ansible.builtin.shell: >
         {{ oc_tool_path }} get nodes --no-headers=true |
-        grep 'Ready,SchedulingDisabled' | grep worker | awk '{ print $1 }'
+        grep 'Ready,SchedulingDisabled' | awk '{ print $1 }'
       register: reg_disabled_nodes
       until: reg_disabled_nodes.stdout | length == 0
       retries: 9
       delay: 20
 
     # If the previous checks passed because there were no nodes in NotReady or
-    # SchedulngDisabled status, then let's retry the check.  We will only allow
-    # one more attempt (num_repetitions = 2 by default)
+    # SchedulngDisabled status, then let's retry the check. We will only allow
+    # one more attempt (num_repetitions = 1 by default)
     - name: Fail if the maximum number of retries have been reached
       ansible.builtin.fail:
         msg: >
@@ -58,6 +58,7 @@
     # Keeping this call to uncordon_workers just in case this issue appears
     # again in the near future.
     # TODO. Remove it if this issue is no longer appearing.
+    # TODO. If required again, extend this to master nodes.
     # - name: Check for workers with Ready,SchedulingDisabled status
     #   include_tasks: uncordon_workers.yml
 


### PR DESCRIPTION
In theory, the wait-mcp is performed once if the check fails and there are not worker nodes in Ready,SchedulingDisabled status, but in this [job](https://www.distributed-ci.io/jobs/24cbd731-824f-4d36-b886-89c77591c90f/jobStates?sort=date&task=7986dc0c-7bf4-488b-af57-87bd50bf6b37), it happened two things:

- Affected nodes were masters

```
$ oc get nodes                                                               
NAME       STATUS                     ROLES                  AGE     VERSION                                        
master-0   Ready                      control-plane,master   6h25m   v1.27.10+28ed2d7                               
master-1   Ready,SchedulingDisabled   control-plane,master   6h24m   v1.27.10+28ed2d7                               
master-2   Ready                      control-plane,master   6h24m   v1.27.10+28ed2d7                               
worker-0   Ready                      worker                 5h27m   v1.27.10+28ed2d7                               
worker-1   Ready                      worker                 5h28m   v1.27.10+28ed2d7                               
worker-2   Ready                      worker                 5h27m   v1.27.10+28ed2d7                               
worker-3   Ready                      worker                 5h27m   v1.27.10+28ed2d7
```

- The check was repeated twice, and should be only once

This change updates the check_resource role to also check master nodes and set the correct value for num_repetitions variable