### PR TITLE
Fake stable Preflight to test Pyxis submission daily

### DIFF
--- a/roles/preflight/tasks/prepare_preflight_image.yml
+++ b/roles/preflight/tasks/prepare_preflight_image.yml
@@ -25,13 +25,21 @@
     preflight_image: "{{ preflight_image + '-' + job_id }}"
   when: job_id is defined
 
+- name: Get latest tag from Preflight repository
+  uri:
+    url: "https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/tags"
+    method: GET
+  register: preflight_github_tags
+
+# We have to tag using the last stable version
+# to make Pyxis submission work
 - name: Build Preflight image
   ansible.builtin.shell:
     cmd: >
       podman build .
       --no-cache
       -t {{ preflight_image }}
-      --build-arg=release_tag={{ preflight_branch }} &&
+      --build-arg=release_tag={{ preflight_github_tags.json[0].name }} &&
       podman push
       --authfile {{ partner_creds }}
       {{ preflight_image }}

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -9,6 +9,15 @@
     preflight_artifact: "{{ lookup('file', preflight_log_file) | to_json }}"
     pyxis_apikey: "{{ lookup('file', pyxis_apikey_path) }}"
 
+- name: Get latest commit hash for the Preflight release
+  vars:
+    preflight_release: "{{ preflight_output.test_library.version }}"
+  ansible.builtin.uri:
+    url: >
+      https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/git/refs/tags/{{ preflight_release }}
+    method: GET
+  register: preflight_latest
+
 - name: Get info of artifact file
   stat:
     path: "{{ job_logs.path }}/preflight_operator_{{ operator.name }}_preflight.log"

--- a/roles/pyxis/templates/test_results.json.j2
+++ b/roles/pyxis/templates/test_results.json.j2
@@ -13,7 +13,7 @@
   "operator_package_name": "{{ operator.name }}",
   "passed": {{ preflight_output.passed }},
   "results": {{ preflight_output.results }},
-  "test_library": {{ preflight_output.test_library }},
+  "test_library": {{ preflight_output.test_library | combine({'commit': preflight_latest.json.object.sha}) }},
   "tested_on": {
     "name": "OCP",
     "version": "{{ ocp_version_full }}"


### PR DESCRIPTION
Pyxis API started to require the Preflight version to be stable for submission:
```
{\"detail\": \"Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' 
version '1.9.1+54e0bc3624e7fed03798e33892cad22c5aab0169' is not supported. 
Supported versions are: ['1.9.1']\"}
```

To continue testing daily, we're going to use the base stable version, replacing the commit hash in the `preflight_output.test_library": {"commit": "54e0bc3624e7fed03798e33892cad22c5aab0169", "name": "github.com/redhat-openshift-ecosystem/openshift-preflight", "version": "1.9.1"} ` by the latest commit from the stable version.