### PR TITLE
Add general role-collection of useful GitOps tasks

### DIFF
--- a/roles/gitops_operations/README.md
+++ b/roles/gitops_operations/README.md
@@ -1,0 +1,35 @@
+gitops_operations
+=================
+
+This Ansible role contains varios tasks for GitOps operations.
+
+Requirements
+------------
+
+* Access to an OpenShift cluster
+* Properly configured kubeconfig file for cluster access
+
+Role Variables
+--------------
+
+* `gops_kubeconfig_file`: (string) The file path of kubeconfig file for cluster. Default: undefined, If not provided, and no other connection options are provided, the Kubernetes client will attempt to load the default configuration file from ~/.kube/config. Can also be specified via `K8S_AUTH_KUBECONFIG` environment variable.
+* `gops_app_name`: (string) The name of Application in GitOps.
+* `gops_namespace`: (string) The namespace to use.
+
+Example Playbook
+----------------
+
+* Sync repo for ArgoCD if autosync is disabled
+
+```yaml
+    - hosts: localhost
+      tasks:
+
+        - name: Force sync repo for "clusters" Applicaion in ArgoCD
+          include_role:
+            name: gitops_operations
+          tasks_from: sync_repo
+          vars:
+            gops_kubeconfig_file: /path/to/kubeconfig
+            gops_app_name: clusters
+```

--- a/roles/gitops_operations/defaults/main.yml
+++ b/roles/gitops_operations/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Path to kubeconfig file to use for deletion, or K8S_AUTH_KUBECONFIG environment variable is used
+# gops_kubeconfig_file:
+gops_app_name:
+gops_namespace:

--- a/roles/gitops_operations/tasks/main.yml
+++ b/roles/gitops_operations/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Fail if no tasks are specified
+  fail:
+    msg: >
+      Fail, because no tasks specified for role gitops_operations.
+      Use tasks_from keyword to include tasks from collection, don't run this role directly.

--- a/roles/gitops_operations/tasks/sync_repo.yml
+++ b/roles/gitops_operations/tasks/sync_repo.yml
@@ -1,0 +1,14 @@
+---
+- name: Sync repository for ArgoCD with patch merge
+  kubernetes.core.k8s:
+    kubeconfig: "{{ gops_kubeconfig_file | default(omit) }}"
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    name: "{{ gops_app_name }}"
+    namespace: "{{ gops_namespace | default('openshift-gitops') }}"
+    merge_type:
+      - merge
+    definition:
+      operation:
+        sync:
+          revision: "HEAD"


### PR DESCRIPTION
Sometimes there are useful automation tasks that we can use, but they don't deserve a role. Collect them in one role and then use as `tasks_from` of specific file.