### PR TITLE
ACM - Move the Agent Service config to acm_setup

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.8.EPOCH
+Version:        0.9.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -51,6 +51,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Tue Apr 30 2024 Beto Rodriguez <josearod@redhat.com> - 0.9.EPOCH-VERS
+- Dependency for acm_* roles
+
 * Wed Mar 20 2024 Jorge A Gallegos <jgallego@redhat.com> - 0.5.EPOCH-VERS
 - Adding community.crypto dependency
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.8.0
+version: 0.9.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/acm_setup/README.md
+++ b/roles/acm_setup/README.md
@@ -11,16 +11,20 @@ The configuration of the ACM hub can be customized by using the following variab
 
 ## Variables
 
-| Variable                           | Default                       | Required    | Description                                   |
-| ---------------------------------- | ----------------------------- | ----------- | ----------------------------------------------|
-|hub_availability                    |High                           |No           |Multicluster hub High Availability configuration |
-|hub_disable_selfmanagement          |False                          |No           |Do not import the hub cluster as managed in ACM  |
-|hub_namespace                       |open-cluster-management        |No           |Namespace where ACM has been installed and will be configured |
-|hub_instance                        |multiclusterhub                |No           |Name of the multiclusterhub instance to be created (fail if already exists) |
-|hub_disconnected                    |false                          |No           |If true, it will create custom ClusterImageSets and remove the Channel subscriptions |
-|hub_sc                              |Undefined                      |If no default StorageClass is available | Desired storage class for ACM resources. If undefined, the default SC will be used |
-|hub_hugepages_type                  |hugepages-2Mi                  |No           |Hugepages type to be configured for Postgres search pods. x86_64 support hugepages-2Mi and hugepages-1Gi |
-|hub_hugepages_size                  |1024Mi                         |No           |Hugepages `hub_hugepages_type` size              |
+| Variable                           | Default                       | Required    | Description
+| ---------------------------------- | ----------------------------- | ----------- | ----------------------------------------------
+|hub_availability                    |High                           |No           | Multicluster hub High Availability configuration
+|hub_disable_selfmanagement          |False                          |No           | Do not import the hub cluster as managed in ACM
+|hub_namespace                       |open-cluster-management        |No           | Namespace where ACM has been installed and will be configured
+|hub_instance                        |multiclusterhub                |No           | Name of the multiclusterhub instance to be created (fail if already exists)
+|hub_disconnected                    |false                          |No           | If true, it will create custom ClusterImageSets and remove the Channel subscriptions
+|hub_sc                              |Undefined                      |If no default StorageClass is available | Desired storage class for ACM resources. If undefined, the default SC will be used
+|hub_hugepages_type                  |hugepages-2Mi                  |No           | Hugepages type to be configured for Postgres search pods. x86_64 support hugepages-2Mi and hugepages-1Gi
+|hub_hugepages_size                  |1024Mi                         |No           | Hugepages `hub_hugepages_type` size
+|hub_db_volume_size                  |40Gi                           |No           | This value specifies how much storage it is allocated for storing files like database tables and database views for the clusters. You might need to use a higher value if there are many clusters
+|hub_fs_volume_size                  |50Gi                           |No           | This value specifies how much storage is allocated for storing logs, manifests, and kubeconfig files for the clusters. You might need to use a higher value if there are many clusters
+|hub_img_volume_size                 |40Gi                           |No           | This value specifies how much storage is allocated for the images of the clusters. You need to allow 1 GB of image storage for each instance of Red Hat Enterprise Linux CoreOS
+|hub_os_images                       |<Undefined>                    |No           | Locations of OS Images to be used when generating the discovery ISOs for different OpenShift versions. See [OS images](./README.md#os-images). It is mandatory for disconnected environments.
 
 ## Requirements
 1. An OpenShift Cluster with a subscription for the ACM operator.
@@ -42,6 +46,31 @@ See below an example of how to use the acm_setup role to configure ACM.
       hub_disable_selfmanagement: true
       hub_availabilityConfig: High
       hub_disconnected: true
+      hub_os_images:
+        - openshiftVersion: "4.15.0-0.nightly-2024-04-21-051624"
+          version: "4.15"
+          url: "http://example.com/rhcos-415.92.202402201450-0-live.x86_64.iso"
+          cpuArchitecture: x86_64
+```
+
+## OS images
+
+See below some examples of how to define a list of OS maintained by the Agent service config.
+
+```yaml
+hub_os_images:
+  - cpuArchitecture: x86_64
+      openshiftVersion: "4.<minor-version>"
+      rootFSUrl: https://<host>/<path>/rhcos-live-rootfs.x86_64.img
+      url: https://<mirror-registry>/<path>/rhcos-live.x86_64.iso
+  - cpuArchitecture: x86_64
+      openshiftVersion: "4.<minor-version>"
+      url: https://<mirror-registry>/<path>/rhcos-4.<minor-version>-live.x86_64.iso
+
+hub_os_images:
+  - cpuArchitecture: x86_64
+      openshiftVersion: "4.<minor-version>"
+      url: https://<mirror-registry>/<path>/rhcos-live.x86_64.iso
 ```
 
 ## References

--- a/roles/acm_setup/defaults/main.yml
+++ b/roles/acm_setup/defaults/main.yml
@@ -6,4 +6,8 @@ hub_namespace: open-cluster-management
 hub_disconnected: false
 hub_hugepages_type: hugepages-2Mi
 hub_hugepages_size: 1024Mi
+hub_db_volume_size: 40Gi
+hub_fs_volume_size: 50Gi
+hub_img_volume_size: 40Gi
+hub_vm_external_network: true
 ...

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -139,7 +139,7 @@
     - name: "Delete all ClusterImageSets"
       vars:
         subs_details: "resources[*].{ app_subs_name: metadata.name }"
-        app_subs: "{{ cis_list | json_query(subs_details) }}"  # noqa: jinja[invalid]
+        app_subs: "{{ cis_list | json_query(subs_details) }}"
       community.kubernetes.k8s:
         api: hive.openshift.io/v1
         state: absent
@@ -240,4 +240,97 @@
           spec:
             routeAdmission:
               wildcardPolicy: WildcardsAllowed
+
+- name: "Check the AgentServiceConfig instance"
+  community.kubernetes.k8s_info:
+    api: agent-install.openshift.io/v1beta1
+    kind: AgentServiceConfig
+    name: agent
+    namespace: multicluster-engine
+  register: _asg
+
+- name: "Create the Agent Service config"
+  when: _asg.resources | length == 0
+  vars:
+    agent_def: |
+      apiVersion: agent-install.openshift.io/v1beta1
+      kind: AgentServiceConfig
+      metadata:
+        name: agent
+        namespace: multicluster-engine
+      spec:
+        databaseStorage:
+      {% if hub_sc is defined %}
+          storageClassName: {{ hub_sc }}
+      {% endif %}
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: "{{ hub_db_volume_size }}"
+        filesystemStorage:
+      {% if hub_sc is defined %}
+          storageClassName: {{ hub_sc }}
+      {% endif %}
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: "{{ hub_fs_volume_size }}"
+        imageStorage:
+      {% if hub_sc is defined %}
+          storageClassName: {{ hub_sc }}
+      {% endif %}
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: "{{ hub_img_volume_size }}"
+      {% if hub_os_images is defined %}
+        osImages: {{ hub_os_images }}
+      {% endif %}
+  community.kubernetes.k8s:
+    state: present
+    definition: "{{ agent_def }}"
+
+# In connected envs, it takes some time to generate the ISOs
+# for multiple OCP versions and Architectures
+- name: "Wait for assisted-image-service pods to be Running"
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Pod
+    label_selectors:
+      - "app=assisted-image-service"
+    field_selectors:
+      - status.phase=Running
+    namespace: multicluster-engine
+    wait: true
+  register: pod_list
+  until:
+    - pod_list is defined
+    - pod_list.resources is defined
+    - pod_list.resources | length > 0
+    - pod_list | json_query('resources[*].status.phase') | unique == ["Running"]
+  retries: 100
+  delay: 15
+
+- name: "Wait for assisted-service pods to be Running"
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Pod
+    label_selectors:
+      - "app=assisted-service"
+    field_selectors:
+      - status.phase=Running
+    namespace: multicluster-engine
+    wait: true
+  register: _pod_list
+  until:
+    - _pod_list is defined
+    - _pod_list.resources is defined
+    - _pod_list.resources | length > 0
+    - _pod_list | json_query('resources[*].status.phase') | unique == ["Running"]
+  retries: 20
+  delay: 15
+  no_log: true
 ...

--- a/roles/acm_setup/tasks/validation.yml
+++ b/roles/acm_setup/tasks/validation.yml
@@ -1,4 +1,11 @@
 ---
+- name: "Assert hub_os_images"
+  when: hub_disconnected | bool
+  ansible.builtin.assert:
+    that:
+      - hub_os_images is defined
+      - hub_os_images | type_debug == 'list'
+      - hub_os_images | length
 - name: "Get Storage Classes"
   community.kubernetes.k8s_info:
     api_version: v1
@@ -11,7 +18,7 @@
   when:
     - storage_class.resources | length == 0
 
-- name: "Fail when defined storage class does not exists"  # noqa: jinja[invalid]
+- name: "Fail when defined storage class does not exists"
   vars:
     query_sc_name: 'resources[*].metadata.name'
     query_results: "{{ storage_class | json_query(query_sc_name) }}"
@@ -21,7 +28,7 @@
     - hub_sc is defined
     - hub_sc not in query_results
 
-- name: "Fail when no default storage class"  # noqa: jinja[invalid]
+- name: "Fail when no default storage class"
   vars:
     query_default_sc: 'resources[*].metadata.annotations."storageclass.kubernetes.io/is-default-class"'
     query_results: "{{ storage_class | json_query(query_default_sc) }}"
@@ -40,7 +47,7 @@
   retries: 5
   delay: 5
 
-- name: "Fail if ACM csv is not present"  # noqa: jinja[invalid]
+- name: "Fail if ACM csv is not present"
   vars:
     csv_details: "resources[*].metadata.name"
     csvs: "{{ current_csvs | json_query(csv_details) }}"

--- a/roles/acm_sno/README.md
+++ b/roles/acm_sno/README.md
@@ -41,15 +41,12 @@ This role only been tested in x86_64 architectures.
 | acm_bmc_address                        | None                          | Yes         | BMC Address. BMC URLs vary based on the type of BMC and the protocol used to communicate with them. See: [BareMetalHost](https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md) for details|
 | acm_boot_mac_address                   | None                          | Yes         | MAC Address of the interface to be used to bootstrap the node |
 | acm_machine_cidr                       | None                          | Yes         | A block of IPv4 or IPv6 addresses in CIDR notation used for the target bare-metal host external communication. Also used to determine the API and Ingress VIP addresses when provisioning Distributed Units (DU) single-node clusters|
-| acm_cluster_network_host_prefix         | 23                           | No          | Network prefix for cluster nodes|
-| acm_cluster_network_cidr                | 10.128.0.0/14                 | No          | A block of IPv4 or IPv6 addresses in CIDR notation used for communication among cluster nodes|
-| acm_service_network_cidr                | 172.30.0.0/16                 | NO          | A block of IPv4 or IPv6 addresses in CIDR notation used for internal communication of cluster services|
+| acm_cluster_network_host_prefix        | 23                            | No          | Network prefix for cluster nodes|
+| acm_cluster_network_cidr               | 10.128.0.0/14                 | No          | A block of IPv4 or IPv6 addresses in CIDR notation used for communication among cluster nodes|
+| acm_service_network_cidr               | 172.30.0.0/16                | No           | A block of IPv4 or IPv6 addresses in CIDR notation used for internal communication of cluster services|
 | acm_iso_url                            | https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.9/49.84.202207192205-0/x86_64/rhcos-49.84.202207192205-0-live.x86_64.iso"                                 | No         | ISO boot Image. See: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/ |
-| acm_root_fs_url                        | https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.9/49.84.202207192205-0/x86_64/rhcos-49.84.202207192205-0-live-rootfs.x86_64.img                         | No                            | Root FS image. See https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/|
-|acm_sc                                  |Undefined                       | If no default StorageClass is available | Storage class to use for the `AgentServiceConfig` volumes: `acm_db_volume_size`, `acm_fs_volume_size`, and `acm_img_volume_size`. |
-|acm_db_volume_size                      |40Gi                           |No           | This value specifies how much storage it is allocated for storing files like database tables and database views for the clusters. You might need to use a higher value if there are many clusters|
-|acm_fs_volume_size                      |50Gi                           |No           | This value specifies how much storage is allocated for storing logs, manifests, and kubeconfig files for the clusters. You might need to use a higher value if there are many clusters|
-|acm_img_volume_size                     |40Gi                           |No           | This value specifies how much storage is allocated for the images of the clusters. You need to allow 1 GB of image storage for each instance of Red Hat Enterprise Linux CoreOS that is running. You might need to use a higher value if there are many clusters and instances of Red Hat Enterprise Linux CoreOS|
+| acm_root_fs_url                        | ''                            | No          | Root FS image. See https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/|
+that is running. You might need to use a higher value if there are many clusters and instances of Red Hat Enterprise Linux CoreOS|
 |acm_user_bundle                         |Undefined                      |No           |CA certificate to be injected to spoke nodes. Requires `acm_disconnected` set to true |
 |acm_user_registry                       |Undefined                      |Yes, for disconnected environments | Entries added to the registries.conf file during the initial spoke cluster bootstrap. Must include entries for the OCP release and multicluster-engine images. See examples below|
 |acm_vm_external_network                 |true                           |No           |Defines if the ISO created by the Bare Metal Operator is exposed via the External Network (baremetal) or the provisioning network (172.22.0.x), if set to `false` the ISO will be exposed using the private IP of the metal3 pod, Set to False in Deployments with Assisted Installer|
@@ -58,6 +55,11 @@ This role only been tested in x86_64 architectures.
 *Important:* The values defined for the `acm_ocp_version` must match with the images provided for `acm_iso_url` and `acm_root_fs_url` variables.
 
 ## Role requirements
+
+1. An OCP cluster with the ACM operators installed.
+1. The OCP cluster acting as a Hub/Management cluster must have an Agent Service Config properly configured. This role will patch the instance according the target spoke installation.
+
+* ACM Hub configuration can be performed by using the [acm_setup](../acm_setup/README.md) role.
 
 ### Networking
 
@@ -86,7 +88,7 @@ Pulling the mirroring configs from a cluster can be set by the `acm_disconnected
 
 ## Usage example
 
-See below for some examples of how to use the acm_setup role to configure ACM.
+See below some examples of how to use the acm_sno role to deploy an SNO instance.
 
 *Deployment of a SNO instance in connected mode*
 ```yaml
@@ -104,7 +106,6 @@ See below for some examples of how to use the acm_setup role to configure ACM.
     acm_bmc_pass: REDACTED
     acm_iso_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/latest/rhcos-4.10.16-x86_64-live.x86_64.iso
     acm_root_fs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/latest/rhcos-installer-rootfs.x86_64.img
-    acm_sc: "assisted-service"
   ansible.builtin.include_role:
     name: redhatci.ocp.acm_sno
 ```
@@ -124,8 +125,6 @@ See below for some examples of how to use the acm_setup role to configure ACM.
     acm_bmc_user: REDACTED
     acm_bmc_pass: REDACTED
     acm_iso_url: https://mirror.example.comrhcos/4.10/latest/rhcos-4.10.16-x86_64-live.x86_64.iso
-    acm_root_fs_url: https://mirror.example.comrhcos/4.10/latest/rhcos-installer-rootfs.x86_64.img
-    acm_sc: "assisted-service"
     acm_user_bundle: |
       -----BEGIN CERTIFICATE-----
       REDACTED
@@ -168,7 +167,6 @@ See below for some examples of how to use the acm_setup role to configure ACM.
     acm_machine_cidr: 192.168.16.0/25
     acm_bmc_user: REDACTED
     acm_bmc_pass: REDACTED
-    acm_sc: "assisted-service"
   ansible.builtin.include_role:
     name: redhatci.ocp.acm_sno
 ```

--- a/roles/acm_sno/defaults/main.yml
+++ b/roles/acm_sno/defaults/main.yml
@@ -12,9 +12,6 @@ acm_cluster_network_host_prefix: 23
 acm_service_network_cidr: 172.30.0.0/16
 acm_release_image: quay.io/openshift-release-dev/ocp-release:4.9.47-x86_64
 acm_iso_url: "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.9/49.84.202207192205-0/x86_64/rhcos-49.84.202207192205-0-live.x86_64.iso"
-acm_root_fs_url: "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.9/49.84.202207192205-0/x86_64/rhcos-49.84.202207192205-0-live-rootfs.x86_64.img"
-acm_db_volume_size: 40Gi
-acm_fs_volume_size: 50Gi
-acm_img_volume_size: 40Gi
+acm_root_fs_url: ''
 acm_vm_external_network: true
 ...

--- a/roles/acm_sno/tasks/create-cluster.yml
+++ b/roles/acm_sno/tasks/create-cluster.yml
@@ -79,61 +79,12 @@
         namespace: multicluster-engine
       spec:
         osImages: "{{ asg.resources[0].spec.osImages + [os_images] }}"
+        mirrorRegistryRef:
+            name: mirror-registry-config-map
   community.kubernetes.k8s:
     state: present
     definition: "{{ as_def }}"
   when: (asg.resources | length == 1)
-
-- name: "Create the Agent Service config"
-  vars:
-    agent_def: |
-      apiVersion: agent-install.openshift.io/v1beta1
-      kind: AgentServiceConfig
-      metadata:
-        name: agent
-        namespace: multicluster-engine
-      spec:
-        databaseStorage:
-      {% if acm_sc is defined %}
-          storageClassName: {{ acm_sc }}
-      {% endif %}
-          accessModes:
-          - ReadWriteOnce
-          resources:
-            requests:
-              storage: "{{ acm_db_volume_size }}"
-        filesystemStorage:
-      {% if acm_sc is defined %}
-          storageClassName: {{ acm_sc }}
-      {% endif %}
-          accessModes:
-          - ReadWriteOnce
-          resources:
-            requests:
-              storage: "{{ acm_fs_volume_size }}"
-        imageStorage:
-      {% if acm_sc is defined %}
-          storageClassName: {{ acm_sc }}
-      {% endif %}
-          accessModes:
-          - ReadWriteOnce
-          resources:
-            requests:
-              storage: "{{ acm_img_volume_size }}"
-        osImages:
-          - openshiftVersion: "{{ acm_ocp_version }}"
-            version: "{{ acm_ocp_version.split('.')[:2] | join('.') }}"
-            url: "{{ acm_iso_url }}"
-            rootFSUrl: "{{ acm_root_fs_url }}"
-            cpuArchitecture: x86_64
-        {% if inherit_mirroring is defined and inherit_mirroring | bool %}
-      mirrorRegistryRef:
-          name: mirror-registry-config-map
-        {% endif %}
-  community.kubernetes.k8s:
-    state: present
-    definition: "{{ agent_def }}"
-  when: (asg.resources | length != 1)
 
 - name: "Wait for assisted-image-service pods to be Running"
   community.kubernetes.k8s_info:

--- a/roles/acm_sno/tasks/pre-run.yml
+++ b/roles/acm_sno/tasks/pre-run.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: "Fail when acm_user_registry is not defined"
   fail:
     msg: >
@@ -21,38 +20,17 @@
     msg: "CRDs are not present"
   when: acm_crd.resources | list | count == 0
 
-- name: "Get Storage Classes"
+- name: "Check the AgentServiceConfig instance"
   community.kubernetes.k8s_info:
-    api_version: v1
-    kind: StorageClass
-  register: storage_class
+    api: agent-install.openshift.io/v1beta1
+    kind: AgentServiceConfig
+    name: agent
+  register: _asg
 
-- name: "Fail when there is no storage class available"
+- name: "Fail if AgentServiceConfig is missing"
   fail:
-    msg: "Defined storage class do not exists"
-  when:
-    - storage_class.resources | length == 0
-
-- name: "Fail when defined storage class do not exists"
-  vars:
-    query_sc_name: 'resources[*].metadata.name'
-    query_results: "{{ storage_class | json_query(query_sc_name) }}"  # noqa: jinja[invalid]
-  fail:
-    msg: "Defined storage class do not exists"
-  when:
-    - acm_sc is defined
-    - acm_sc not in query_results
-
-- name: "Fail when no default storage class"
-  vars:
-    query_default_sc: 'resources[*].metadata.annotations."storageclass.kubernetes.io/is-default-class"'
-    query_results: "{{ storage_class | json_query(query_default_sc) }}"  # noqa: jinja[invalid]
-  fail:
-    msg: "No default storage class was found"
-  when:
-    - storage_class is defined
-    - "not('true' in query_results)"
-    - acm_sc is not defined
+    msg: "An Agent Service config must be running on the Hub/Management Cluster"
+  when: _asg.resources | default([]) | length == 0
 
 - name: "Disable provisioning"
   when:


### PR DESCRIPTION
An agent service config config is a requirement for acm_sno, acm_hypershift, acm_ztp roles. Creating the resource in acm_setup allows to have the requirements for ACM base installation during the configuration of hub.