### PR TITLE
Revert "Adding dependencies to galaxy spec" to fix DCI app-agent jobs

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -95,14 +95,7 @@ license_file: ''
 # value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification).
 # Multiple version range specifiers can be set and are separated by ','
-dependencies:
-  ansible.posix: "*"
-  ansible.utils: "*"
-  community.crypto: "*"
-  community.general: "*"
-  community.kubernetes: "*"
-  community.libvirt: "*"
-  containers.podman: "*"
+dependencies: {}
 
 # The URL of the originating SCM repository
 repository: https://github.com/redhatci/ansible-collection-redhatci-ocp


### PR DESCRIPTION
This reverts commit d715b54e97615e4060f7eaf22398bb3d2fc1a860.

This PR is to fix DCI jobs currently failing with [couldn't resolve module/action 'community.kubernetes.k8s_info'](https://www.distributed-ci.io/jobs/1235ef7a-8b4c-44eb-945f-98cb42540b79/jobStates?sort=date&task=606a04e5-ff61-4e1f-b7e3-9e85162e711b)