### PR TITLE
Use container to extract rhcos from installer

### DIFF
--- a/roles/acm_hypershift/tasks/kvirt-disconnected.yml
+++ b/roles/acm_hypershift/tasks/kvirt-disconnected.yml
@@ -83,7 +83,7 @@
       {%- else %}
       {{ local_registry_repo }}
       {%- endif %}
-    rhcos_tag: "{{ lookup('community.general.random_string', length=10, upper=false, special=false) }}"
+    rhcos_tag: "{{ lookup('ansible.builtin.password', '/dev/null length=10 chars=ascii_letters') | lower }}"
   ansible.builtin.shell:
     chdir: "{{ ah_tmp_dir }}"
     cmd: >

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -7,12 +7,27 @@
   register: release_image
   changed_when: false
 
-- name: "Write rhcos.json from command (>= 4.8)"
+- name: Write rhcos.json from command (4.16+)
+  when: mor_version is version("4.16", ">=")
+  containers.podman.podman_container:
+    name: extract-rhcos
+    image: quay.io/centos/centos:stream9
+    command:
+      - /bin/bash
+      - -c
+      - "/ocp/openshift-baremetal-install coreos print-stream-json > /ocp/rhcos-test.json"
+    rm: true
+    volumes:
+      - "{{ mor_cache_dir }}/{{ mor_version }}:/ocp"
+
+- name: "Write rhcos.json from command (4.8 - 4.15)"
   ansible.builtin.shell: >
     {{ mor_cache_dir }}/{{ mor_version }}/openshift-baremetal-install coreos print-stream-json >
     {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json
   when:
+    - mor_version is version("4.16", "<")
     - mor_version is version("4.8", ">=")
+  changed_when: true
 
 # TODO: Remove this block when 4.7 is no longer supported
 - name: "Download rhcos.json (< 4.8)"

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -15,7 +15,7 @@
     command:
       - /bin/bash
       - -c
-      - "/ocp/openshift-baremetal-install coreos print-stream-json > /ocp/rhcos-test.json"
+      - "/ocp/openshift-baremetal-install coreos print-stream-json > /ocp/rhcos.json"
     rm: true
     volumes:
       - "{{ mor_cache_dir }}/{{ mor_version }}:/ocp"


### PR DESCRIPTION
Starting 4.16 (nightlies) openshift BM install uses el9 libraries that does not run under el8, due to FIPS compliance. Using a container for this task reduces the need of the ansible controller using el9.

---

- [x]  TestDallas: ocp-4.16-vanilla  -> https://www.distributed-ci.io/jobs/ebdbbff6-4826-4ebc-969d-c73628245826?sort=date&task=12f08727-6a1b-464c-9d50-f54d981560e6

---
Test-Hints: no-check