### PR TITLE
Use podman_image module to remove root-owned image

### DIFF
--- a/roles/preflight/tasks/test_run_health_check.yml
+++ b/roles/preflight/tasks/test_run_health_check.yml
@@ -55,13 +55,11 @@
   become: true
 
 - name: Remove the tested image
-  shell:
-    cmd: >
-      podman rmi
-      --force
-      --ignore
-      {{ current_operator_image }}
+  containers.podman.podman_image:
+    name: "{{ current_operator_image }}"
+    state: absent
   become: true
+  ignore_errors: true
 
 - name: Change the ownership of oval report
   ansible.builtin.file:


### PR DESCRIPTION
CheckDallasWorkload: preflight-green
Test-Hints: no-check