### PR TITLE
cnf_cert | Move some tasks from tests to teardown stage

### DIFF
--- a/roles/cnf_cert/tasks/logging.yml
+++ b/roles/cnf_cert/tasks/logging.yml
@@ -4,19 +4,14 @@
   ansible.builtin.set_fact:
     tnf_logs_location: "{{ tnf_dir }}/{{ test_network_function_project_name }}"
 
-# There are three types of files to be submitted:
-# - Configuration files - tnf_config.yml
-# - Execution logs - dci-tnf-execution.log and cnf-certsuite.log, if exists
-# - Results of the execution (only generated if tnf execution was correct) -
+# Copy the results of the execution (only generated if tnf execution was correct) -
 #   JUnit XML report and claim.json file
-- name: Copy files related to CNF Cert Suite
+- name: Copy files related to CNF Cert Suite result execution
   ansible.builtin.copy:
     src: "{{ item }}"
     dest: "{{ job_logs.path }}"
     mode: "0750"
   with_fileglob:
-    - "{{ tnf_logs_location }}/tnf_config.yml"
-    - "{{ tnf_logs_location }}/*.log"
     - "{{ tnf_logs_location }}/*.xml"
     - "{{ tnf_logs_location }}/*.json"
 
@@ -59,7 +54,7 @@
         dest: "{{ job_logs.path }}/{{ html_report_filename }}"
 
 # claim.json file must be present if the execution finished correctly
-# This is needed for the next blocks.
+# This is needed for the next task.
 - name: Check the presence of claim.json
   ansible.builtin.stat:
     path: "{{ tnf_logs_location }}/claim.json"

--- a/roles/cnf_cert/tasks/teardown.yml
+++ b/roles/cnf_cert/tasks/teardown.yml
@@ -16,6 +16,7 @@
   containers.podman.podman_image:
     name: "{{ tnf_image }}"
     state: absent
+  ignore_errors: true
 
 # Deleting resources created by the CNF Cert Suite to support the execution
 - name: Clean CNF Cert Suite resources

--- a/roles/cnf_cert/tasks/teardown.yml
+++ b/roles/cnf_cert/tasks/teardown.yml
@@ -1,4 +1,22 @@
 ---
+# Always submit these files to DCI:
+# - Configuration files - tnf_config.yml
+# - Execution logs - dci-tnf-execution.log and cnf-certsuite.log, if exists
+- name: Copy config and log files related to CNF Cert Suite execution
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ job_logs.path }}"
+    mode: "0750"
+  with_fileglob:
+    - "{{ tnf_dir }}/{{ test_network_function_project_name }}/tnf_config.yml"
+    - "{{ tnf_dir }}/{{ test_network_function_project_name }}/*.log"
+
+# Clean images just after finishing the execution
+- name: Remove local tnf image
+  containers.podman.podman_image:
+    name: "{{ tnf_image }}"
+    state: absent
+
 # Deleting resources created by the CNF Cert Suite to support the execution
 - name: Clean CNF Cert Suite resources
   when: tnf_postrun_delete_resources|bool

--- a/roles/cnf_cert/tasks/tests.yml
+++ b/roles/cnf_cert/tasks/tests.yml
@@ -42,12 +42,6 @@
     chdir: "{{ tnf_dir }}"
   ignore_errors: "{{ tnf_exec_ignore_errors | bool }}"
 
-# Clean images just after finishing the execution
-- name: Remove local tnf image
-  containers.podman.podman_image:
-    name: "{{ tnf_image }}"
-    state: absent
-
 - name: Logging tasks after finishing the execution of CNF Cert
   ansible.builtin.include_tasks: logging.yml
 ...


### PR DESCRIPTION
Now that a tnf job can fail in the tnf execution, we're missing the logs in the DCI job, so moving these tasks and some others that are required for cleaning the environment to the teardown playbook, which is always executed