### PR TITLE
Adding dependencies to galaxy spec

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -95,7 +95,14 @@ license_file: ''
 # value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification).
 # Multiple version range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+  ansible.posix: "*"
+  ansible.utils: "*"
+  community.crypto: "*"
+  community.general: "*"
+  community.kubernetes: "*"
+  community.libvirt: "*"
+  containers.podman: "*"
 
 # The URL of the originating SCM repository
 repository: https://github.com/redhatci/ansible-collection-redhatci-ocp


### PR DESCRIPTION
We have requirements.yml, but this doesn't automatically pull the required dependencies when installing via `ansible-galaxy install`. This should take care of that