### PR TITLE
Make webserver_caching_image consistent with setup_http_store

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -9,7 +9,7 @@ install_config_appends_file: install-config-appends.yml
 registry_auth_file: registry-auths.json
 disconnected_registry_user: dummy
 disconnected_registry_password: dummy
-webserver_cache_image: "quay.io/centos7/httpd-24-centos7:latest"
+webserver_cache_image: "quay.io/fedora/httpd-24:latest"
 webserver_caching_port: "{{ webserver_caching_port_container }}"
 webserver_caching_port_container: 8080
 registry_creation: false

--- a/roles/sno_installer/defaults/main.yml
+++ b/roles/sno_installer/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for sno_installer
 cache_enabled: true
 provision_cache_store: "{{ cache_dir }}"
-webserver_caching_image: "quay.io/centos7/httpd-24-centos7:latest"
+webserver_caching_image: "quay.io/fedora/httpd-24:latest"
 webserver_caching_port_container: 8080
 webserver_caching_port: "{{ webserver_caching_port_container }}"
 url_passed: false


### PR DESCRIPTION
Change was prompted by quay.io/centos7/httpd-24-centos7 removing the latest tag which was what was being used previously

See https://quay.io/repository/centos7/httpd-24-centos7?tab=history

Test-Hints: libvirt
Test-Args-Hints: -e cache_enabled=True