### PR TITLE
acm_setup: hub_os_images must be optional

### DIFF
--- a/roles/acm_setup/README.md
+++ b/roles/acm_setup/README.md
@@ -24,7 +24,7 @@ The configuration of the ACM hub can be customized by using the following variab
 |hub_db_volume_size                  |40Gi                           |No           | This value specifies how much storage it is allocated for storing files like database tables and database views for the clusters. You might need to use a higher value if there are many clusters
 |hub_fs_volume_size                  |50Gi                           |No           | This value specifies how much storage is allocated for storing logs, manifests, and kubeconfig files for the clusters. You might need to use a higher value if there are many clusters
 |hub_img_volume_size                 |40Gi                           |No           | This value specifies how much storage is allocated for the images of the clusters. You need to allow 1 GB of image storage for each instance of Red Hat Enterprise Linux CoreOS
-|hub_os_images                       |                               |Yes          | Locations of OS Images to be used when generating the discovery ISOs for different OpenShift versions. See [OS images](./README.md#os-images)
+|hub_os_images                       | *null*                        |No           | Locations of OS Images to be used when generating the discovery ISOs for different OpenShift versions. See [OS images](./README.md#os-images)
 
 ## Requirements
 1. An OpenShift Cluster with a subscription for the ACM operator.

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -285,7 +285,9 @@
           resources:
             requests:
               storage: "{{ hub_img_volume_size }}"
+      {% if hub_os_images is defined %}
         osImages: {{ hub_os_images }}
+      {% endif %}
   community.kubernetes.k8s:
     state: present
     definition: "{{ agent_def }}"

--- a/roles/acm_setup/tasks/validation.yml
+++ b/roles/acm_setup/tasks/validation.yml
@@ -2,8 +2,7 @@
 - name: "Assert hub_os_images"
   ansible.builtin.assert:
     that:
-    - hub_os_images is defined
-    - hub_os_images | type_debug == 'list'
+    - hub_os_images is undefined or hub_os_images | type_debug == 'list'
 
 - name: "Get Storage Classes"
   community.kubernetes.k8s_info:


### PR DESCRIPTION
hub_os_images must be optional to work on connected environments.

Test-Hints: no-check