### PR TITLE
Use mor_oc variable instead of oc_tool_path in mirror_ocp_release

### DIFF
--- a/roles/mirror_ocp_release/tasks/download.yml
+++ b/roles/mirror_ocp_release/tasks/download.yml
@@ -11,7 +11,7 @@
 - name: "Extract artifacts from release image"
   ansible.builtin.command:
     cmd: >
-      {{ oc_tool_path }} adm release extract
+      {{ mor_oc }} adm release extract
       --registry-config {{ mor_auths_file }}
       --tools
       --from {{ mor_pull_url }}

--- a/roles/mirror_ocp_release/tasks/installer.yml
+++ b/roles/mirror_ocp_release/tasks/installer.yml
@@ -9,7 +9,7 @@
 
 - name: "Extract installer command from release image"
   ansible.builtin.command: >
-    {{ oc_tool_path }} adm release extract
+    {{ mor_oc }} adm release extract
     --registry-config={{ mor_auths_file }}
     --command=openshift-baremetal-install
     --from {{ mor_pull_url }}


### PR DESCRIPTION
`mor_oc` variable describe in the readme is not used. We are using `oc_tool_path` instead.