### PR TITLE
ocp_on_libvirt: treating enable_virtualmedia as boolean

### DIFF
--- a/roles/ocp_on_libvirt/templates/hosts.j2
+++ b/roles/ocp_on_libvirt/templates/hosts.j2
@@ -59,7 +59,7 @@ ansible_ssh_extra_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/n
 [provisioner]
 {% for key, value in ironic_nodes.items() -%}
 {% if 'provision' in key -%}
-{{ key }}{{ "." + ansible_fqdn if not do_dns_config|bool else "" }} {{ "ansible_host=" + key + "." + ansible_fqdn if not do_dns_config|bool else "" }} name={{ key }} ansible_user={{ provisionhost_user }} prov_nic=eth0 pub_nic=eth1 ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"{% if enable_virtualmedia %} bootstrapProvisioningIP={{ bootstrapProvisioningIP }}{% endif %}
+{{ key }}{{ "." + ansible_fqdn if not do_dns_config|bool else "" }} {{ "ansible_host=" + key + "." + ansible_fqdn if not do_dns_config|bool else "" }} name={{ key }} ansible_user={{ provisionhost_user }} prov_nic=eth0 pub_nic=eth1 ansible_ssh_common_args="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"{% if enable_virtualmedia | bool %} bootstrapProvisioningIP={{ bootstrapProvisioningIP }}{% endif %}
 {% endif %}
 {%- endfor %}
 


### PR DESCRIPTION
OCP on Libvirt parameter enable_virtualmedia seems not to have any effect when running dci-pipeline-check.

This change is to ensure the parameter is treated as a boolean.

Test-Hints: no-check
Test-Args-Hints: -e enable_redfish=true -e enable_virtualmedia=true
Build-Depends: https://github.com/dci-labs/bos2-ci-config/pull/130
Build-Depends: https://softwarefactory-project.io/r/c/dci-openshift-agent/+/31415
TestBos2: virt libvirt:ansible_extravars=enable_redfish:true libvirt:ansible_extravars=enable_virtualmedia:true