### PR TITLE
Make post_install role to default to use_agent_based_installer == True

### DIFF
--- a/roles/post_install/defaults/main.yml
+++ b/roles/post_install/defaults/main.yml
@@ -11,3 +11,4 @@ domain: "{{ cluster_name }}.{{ base_dns_domain }}"
 generated_dir: "{{ repo_root_path }}/generated"
 manifests_dir: "{{ generated_dir }}/{{ cluster_name }}"
 auth_dir: "{{ manifests_dir }}/auth"
+use_agent_based_installer: true

--- a/roles/post_install/tasks/fetch_kubeconfg_agent_based_installer.yml
+++ b/roles/post_install/tasks/fetch_kubeconfg_agent_based_installer.yml
@@ -2,4 +2,4 @@
   ansible.builtin.copy:
     src: "{{ auth_dir }}/kubeconfig"
     dest: "{{ kubeconfig_path }}"
-    mode: 0664
+    mode: "0664"

--- a/roles/post_install/tasks/fetch_kubeconfg_assisted_installer.yml
+++ b/roles/post_install/tasks/fetch_kubeconfg_assisted_installer.yml
@@ -2,4 +2,4 @@
   ansible.builtin.get_url:
     url: "{{ URL_ASSISTED_INSTALLER_CLUSTER }}/downloads/credentials?file_name=kubeconfig"
     dest: "{{ kubeconfig_path }}"
-    mode: 0664
+    mode: "0664"

--- a/roles/post_install/tasks/main.yml
+++ b/roles/post_install/tasks/main.yml
@@ -2,12 +2,12 @@
 - name: Fetch kubeconfig for assisted installer
   ansible.builtin.include_tasks:
     file: fetch_kubeconfg_assisted_installer.yml
-  when: not ((use_agent_based_installer | default(false)) | bool)
+  when: not (use_agent_based_installer | bool)
 
 - name: Fetch kubeconfig for agent based installer
   ansible.builtin.include_tasks:
     file: fetch_kubeconfg_agent_based_installer.yml
-  when: (use_agent_based_installer | default(false)) | bool
+  when: use_agent_based_installer | bool
 
 - name: Perform basic checks and login
   environment:
@@ -41,18 +41,18 @@
 - name: Fetch credentials for assisted installer
   ansible.builtin.include_tasks:
     file: credentails_assisted_installer.yml
-  when: not ((use_agent_based_installer | default(false)) | bool)
+  when: not (use_agent_based_installer | bool)
 
 - name: Fetch credentials for agent based installer
   ansible.builtin.include_tasks:
     file: credentails_agent_based_installer.yml
-  when: (use_agent_based_installer | default(false)) | bool
+  when: use_agent_based_installer | bool
 
 - name: Save credentials to file
   ansible.builtin.copy:
     content: "{{ credentials | to_nice_json }}"
     dest: "{{ dest_dir }}/{{ kubeadmin_vault_name }}"
-    mode: 0600
+    mode: "0600"
 
 - name: Save credentials to vault
   ansible.builtin.shell:


### PR DESCRIPTION
It appears that DCI has use_agent_based_installer set to true in the agent so we should just default to that. 

Also fixed some issues with ansible-lint

Test-Hints: assisted-abi