### PR TITLE
Delete the collector

### DIFF
--- a/roles/setup_netobserv_stack/tasks/cleanup.yml
+++ b/roles/setup_netobserv_stack/tasks/cleanup.yml
@@ -1,23 +1,11 @@
 ---
-- name: Get PVCs in the namespace
-  community.kubernetes.k8s_info:
-    api_version: v1
-    kind: PersistentVolumeClaim
-    namespace: "netobserv"
-  register: pvc_info
-
-- name: Delete PVCs
+- name: Delete the Flow collector
   community.kubernetes.k8s:
-    definition:
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: "{{ item.metadata.name }}"
-        namespace: "{{ item.metadata.namespace }}"
-      spec: {}
+    api_version: flows.netobserv.io/v1beta1
+    kind: FlowCollector
+    name: "cluster"
     state: absent
-  loop: "{{ pvc_info.resources }}"
-  when: pvc_info.resources | length > 0
+    wait: true
 
 - name: Delete the namespace netobserv
   community.kubernetes.k8s:
@@ -25,4 +13,5 @@
     api: "v1"
     kind: "Namespace"
     name: "netobserv"
+    wait: true
 ...

--- a/roles/setup_netobserv_stack/tasks/setup.yml
+++ b/roles/setup_netobserv_stack/tasks/setup.yml
@@ -1,4 +1,7 @@
 ---
+- name: Resources cleanup
+  include_tasks: cleanup.yml
+
 - name: Create the Namespace
   community.kubernetes.k8s:
     definition:

--- a/roles/setup_netobserv_stack/tasks/verify.yml
+++ b/roles/setup_netobserv_stack/tasks/verify.yml
@@ -36,7 +36,7 @@
     wait: true
     wait_condition:
       type: Ready
-      status: true
+      status: "True"
     wait_sleep: 2
     wait_timeout: 300
 ...

--- a/roles/setup_netobserv_stack/templates/flow-collector.yml.j2
+++ b/roles/setup_netobserv_stack/templates/flow-collector.yml.j2
@@ -3,7 +3,6 @@ kind: FlowCollector
 metadata:
   name: "cluster"
 spec:
-  namespace: "netobserv"
   deploymentModel: DIRECT
   agent:
     ebpf:


### PR DESCRIPTION
- Delete the instance if already exists, as it will fail if an instance from a previous deployment already exists.
- Delete the instance during the teardown