### PR TITLE
Add no certificates validations to jenkins_job_launcher uri module usage

### DIFF
--- a/roles/jenkins_job_launcher/tasks/main.yml
+++ b/roles/jenkins_job_launcher/tasks/main.yml
@@ -12,6 +12,7 @@
   ansible.builtin.uri:
     url: "{{ jjl_job_url }}/buildWithParameters/"
     method: POST
+    validate_certs: false
     user: "{{ jjl_username }}"
     password: "{{ jjl_token }}"
     force_basic_auth: true


### PR DESCRIPTION
Test-Hints: no-check