### PR TITLE
[DNM] Test Image Source creation and deletion in preflight without launching tests

### DIFF
--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -79,19 +79,6 @@
       ansible.builtin.include_tasks: mirroring.yml
       when: dci_disconnected | default(false) | bool
 
-    # The main tests: containers
-    - name: Check container - Preflight check operator images with check container one by one
-      ansible.builtin.include_tasks: test_preflight_check_container.yml
-      loop: "{{ preflight_operators_to_check }}"
-      loop_control:
-        loop_var: operator
-
-    # The main tests: operators
-    - name: Check operator - Preflight check operators one by one
-      ansible.builtin.include_tasks: tests_preflight_check_operator.yml
-      loop: "{{ preflight_operators_to_check }}"
-      loop_control:
-        loop_var: operator
   always:
     - name: Teardown
       ansible.builtin.include_tasks: teardown.yml


### PR DESCRIPTION
This is just to validate https://github.com/dci-labs/example-cnf-config/pull/98 and confirm that CILAB-1230 is gone, I'll close it when finishing