### PR TITLE
DNM - Reducing scope for pods status check

### DIFF
--- a/roles/hco_setup/tasks/deploy-hco.yml
+++ b/roles/hco_setup/tasks/deploy-hco.yml
@@ -32,20 +32,10 @@
 - name: test_ Check for hyperconverged operator  # noqa: name[casing]
   community.kubernetes.k8s_info:
     api_version: v1
-    namespace: "{{ hs_ns }}"
     kind: Pod
-    label_selectors:
-      - name=hyperconverged-cluster-operator
-  register: hco_pods
-  retries: "{{ hs_retries }}"
-  delay: 60
-  no_log: false
-  until:
-    - hco_pods.resources is defined
-    - "hco_pods.resources|length == 1"
-    - "'status' in hco_pods.resources[0]"
-    - "'containerStatuses' in hco_pods.resources[0].status"
-    - "hco_pods.resources[0].status.containerStatuses|length == 1"
-    - "'ready' in hco_pods.resources[0].status.containerStatuses[0]"
-    - "hco_pods.resources[0].status.containerStatuses[0].ready|bool"
+    namespace: "{{ hs_ns }}"
+  register: pod_list
+  until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
+  retries: 9
+  delay: 10
 ...


### PR DESCRIPTION
Checking if reducing the scope for resource discovery is a workaround for https://github.com/ansible/awx-operator/issues/1671 as using label_selectors looks at all namespaces. 

