### PR TITLE
Remove need for openshift_full_version in setup_mirror_registry role

### DIFF
--- a/roles/setup_mirror_registry/defaults/main.yml
+++ b/roles/setup_mirror_registry/defaults/main.yml
@@ -15,8 +15,6 @@ required_packages:
   - httpd
   - httpd-tools
 
-openshift_version: "{{ openshift_full_version.split('.')[:2] | join('.') }}"
-
 # Name of the pod running as the registry.
 image_name_registry: ocpdiscon-registry
 

--- a/roles/setup_mirror_registry/tasks/var_check.yml
+++ b/roles/setup_mirror_registry/tasks/var_check.yml
@@ -13,18 +13,3 @@
   fail:
     msg: disconnected_registry_password must be set and not empty
   when: (disconnected_registry_password is not defined) or (disconnected_registry_password == "")
-
-- name: Check openshift_full_version is set
-  fail:
-    msg: openshift_full_version must be set and not empty
-  when: (openshift_full_version is not defined) or (openshift_full_version == "")
-
-- name: Check openshift_full_version is has at last two parts
-  block:
-    - name: Split openshift_full_version
-      set_fact:
-        openshift_version_parts: "{{ openshift_full_version.split('.') }}"
-    - name: "Fail: Incorrect openshift_full_version found"
-      fail:
-        msg: openshift_full_version does not have at least two parts
-      when: openshift_version_parts | length < 2


### PR DESCRIPTION
Test-Hints: assisted

openshift_full_version is not used in setup_mirror_registry role. Remove the check and the default value.