### PR TITLE
Retry Opcap release download to mitigate GH timeouts

### DIFF
--- a/roles/opcap_tool/tasks/build.yml
+++ b/roles/opcap_tool/tasks/build.yml
@@ -12,6 +12,10 @@
     url: "{{ opcap_download_url }}/v{{ opcap_version }}/opcap-{{ opcap_archi }}"
     dest: "{{ opcap_dir.path }}/opcap/bin/opcap"
     mode: "0755"
+  register: opcap_download
+  until: opcap_download is succeeded
+  retries: 2
+  delay: 30
 
 - name: Check opcap bin
   ansible.builtin.command:


### PR DESCRIPTION
TestDallas: ocp-4.13-vanilla tnf-test-cnf tnf-test-cnf:ansible_extravars=test_network_function_version:HEAD