### PR TITLE
Set a temporary workaround to opm issues

### DIFF
--- a/roles/fbc_catalog/tasks/main.yml
+++ b/roles/fbc_catalog/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: "Download stable opm client"
   vars:
-    ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/opm-linux.tar.gz"
+    ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.14/opm-linux.tar.gz"
   ansible.builtin.unarchive:
     src: "{{ ocp_clients_url }}"
     dest: "{{ fbc_tmp_dir }}"

--- a/roles/mirror_from_directory/tasks/load-operators.yml
+++ b/roles/mirror_from_directory/tasks/load-operators.yml
@@ -14,7 +14,7 @@
 
 - name: "Download stable oc-mirror plugin"
   vars:
-    ocp_mirror_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/oc-mirror.tar.gz"
+    ocp_mirror_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.14/oc-mirror.tar.gz"
   ansible.builtin.unarchive:
     src: "{{ ocp_mirror_url }}"
     dest: "{{ image_dir }}"

--- a/roles/prune_catalog/tasks/main.yml
+++ b/roles/prune_catalog/tasks/main.yml
@@ -49,7 +49,7 @@
 
     - name: "Download stable opm client"
       vars:
-        ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/opm-linux.tar.gz"
+        ocp_clients_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.14/opm-linux.tar.gz"
       ansible.builtin.unarchive:
         src: "{{ ocp_clients_url }}"
         dest: "{{ pc_tmp_dir }}"


### PR DESCRIPTION
Stable version of opm requires glibc libraries that are not available in el8. Pinning temporarily stable 4.14 to avoid this situation.