### PR TITLE
Ansible collection community.crypto isn't packaged yet

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -98,7 +98,6 @@ license_file: ''
 dependencies:
   "ansible.posix": "*"
   "ansible.utils": "*"
-  "community.crypto": "*"
   "community.general": "*"
   "community.kubernetes": "1.2.1"
   "community.libvirt": "*"


### PR DESCRIPTION
Removing from the dependency list until there's an RPM to provide it