### PR TITLE
pin community.general collection to version in dci repo

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -98,7 +98,7 @@ license_file: ''
 dependencies:
   "ansible.posix": "*"
   "ansible.utils": "*"
-  "community.general": "*"
+  "community.general": "7.0.1"
   "community.kubernetes": "1.2.1"
   "community.libvirt": "*"
   "containers.podman": "*"


### PR DESCRIPTION
Some roles using community.general.python_requirements_info module are not playing well with the latest version (8.4.0) provided via galaxy. This CR is pinning the collection to match the version used in the rpm provided in DCI dnf repo.

Test-Hints: sno