### PR TITLE
Skip chart from PR

### DIFF
--- a/roles/chart_verifier/tasks/tests.yml
+++ b/roles/chart_verifier/tasks/tests.yml
@@ -194,6 +194,7 @@
     product_version: "{{ chart_version }}"
     fork_name: "charts-{{ chart_name }}-{{ chart_version }}-{{ ansible_date_time.iso8601_basic_short }}"
     work_dir: "{{ work_chart_dir }}"
+    publish_chart: "{{ chart.flags | regex_search('-W') | default('', True) | length == 0 }}"
   when:
     - chart.create_pr | default(false) | bool
     - cv_fail_count.stdout | int == 0

--- a/roles/create_pr/README.md
+++ b/roles/create_pr/README.md
@@ -12,6 +12,7 @@ partner_name                        | undefined | true/false                  | 
 partner_email                       | undefined | true/false                  | Define this parameter only when opening PR for chart_verifier. Email address to be used in the pull request.
 target_repository                   | undefined | true                        | GitHub repository where the pull request will be created.
 product_type                        | undefined | true                        | Product type. Either "helmchart" or "operator".
+publish_chart                       | true      | false                       | For helm charts, disable adding the Chart as part of the pull request.
 
 Those are the common variables used by both certification project.
 It includes tasks to generate an SSH key needed to push to GitHub repository and add it to the GitHub account.

--- a/roles/create_pr/defaults/main.yml
+++ b/roles/create_pr/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+publish_chart: true
+...

--- a/roles/create_pr/tasks/helm_chart_verifier.yml
+++ b/roles/create_pr/tasks/helm_chart_verifier.yml
@@ -40,6 +40,8 @@
     url: "{{ chart.chart_file }}"
     dest: "{{ chart_path }}"
     mode: "u=rwx,g=rx,o=rx"
+  when:
+    - publish_chart | bool
 
 - name: "Git add chart_file and report.yaml to the repository"
   vars:
@@ -48,9 +50,8 @@
     cmd: |
       git config user.email {{ partner_email }}
       git config user.name {{ github_username }}
-      git add {{ work_dir }}/{{ fork_name }}/charts/partners/{{ partner }}/OWNERS
-      git add {{ work_dir }}/{{ fork_name }}/charts/partners/{{ partner }}/{{ chart_name }}/{{ chart_version }}/
-      git commit -m 'Added {{ chart_name }}_{{ chart_version }}'
+      git add {{ work_dir }}/{{ fork_name }}/charts/partners/{{ partner }}/
+      git commit -m 'Added files for {{ chart_name }}_{{ chart_version }}'
   args:
     chdir: "{{ work_dir }}/{{ fork_name }}/charts"
 


### PR DESCRIPTION
Test-App-Args-Hints: -e do_chart_verifier=true -e github_token_path=/opt/cache/token.txt -e partner_name=fredco -e sandbox_repository=dcicertbot/charts -e partner_email=telcoci -e {"dci_charts":[{"name":"samplechart","chart_file":"/opt/cache/charts/samplechart/samplechart-0.1.1.tgz","flags":"-W","values_file":["/opt/cache/charts/samplechart/values.yaml","/opt/cache/charts/samplechart/values2.yaml"],"deploy_chart":true,"create_pr":false},{"name":"remotechart","chart_file":"http://jumpbox.partnerci.bos2.lab/charts/samplechart-0.1.2.tgz","values_file":["http://jumpbox.partnerci.bos2.lab/charts/values1.yaml","http://jumpbox.partnerci.bos2.lab/charts/values2.yaml"],"deploy_chart":true,"create_pr":false},{"name":"remotechart","chart_file":"http://jumpbox.partnerci.bos2.lab/charts/samplechart-0.1.2.tgz","deploy_chart":true,"create_pr":true,"flags":"-W"}]}



The -W option sets the "catalog distribution method" for the chart and it only requires the report to be submitted. It will fail if the chart is added to the pull request.

Skipping adding the actual chart to the PR if -W is passed in the flags.