### PR TITLE
Remove DCI agent variable from check resource role

### DIFF
--- a/roles/check_resource/README.md
+++ b/roles/check_resource/README.md
@@ -14,6 +14,7 @@ Name                        | Required  | Default                | Description
 resource\_to\_check         | Yes       | MachineConfigPool      | Name of the resource to check. Possible values: "MachineConfigPool", or "SriovNetworkNodeState".
 check\_wait\_retries        | Yes       | Undefined              | Number of times in which the wait task is performed.
 check\_wait\_delay          | Yes       | Undefined              | Time spent between wait tasks' iterations.
+cr_oc                       | Yes       | Undefined              | Path to oc binary
 check\_reason               | No        | Undefined              | Reason for the check to be done.
 
 ## Requirements
@@ -32,6 +33,7 @@ Confirm that Machine Config Pools are not updating
     check_wait_retries: 120
     check_wait_delay: 10
     check_reason: "Apply ICSPs for mirrored catalogs"
+    cr_oc: "/path/to/oc"
 ```
 
 Confirming SRIOV node state
@@ -44,4 +46,5 @@ Confirming SRIOV node state
     check_wait_retries: 120
     check_wait_delay: 10
     check_reason: "Apply SRIOV policies"
+    cr_oc: "/path/to/oc"
 ```

--- a/roles/check_resource/tasks/uncordon_workers.yml
+++ b/roles/check_resource/tasks/uncordon_workers.yml
@@ -2,7 +2,7 @@
 - name: Check for workers with Ready,SchedulingDisabled status
   ansible.builtin.shell: >
     set -eo pipefail;
-    {{ oc_tool_path }} get nodes --no-headers=true |
+    {{ cr_oc }} get nodes --no-headers=true |
     grep 'Ready,SchedulingDisabled' |
     grep worker |
     awk '{ print $1 }'
@@ -17,13 +17,13 @@
   when: reg_disabled_nodes.stdout | length > 0
   block:
     - name: Workaround - uncordon all ready workers with disabled scheduling
-      ansible.builtin.command: "{{ oc_tool_path }} adm uncordon {{ item }}"
+      ansible.builtin.command: "{{ cr_oc }} adm uncordon {{ item }}"
       loop: "{{ reg_disabled_nodes.stdout.split('\n') }}"
 
     # If nodes are not ready after this time, then the whole role will fail
     - name: "Wait for workers to be ready - {{ check_reason | default('To define the location') }}"
       ansible.builtin.shell: >
-        {{ oc_tool_path }} get nodes --no-headers=true | grep worker
+        {{ cr_oc }} get nodes --no-headers=true | grep worker
       register: nodes
       until:
         - '"SchedulingDisabled" not in nodes.stdout'

--- a/roles/check_resource/tasks/wait-mcp.yml
+++ b/roles/check_resource/tasks/wait-mcp.yml
@@ -27,7 +27,7 @@
     # Ready, so retrying this task during 10 minutes maximum.
     - name: Check for nodes with NotReady,SchedulingDisabled status
       ansible.builtin.shell: >
-        {{ oc_tool_path }} get nodes --no-headers=true |
+        {{ cr_oc }} get nodes --no-headers=true |
         grep 'NotReady,SchedulingDisabled' | awk '{ print $1 }'
       register: not_ready_disabled_nodes
       until: not_ready_disabled_nodes.stdout | length == 0
@@ -38,7 +38,7 @@
     # Run this check during 3 minutes maximum.
     - name: Check for nodes with Ready,SchedulingDisabled status
       ansible.builtin.shell: >
-        {{ oc_tool_path }} get nodes --no-headers=true |
+        {{ cr_oc }} get nodes --no-headers=true |
         grep 'Ready,SchedulingDisabled' | awk '{ print $1 }'
       register: reg_disabled_nodes
       until: reg_disabled_nodes.stdout | length == 0


### PR DESCRIPTION
The role was using variables defined in the DCI agents, removing its references to make it independent

build-depends: https://softwarefactory-project.io/r/c/dci-openshift-app-agent/+/31276
build-depends: https://softwarefactory-project.io/r/c/dci-openshift-agent/+/31277