### PR TITLE
Fixed "Pyxis rejects test library development version numbers"

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.6.EPOCH
+Version:        0.7.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.6.0
+version: 0.7.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/pyxis/tasks/main.yml
+++ b/roles/pyxis/tasks/main.yml
@@ -9,9 +9,11 @@
     preflight_artifact: "{{ lookup('file', preflight_log_file) | to_json }}"
     pyxis_apikey: "{{ lookup('file', pyxis_apikey_path) }}"
 
-- name: Get latest commit hash for the Preflight release
-  vars:
+- name: Set preflight release
+  set_fact: 
     preflight_release: "{{ preflight_output.test_library.version.split('+')[0] }}"
+
+- name: Get latest commit hash for the Preflight release
   ansible.builtin.uri:
     url: >
       https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/git/refs/tags/{{ preflight_release }}

--- a/roles/pyxis/templates/test_results.json.j2
+++ b/roles/pyxis/templates/test_results.json.j2
@@ -13,7 +13,7 @@
   "operator_package_name": "{{ operator.name }}",
   "passed": {{ preflight_output.passed }},
   "results": {{ preflight_output.results }},
-  "test_library": {{ preflight_output.test_library | combine({'commit': preflight_latest.json.object.sha}) }},
+  "test_library": {{ preflight_output.test_library | combine({'commit': preflight_latest.json.object.sha, 'version': preflight_release}) }},
   "tested_on": {
     "name": "OCP",
     "version": "{{ ocp_version_full }}"


### PR DESCRIPTION
CheckDallasWorkload: preflight-green

The Pyxis API currently only supports the test library version 1.9.1 and rejects any development version based on that one (for instance, 1.9.1+abcdef0123456789).

We had a partial fix that would replace the test library commit ID in the pushed test results, but it left the version number unaltered, thus causing the Pyxis API to reject the requests.

This fix overrides the version number (if needed) along with the commit ID in the test results data.

build-depends: https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/1139