### PR TITLE
Allow skopeo insecure

### DIFF
--- a/roles/mirror_catalog/tasks/main.yml
+++ b/roles/mirror_catalog/tasks/main.yml
@@ -18,6 +18,7 @@
       ansible.builtin.shell:
         cmd: >
           skopeo inspect
+          --tls-verify=false
           {% if mc_pullsecret is defined %}
           --authfile {{ mc_pullsecret }}
           {% endif %}


### PR DESCRIPTION
TestDallas: ocp-4.14-vanilla 

Allow inspecting images in registries using Self-signed certs