### PR TITLE
Add ZTP-GitOps workflow role

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Name | Description
 [redhatci.ocp.vendors.supermicro](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/vendors/supermicro/README.md) | Boots a supermicro machine to iso or disk via redfish
 [redhatci.ocp.vendors.zt](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/vendors/zt/README.md) | Boots a zt machine to iso or disk via redfish
 [redhatci.ocp.verify_tests](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/verify_tests/README.md) | Verification of tests based on rules
+[redhatci.ocp.ztphub](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/ztphub) | Installs ZTP ACM based hub
 
 ## Plugins
 

--- a/roles/ztphub/README.md
+++ b/roles/ztphub/README.md
@@ -1,0 +1,63 @@
+ZTP GitOps ACM based role
+=========
+
+This Ansible role installs ACM based ZTP GitOps workflow from scratch
+
+Requirements
+------------
+
+* Access to an OpenShift cluster
+* ACM with MCE installed on Openshift cluster
+* Properly configured kubeconfig file for cluster access
+* Existing CatalogSource.
+* Podman and Ansible installed
+
+Role Variables
+--------------
+
+* `ztphub_working_dir`: (string) Local working directory path for files.
+* `ztphub_gitops_operator_install_channel`: (string) GitOps (ArgoCD) operator channel version (default is `latest`)
+* `ztphub_talm_operator_install_channel`: (string) TALM operator channel version (default is `stable`)
+* `ztphub_image`: (string) Image for ZTP generator (default is `quay.io/openshift-kni/ztp-site-generator`)
+* `ztphub_out_dir`: (string) Directory path for extracting files from ZTP image (default is `{{ ztphub_working_dir }}/out`)
+* `ztphub_automatic_update`: (bool) Whether to update automatically operators (`installPlanApproval`) (default is `true`)
+* `ztphub_install_ops_mode`: (string) `Manual` or `Automatic` depends on `ztphub_automatic_update`.
+
+* `ztphub_install_gitops_operator_from_image`: (bool) Whether to install GitOps (ArgoCD) operator from image provided file (default is `false`)
+* `ztphub_app_autosync`: (bool) Enable autosync in ArgoCD for repository (default is `false`)
+* `ztphub_gitops_repo_insecure`: (bool) Disable TLS verify for repository settings in ArgoCD (default is `true`)
+* `ztphub_gitops_repo_project`: (string) ArgoCD project for repository settings (default is `default`)
+* `ztphub_gitops_repo`: (string) HTTP Git repository with GitOps files (siteconfigs)
+* `ztphub_gitops_path`: (string) Git repository path to directory with `SiteConfig` configurations
+* `ztphub_gitops_revision`: (string) Git repository version/branch for siteconfigs
+* `ztphub_policy_gitops_repo`: (string) HTTP Git repository with GitOps Policy files
+* `ztphub_policy_gitops_path`: (string) Git repository path to directory with `Policy` configurations
+* `ztphub_policy_gitops_revision`: (string) Git repository version/branch for policies
+
+* `ztphub_custom_images`: (list) Add another images (like nightlies) to the cluster.
+* `ztphub_agent_service_config_spec`: (string) Configuration for AgentServiceConfig for Assisted Installer
+
+Example Playbook
+----------------
+
+* Install ACM ZTP GitOps
+
+```yaml
+    - hosts: localhost
+      tasks:
+      - name: Install ACM ZTP GitOps
+        include_role:
+          name: ztphub
+        vars:
+          ztphub_working_dir: ~/tmp/ztphub
+          ztphub_kubeconfig_file: my-kubeconfig-file
+          ztphub_gitops_repo: https://gitlab.cee.redhat.com/telco-5g-devops-ci-infra/gitops.git
+          ztphub_gitops_path: install
+          ztphub_gitops_revision: master
+          ztphub_policy_gitops_repo: https://gitlab.cee.redhat.com/telco-5g-devops-ci-infra/gitops.git
+          ztphub_policy_gitops_path: configuration
+          ztphub_policy_gitops_revision: master
+          ztphub_custom_images:
+            - name: openshift-v4.15.0
+              image: quay.io/openshift-release-dev/ocp-release:4.15.0-x86_64
+```

--- a/roles/ztphub/defaults/main.yml
+++ b/roles/ztphub/defaults/main.yml
@@ -1,0 +1,72 @@
+---
+
+ztphub_working_dir: "/tmp/hub/{{ cluster | default('ztp') }}"
+ztphub_gitops_operator_install_channel: latest
+ztphub_talm_operator_install_channel: stable
+ztphub_image: quay.io/openshift-kni/ztp-site-generator:latest
+ztphub_out_dir: "{{ ztphub_working_dir }}/out"
+ztphub_automatic_update: true
+ztphub_install_ops_mode: "{% if ztphub_automatic_update %}Automatic{% else %}Manual{% endif %}"
+ztphub_install_gitops_operator_from_image: false
+
+ztphub_app_autosync: false
+
+# ztphub_kubeconfig_file:
+ztphub_gitops_repo_insecure: true
+ztphub_gitops_repo_project: default
+
+ztphub_gitops_repo: https://gitlab.cee.redhat.com/telco-5g-devops-ci-infra/gitops.git
+ztphub_gitops_path: install
+ztphub_gitops_revision: master
+
+ztphub_policy_gitops_repo: https://gitlab.cee.redhat.com/telco-5g-devops-ci-infra/gitops.git
+ztphub_policy_gitops_path: configuration
+ztphub_policy_gitops_revision: master
+
+ztphub_custom_images: []
+
+ztphub_agent_service_config_spec: |-
+  databaseStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 19Gi
+  filesystemStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 19Gi
+  imageStorage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 190Gi
+  osImages:
+  - cpuArchitecture: x86_64
+    openshiftVersion: "4.12"
+    rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/latest/rhcos-live-rootfs.x86_64.img
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/latest/rhcos-live.x86_64.iso
+    version: "4.12"
+  - cpuArchitecture: x86_64
+    openshiftVersion: "4.13"
+    rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.13/latest/rhcos-live-rootfs.x86_64.img
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.13/latest/rhcos-live.x86_64.iso
+    version: "4.13"
+  - cpuArchitecture: x86_64
+    openshiftVersion: "4.14"
+    rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.14/latest/rhcos-live-rootfs.x86_64.img
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.14/latest/rhcos-live.x86_64.iso
+    version: "4.14"
+  - cpuArchitecture: x86_64
+    openshiftVersion: "4.15"
+    rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest-4.15/rhcos-live-rootfs.x86_64.img
+    url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest-4.15/rhcos-live.x86_64.iso
+    version: "4.15"
+  - cpuArchitecture: x86_64
+    openshiftVersion: "4.16"
+    rootFSUrl: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/4.16-9.4/builds/416.94.202402021701-0/x86_64/rhcos-416.94.202402021701-0-live-rootfs.x86_64.img
+    url: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/4.16-9.4/builds/416.94.202402021701-0/x86_64/rhcos-416.94.202402021701-0-live.x86_64.iso
+    version: "4.16"

--- a/roles/ztphub/tasks/approve_install_plan.yml
+++ b/roles/ztphub/tasks/approve_install_plan.yml
@@ -1,0 +1,42 @@
+---
+- name: Let the operator to wait to create an Install Plan
+  pause:
+    seconds: 30
+
+- name: Get all InstallPlans that are set to Manual and not approved
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+  register: install_plans
+
+- name: Print InstallPlans that are set to Manual and not approved
+  debug:
+    msg: "Approving Install Plan for {{ item.spec.clusterServiceVersionNames.0 }} - {{ item.metadata.namespace }}/{{ item.metadata.name }}"
+  loop: >-
+    {{ install_plans.resources |
+        selectattr('spec.approval', 'equalto', 'Manual') |
+        selectattr('spec.approved', 'equalto', false) |
+        list }}
+  loop_control:
+    label: "{{ item.metadata.namespace }}/{{ item.metadata.name }}"
+
+- name: Approve InstallPlans
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: InstallPlan
+      metadata:
+        name: "{{ item.metadata.name }}"
+        namespace: "{{ item.metadata.namespace }}"
+      spec:
+        approved: true
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+  loop: >-
+    {{ install_plans.resources |
+        selectattr('spec.approval', 'equalto', 'Manual') |
+        selectattr('spec.approved', 'equalto', false) |
+        list }}
+  loop_control:
+    label: "{{ item.metadata.namespace }}/{{ item.metadata.name }}"

--- a/roles/ztphub/tasks/install_gitops.yml
+++ b/roles/ztphub/tasks/install_gitops.yml
@@ -1,0 +1,46 @@
+---
+- name: Subscribe for GitOps (ArgoCD)
+  kubernetes.core.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    name: openshift-gitops-operator
+    namespace: openshift-operators
+    resource_definition:
+      spec:
+        channel: "{{ ztphub_gitops_operator_install_channel }}"
+        name: openshift-gitops-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+        installPlanApproval: "{{ ztphub_install_ops_mode }}"
+  when: not ztphub_install_gitops_operator_from_image
+
+- include_tasks: approve_install_plan.yml
+  when: not ztphub_automatic_update | bool
+
+- name: Ensure GitOps CSV phase has Succeeded before proceeding
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: openshift-operators
+  register: ops_csv_status
+  until:
+    - "'resources' in ops_csv_status"
+    - ops_csv_status.resources | length > 0
+    - "ops_csv_status.resources[0].status.phase == 'Succeeded'"
+  retries: 20
+  delay: 30
+  ignore_errors: true
+  when: not ztphub_install_gitops_operator_from_image
+
+- name: Fail if CSV phase is not Succeeded
+  fail:
+    msg: |
+      State: {{ ops_csv_status.resources[0].state | default('Unknown') }}
+      Status: {{ ops_csv_status.resources[0].status.phase | default('Unknown') }}
+      Reason: {{ ops_csv_status.resources[0].status.reason | default('Unknown') }}
+      Message: {{ ops_csv_status.resources[0].status.message | default('Unknown') }}
+  when:
+    - ops_csv_status is failed
+    - not ztphub_install_gitops_operator_from_image

--- a/roles/ztphub/tasks/install_gitops_from_ztp_image.yml
+++ b/roles/ztphub/tasks/install_gitops_from_ztp_image.yml
@@ -1,0 +1,26 @@
+---
+- name: Print install command from image if need
+  debug:
+    msg: |-
+      In case of installation from the image, run:
+      oc --kubeconfig={{ ztphub_kubeconfig_file | default('') }} apply -f {{ ztphub_out_dir }}/argocd/deployment/openshift-gitops-operator.yaml
+
+- name: Create ArgoCD operator
+  shell: >-
+    oc --kubeconfig={{ ztphub_kubeconfig_file }} apply -f {{ ztphub_out_dir }}/argocd/deployment/openshift-gitops-operator.yaml
+
+- name: Wait for ArgoCD operator to be ready
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    name: openshift-gitops-operator
+    namespace: openshift-gitops
+  register: gitops_operator_status
+  until:
+    - "'resources' in gitops_operator_status"
+    - gitops_operator_status.resources | length > 0
+    - "gitops_operator_status.resources[0].status.readyReplicas == gitops_operator_status.resources[0].status.replicas"
+  retries: 20
+  delay: 30
+  ignore_errors: true

--- a/roles/ztphub/tasks/install_talm.yml
+++ b/roles/ztphub/tasks/install_talm.yml
@@ -1,0 +1,42 @@
+---
+- name: Subscribe for TALM
+  kubernetes.core.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    name: openshift-topology-aware-lifecycle-manager-subscription
+    namespace: openshift-operators
+    resource_definition:
+      spec:
+        channel: "{{ ztphub_talm_operator_install_channel }}"
+        name: topology-aware-lifecycle-manager
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+        installPlanApproval: "{{ ztphub_install_ops_mode }}"
+
+- include_tasks: approve_install_plan.yml
+  when: not ztphub_automatic_update | bool
+
+- name: Ensure TALM CSV phase has Succeeded before proceeding
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: openshift-operators
+  register: talm_csv_status
+  until:
+    - "'resources' in talm_csv_status"
+    - talm_csv_status.resources | length > 0
+    - "talm_csv_status.resources[0].status.phase == 'Succeeded'"
+  retries: 20
+  delay: 30
+  ignore_errors: true
+
+- name: Fail if CSV phase is not Succeeded
+  fail:
+    msg: |
+      State: {{ talm_csv_status.resources[0].state | default('Unknown') }}
+      Status: {{ talm_csv_status.resources[0].status.phase | default('Unknown') }}
+      Reason: {{ talm_csv_status.resources[0].status.reason | default('Unknown') }}
+      Message: {{ talm_csv_status.resources[0].status.message | default('Unknown') }}
+  when: talm_csv_status is failed

--- a/roles/ztphub/tasks/main.yml
+++ b/roles/ztphub/tasks/main.yml
@@ -1,0 +1,152 @@
+---
+- name: Create out directory if not exist
+  file:
+    path: "{{ ztphub_working_dir }}"
+    state: directory
+
+- name: Create a namespace for GitOps
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Namespace
+    name: openshift-gitops
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+
+- name: Create AgentServiceConfig
+  kubernetes.core.k8s:
+    api_version: agent-install.openshift.io/v1beta1
+    kind: AgentServiceConfig
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    name: agent
+    resource_definition:
+      metadata:
+        annotations:
+          unsupported.agent-install.openshift.io/assisted-image-service-skip-verify-tls: "true"
+      spec: "{{ ztphub_agent_service_config_spec | from_yaml }}"
+
+- name: Ensure provisioning-configuration is patched
+  kubernetes.core.k8s:
+    api_version: metal3.io/v1alpha1
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    kind: Provisioning
+    name: provisioning-configuration
+    merge_type:
+      - merge
+    definition:
+      spec:
+        watchAllNamespaces: true
+        disableVirtualMediaTLS: true
+
+- include_tasks: install_gitops.yml
+- include_tasks: install_talm.yml
+
+- name: Create custom images
+  kubernetes.core.k8s:
+    api_version: hive.openshift.io/v1
+    kind: ClusterImageSet
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    name: "{{ item.name }}"
+    resource_definition:
+      spec:
+        releaseImage: "{{ item.image }}"
+  loop: "{{ ztphub_custom_images }}"
+  when:
+    - ztphub_custom_images is defined
+    - ztphub_custom_images | length > 0
+
+- name: Get ZTP image
+  containers.podman.podman_image:
+    name: "{{ ztphub_image }}"
+
+- name: Create out directory if not exist
+  file:
+    path: "{{ ztphub_out_dir }}"
+    state: directory
+
+- name: Extract ZTP image
+  shell: podman run --rm --log-driver=none ztp-site-generator:latest extract /home/ztp --tar | tar x -C ./out
+  args:
+    chdir: "{{ ztphub_working_dir }}"
+    creates: "{{ ztphub_out_dir }}/argocd"
+
+- include_tasks: install_gitops_from_ztp_image.yml
+  when: ztphub_install_gitops_operator_from_image | bool
+
+- name: Patch GitOps operator
+  shell: >-
+    oc --kubeconfig={{ ztphub_kubeconfig_file }} patch argocd openshift-gitops -n openshift-gitops
+    --type=merge
+    --patch-file {{ ztphub_out_dir }}/argocd/deployment/argocd-openshift-gitops-patch.json
+  register: patch_result
+  changed_when: "'(no change)' not in patch_result.stdout"
+
+- name: Replace parameters in SiteConfigs YAML file
+  lineinfile:
+    path: "{{ ztphub_out_dir }}/argocd/deployment/clusters-app.yaml"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    backrefs: true
+  loop:
+    - regexp: '^(\s+path:\s+).*'
+      line: '\1{{ ztphub_gitops_path }}'
+    - regexp: '^(\s+repoURL:\s+).*'
+      line: '\1{{ ztphub_gitops_repo }}'
+    - regexp: '^(\s+targetRevision:\s+).*'
+      line: '\1{{ ztphub_gitops_revision }}'
+
+- name: Replace parameters in PolicyConfigs YAML file
+  lineinfile:
+    path: "{{ ztphub_out_dir }}/argocd/deployment/policies-app.yaml"
+    regexp: '{{ item.regexp }}'
+    line: '{{ item.line }}'
+    backrefs: true
+  loop:
+    - regexp: '^(\s+path:\s+).*'
+      line: '\1{{ ztphub_policy_gitops_path }}'
+    - regexp: '^(\s+repoURL:\s+).*'
+      line: '\1{{ ztphub_policy_gitops_repo }}'
+    - regexp: '^(\s+targetRevision:\s+).*'
+      line: '\1{{ ztphub_policy_gitops_revision }}'
+
+- name: Disable auto-sync if configured
+  ansible.builtin.lineinfile:
+    path: "{{ ztphub_out_dir }}/argocd/deployment/clusters-app.yaml"
+    state: absent
+    regexp: "{{ item }}"
+  loop:
+    - '^\s+automated:.*'
+    - '^\s+prune:.*'
+    - '^\s+selfHeal:.*'
+  when: not ztphub_app_autosync
+
+- name: Deploy application
+  shell: >-
+    oc --kubeconfig={{ ztphub_kubeconfig_file }} apply -k {{ ztphub_out_dir }}/argocd/deployment
+  changed_when: "' changed' in deploy_result.stdout or ' created' in deploy_result.stdout"
+  register: deploy_result
+
+- name: Connect repo by creating secret in ArgoCD
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ ztphub_kubeconfig_file | default(omit) }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        annotations:
+          managed-by: argocd.argoproj.io
+        labels:
+          argocd.argoproj.io/secret-type: repository
+        name: repo-5g-devops-ci-infra-12345
+        namespace: openshift-gitops
+      data:
+        insecure: "{{ ztphub_gitops_repo_insecure | string | lower | b64encode }}"
+        project: "{{ ztphub_gitops_repo_project | b64encode }}"
+        type: "{{ 'git' | b64encode }}"
+        url: "{{ ztphub_gitops_repo | b64encode }}"
+
+- name: For sync run the following command if Autosync is disabled
+  debug:
+    msg: |-
+      To sync the application run (if Autosync is disabled):
+      oc --kubeconfig={{ ztphub_kubeconfig_file }} patch app clusters -n openshift-gitops -p '{"operation": {"sync": { "revision": "HEAD" } }}' --type merge


### PR DESCRIPTION
Add role that using existing ACM installation (see other roles for that) installs and configures ZTP GitOps workflow from scratch, configures repositories and ready for usage.