### PR TITLE
Add support for control plane availability policy

### DIFF
--- a/roles/acm_hypershift/README.md
+++ b/roles/acm_hypershift/README.md
@@ -51,6 +51,7 @@ At this time the role supports creating the OpenShift required endpoints under t
 | ah_hcp_cli_path         |                                           | No        | Path to the hcp CLI, if `ah_download_cli` the role will get the binary from the Management Cluster
 | ah_ssh_key              | `sshKey` from Management cluster          | No        | SSH key to be added to the `authorized_keys` file in NodePool's instances
 | ah_disconnected         | False                                     | No        | Defines if the management cluster is in a disconnected (air-gapped) environment
+| ah_control_plane_availability_policy | HighlyAvailable              | No        | ControllerAvailabilityPolicy specifies the availability policy applied to critical control plane components. Options: HighlyAvailable, SingleReplica |
 
 ## Disconnected control planes
 

--- a/roles/acm_hypershift/tasks/create-cluster.yml
+++ b/roles/acm_hypershift/tasks/create-cluster.yml
@@ -16,6 +16,9 @@
       {%- if ah_ca_bundle_file is defined %} --additional-trust-bundle "{{ ah_ca_bundle_file }}"{%- endif %}
       {%- if ah_hc_annotations | length >0 %} --annotations {{ ah_hc_annotations }}{%- endif %}
       {%- if ah_ssh_key | length >0 %} --ssh-key {{ ah_ssh_key }}{%- endif %}
+      {% if ah_control_plane_availability_policy is defined %}
+      --control-plane-availability-policy="{{ ah_control_plane_availability_policy }}"
+      {% endif %}
   notify: Remove working directory
   changed_when: false
 

--- a/roles/acm_hypershift/tasks/validations.yml
+++ b/roles/acm_hypershift/tasks/validations.yml
@@ -75,4 +75,11 @@
     kind: StorageClass
   register: ah_sc
   failed_when: not 'true' in query_results
+
+- name: "Check for valid control plane availability policy"
+  ansible.builtin.fail:
+    msg: "Control plane availability policy '{{ ah_control_plane_availability_policy }}' is not supported"
+  when:
+    - ah_control_plane_availability_policy is defined
+    - ah_control_plane_availability_policy not in ah_control_plane_availability_policies
 ...

--- a/roles/acm_hypershift/vars/main.yml
+++ b/roles/acm_hypershift/vars/main.yml
@@ -2,4 +2,8 @@
 ah_cluster_types:
   - kubevirt
   - agent
+
+ah_control_plane_availability_policies:
+  - HighlyAvailable
+  - SingleReplica
 ...


### PR DESCRIPTION
This commit enhances the hypershift cluster deployment playbook to support specifying  the control plane availability policy using the `ah_control_plane_availability_policy` variable.

The playbook now checks if this variable is defined and includes it in the deployment command accordingly.

This update provides flexibility in configuring the control plane availability policy, allowing users to choose between "HighlyAvailable" and "SingleReplica" options based on their requirements.[1]

Note: "SingleReplica" should not be used in Production clusters.

[1] https://hypershift-docs.netlify.app/reference/api/#hypershift.openshift.io/v1beta1.AvailabilityPolicy

TestDallas: ocp-4.15-acm-hub ocp-4.15-acm-sno control-plane-example control-plane-example:ansible_extravars=openshift_app_replicas:1
Test-Hints: no-check
