### PR TITLE
Fix catalog check for container publication

### DIFF
--- a/roles/preflight/README.md
+++ b/roles/preflight/README.md
@@ -17,7 +17,7 @@ pyxis_apikey_path                | undefined                                    
 preflight_custom_ca              | undefined                                            | Optional. Path of custom ca.crt. Used to test operator stored in a self signed registry
 preflight_source_dir             | undefined                                            | Optional. If this variable is defined, the Preflight role would use this folder to generate preflight image and binary and then use them during Preflight tests execution. That would overwrite predefined preflight_image if any.
 preflight_test_certified_image  | false                                                | Optional. Run preflight tests on already certified images.
-pyxis_url                       | https://catalog.redhat.com/api/containers/v1         | Optional. This is a Pyxis API that used during the check if the image is certified.
+catalog_url                       | https://catalog.redhat.com/api/containers/v1         | Optional. This is a Pyxis API that used during the check if the image is certified.
 preflight_run_health_check      | true                                                 | Optional. Run health check on every container and generate oval reports both in xml and html formats.
 preflight_dci_all_components_are_ga | true                                             | Optional. Only submit test results when all components in the list `dci_ga_components_for_certification` are GA.
 

--- a/roles/preflight/defaults/main.yml
+++ b/roles/preflight/defaults/main.yml
@@ -5,7 +5,7 @@ preflight_namespace: preflight-testing
 preflight_sa: default
 preflight_custom_ca: ""
 preflight_podman_ca: ""
-pyxis_url: "https://catalog.redhat.com/api/containers/v1"
+catalog_url: "https://catalog.redhat.com/api/containers/v1"
 preflight_test_certified_image: false
 preflight_run_health_check: true
 ...

--- a/roles/preflight/tasks/test_check_if_container_certified.yml
+++ b/roles/preflight/tasks/test_check_if_container_certified.yml
@@ -1,9 +1,9 @@
 ---
-- name: Reset variable for certification
+- name: Reset certification status
   ansible.builtin.set_fact:
     already_certified: false
 
-- name: "Get Image Digest"
+- name: Get image digest
   ansible.builtin.shell: >
     set -eo pipefail;
     skopeo inspect
@@ -14,57 +14,28 @@
     {% endif %}
     docker://{{ current_operator_image }} | jq -r '.Digest'
   register: sha
-  retries: 5
-  delay: 10
-  until: sha is not failed
+  retries: 2
+  delay: 30
+  until: sha is succeeded
 
-- name: "Get Image Registry"
-  ansible.builtin.set_fact:
-    image_repository: "{{ current_operator_image.split('/')[0] }}"
-    image_id: "{{ sha.stdout }}"
+- name: Debug image digest
+  ansible.builtin.debug:
+    msg: "{{ sha.stdout }}"
 
 - name: "Use Pyxis API to check if the image is certified {{ current_operator_image }}"
+  vars:
+    filter_params: "filter=image_id%3D%3D{{ sha.stdout }}%3Brepositories.published%3D%3Dtrue"
+    include_params: "include=data.repositories.published&include=data.repositories.repository"
   ansible.builtin.uri:
-    url: "{{ pyxis_url }}/images?\
-          include=data.image_id&\
-          include=data.docker_image_id&\
-          include=data.certified&\
-          filter=docker_image_id%3D%3D%22{{ image_id }}%22&\
-          page_size=1&
-          page=0"
+    url: >
+      {{ catalog_url }}/images?{{ filter_params }}&{{ include_params }}&page_size=1&page=0
     method: GET
     headers:
-      X-API-KEY: "{{ pyxis_apikey }}"
-      accept: application/json
+      X-API-KEY: "{{ lookup('file', pyxis_apikey_path) }}"
     status_code: 200
     timeout: 120
-  register: pyxis_image_info
-  retries: 5
-  delay: 10
-  until: pyxis_image_info.status >= 200
-  no_log: false
-  ignore_errors: true
-  vars:
-    pyxis_apikey: "{{ lookup('file', pyxis_apikey_path) }}"
-  when:
-    - '"registry.redhat" not in image_repository'
-    - 'sha.stdout | length > 0'
+  register: pyxis_cert_status
 
-- name: Handle when previous certification exists
-  when: >
-    (
-      pyxis_image_info.json.data[0] is defined
-      and pyxis_image_info.json.data[0].certified | bool
-      and preflight_test_certified_image | bool
-    )
-    or "registry.redhat" in image_repository
-  block:
-    - name: "Set the variable if the image is already certified"
-      ansible.builtin.set_fact:
-        already_certified: true
-
-    - name: "Certification Skip for {{ current_operator_image }}"
-      ansible.builtin.debug:
-        msg: >
-          Certification for the image {{ current_operator_image }} has been
-          skipped because it has already been certified
+- name: "Skip the certification if already-in-catalog {{ current_operator_image }}"
+  ansible.builtin.set_fact:
+    already_certified: "{{ pyxis_cert_status.json.data | length > 0 }}"

--- a/roles/preflight/tasks/test_preflight_check_container_one_image.yml
+++ b/roles/preflight/tasks/test_preflight_check_container_one_image.yml
@@ -2,6 +2,7 @@
 - name: Check if container has already been certified
   ansible.builtin.include_tasks: test_check_if_container_certified.yml
   when: not preflight_test_certified_image
+  ignore_errors: true
 
 - name: "Non-certified image or force test run for {{ current_operator_image }}"
   when: not (already_certified | default(false) | bool)

--- a/roles/pyxis/defaults/main.yml
+++ b/roles/pyxis/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-pyxis_url: "https://catalog.redhat.com/api/containers/v1"
+catalog_url: "https://catalog.redhat.com/api/containers/v1"
 ...

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -33,7 +33,7 @@
 
 - name: Publishing artifact to Pyxis
   uri:
-    url: "{{ pyxis_url }}/projects/certification/id/{{ cert_project_id }}/artifacts"
+    url: "{{ catalog_url }}/projects/certification/id/{{ cert_project_id }}/artifacts"
     method: POST
     headers:
       X-API-KEY: "{{ pyxis_apikey }}"
@@ -44,7 +44,7 @@
 
 - name: Submit Test result to Pyxis
   uri:
-    url: "{{ pyxis_url }}/projects/certification/id/{{ cert_project_id }}/test-results"
+    url: "{{ catalog_url }}/projects/certification/id/{{ cert_project_id }}/test-results"
     method: POST
     headers:
       X-API-KEY: "{{ pyxis_apikey }}"


### PR DESCRIPTION
DallasCheckWorkload: preflight-green
Test-Hints: no-check

This PR is to change the Pyxis endpoint to have a working check. This change became needed because of the changes in the Pyxis BE logic. Details: CILAB-1445