### PR TITLE
Consider the output change for dev Preflight version

### DIFF
--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Get latest commit hash for the Preflight release
   vars:
-    preflight_release: "{{ preflight_output.test_library.version }}"
+    preflight_release: "{{ preflight_output.test_library.version.split('+')[0] }}"
   ansible.builtin.uri:
     url: >
       https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/git/refs/tags/{{ preflight_release }}


### PR DESCRIPTION
The issue is because of the new version representation by the Preflight container: we now have  `1.9.1+d990640eb0a2193f018c8eec920444dbaa30d4de` instead of `1.9.1` for the dev version based on the latest release. 