### PR TITLE
Notify on publish errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,3 +53,17 @@ jobs:
             fi;
             exit ${ec}
           fi;
+
+      - name: Notify failure
+        if: ${{ failure() }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          ENABLE_ESCAPES: true
+          MSG_MINIMAL: true
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_FOOTER: "version: ${{ steps.galaxy.outputs.ver }}"
+          SLACKIFY_MARKDOWN: true
+          SLACK_MESSAGE: >
+            URL: [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}/checks)
+          SLACK_TITLE: 🔴 Galaxy Publication Failure
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Submit a notification message to slack whenever there's an issue with publishing the collection into galaxy

Here an example on how the message is crafted:
![image](https://github.com/redhatci/ansible-collection-redhatci-ocp/assets/116447/63e46af5-79ee-48fe-8751-3ed5e07dbe0f)

Test-Hints: no-check