### PR TITLE
Replace openshift-baremetal-install with openshift-install in 4.16+

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.9.EPOCH
+Version:        0.10.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -51,6 +51,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Thu May  9 2024 Tony Garcia <tonyg@redhat.com> - 0.10.EPOCH-VERS
+- Version bump in the collection due to baremetal installer 4.16+
+
 * Tue Apr 30 2024 Beto Rodriguez <josearod@redhat.com> - 0.9.EPOCH-VERS
 - Dependency for acm_* roles
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.9.0
+version: 0.10.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/installer/tasks/10_get_oc.yml
+++ b/roles/installer/tasks/10_get_oc.yml
@@ -29,7 +29,7 @@
 - name: Find any existing /usr/local/bin OpenShift binaries
   find:
     paths: /usr/local/bin
-    patterns: 'oc,openshift-baremetal-install,kubectl'
+    patterns: "oc,{{ cmd }},kubectl"
   register: binary_results
   tags:
     - cleanup

--- a/roles/installer/tasks/10_get_oc.yml
+++ b/roles/installer/tasks/10_get_oc.yml
@@ -29,7 +29,7 @@
 - name: Find any existing /usr/local/bin OpenShift binaries
   find:
     paths: /usr/local/bin
-    patterns: "oc,{{ cmd }},kubectl"
+    patterns: "oc,{{ installer_cmd }},kubectl"
   register: binary_results
   tags:
     - cleanup

--- a/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -23,7 +23,7 @@
 - name: Find any existing /usr/local/bin OpenShift binaries on registry host
   find:
     paths: /usr/local/bin
-    patterns: 'oc,openshift-baremetal-install,kubectl'
+    patterns: "oc,{{ cmd }},kubectl"
   register: binary_results
   when: groups['registry_host'][0] != groups['provisioner'][0]
   delegate_to: "{{ groups['registry_host'][0] }}"

--- a/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -23,7 +23,7 @@
 - name: Find any existing /usr/local/bin OpenShift binaries on registry host
   find:
     paths: /usr/local/bin
-    patterns: "oc,{{ cmd }},kubectl"
+    patterns: "oc,{{ installer_cmd }},kubectl"
   register: binary_results
   when: groups['registry_host'][0] != groups['provisioner'][0]
   delegate_to: "{{ groups['registry_host'][0] }}"

--- a/roles/installer/tasks/20_extract_installer.yml
+++ b/roles/installer/tasks/20_extract_installer.yml
@@ -85,7 +85,7 @@
   command: >
     /usr/local/bin/oc adm release extract
     --registry-config {{ pullsecret_file | quote }}
-    --command={{ cmd |quote }}
+    --command={{ installer_cmd |quote }}
     --to {{ tempdir_loc }} {{ disconnected_installer | ternary(disconnected_installer, release_image) }}
   args:
     chdir: "{{ tempdir }}"
@@ -106,8 +106,8 @@
 
 - name: OFFLINE mode requires installer pre-extracted
   get_url:
-    url: "{{ webserver_url }}/{{ version }}/{{ cmd }}"
-    dest: "{{ tempdir }}/{{ cmd }}"
+    url: "{{ webserver_url }}/{{ version }}/{{ installer_cmd }}"
+    dest: "{{ tempdir }}/{{ installer_cmd }}"
   register: result
   retries: 3
   delay: 10
@@ -118,7 +118,7 @@
 
 - name: Copy install binary to /usr/local/bin
   copy:
-    src: "{{ tempdir_loc }}/{{ cmd }}"
+    src: "{{ tempdir_loc }}/{{ installer_cmd }}"
     dest: /usr/local/bin/
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
@@ -132,7 +132,7 @@
   fetch:
     dest: /tmp/
     flat: true
-    src: "{{ tempdir_loc }}/{{ cmd }}"
+    src: "{{ tempdir_loc }}/{{ installer_cmd }}"
   when: registry_creation|bool
   delegate_to: "{{ groups['registry_host'][0] }}"
   tags:
@@ -140,8 +140,8 @@
 
 - name: Copy the install binary from control machine to the provisioner host
   copy:
-    src: /tmp/{{ cmd }}
-    dest: "/usr/local/bin/{{ cmd }}"
+    src: /tmp/{{ installer_cmd }}
+    dest: "/usr/local/bin/{{ installer_cmd }}"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: 0755
@@ -154,7 +154,7 @@
 
 - name: Remove the temporary copy of the install binary on control machine
   file:
-    path: "/tmp/{{ cmd }}"
+    path: "/tmp/{{ installer_cmd }}"
     state: absent
   when:
     - registry_creation|bool

--- a/roles/installer/tasks/20_extract_installer.yml
+++ b/roles/installer/tasks/20_extract_installer.yml
@@ -81,7 +81,6 @@
   tags:
     - extract
 
-# on my other system tempdir_loc required .path (in case you need to revert)
 - name: Extracting the installer
   command: >
     /usr/local/bin/oc adm release extract
@@ -105,21 +104,10 @@
   tags:
     - extract
 
-# - name: Extracting the installer
-#   shell: >
-#     /usr/local/bin/oc adm release extract
-#     --registry-config {{ pullsecret_file | quote }}
-#     --command={{ cmd |quote }}
-#     --to {{ tempdir | quote }} {{ disconnected_installer | ternary(disconnected_installer, release_image) }}
-#  args:
-#    chdir: "{{ tempdir }}"
-#    executable: /bin/bash
-#  tags: extract
-
-- name: OFFLINE mode requires openshift-baremetal-install pre-extracted
+- name: OFFLINE mode requires installer pre-extracted
   get_url:
-    url: "{{ webserver_url }}/{{ version }}/openshift-baremetal-install"
-    dest: "{{ tempdir }}/openshift-baremetal-install"
+    url: "{{ webserver_url }}/{{ version }}/{{ cmd }}"
+    dest: "{{ tempdir }}/{{ cmd }}"
   register: result
   retries: 3
   delay: 10
@@ -128,10 +116,9 @@
   tags:
     - extract
 
-- name: Copy openshift-baremetal-install binary to /usr/local/bin
+- name: Copy install binary to /usr/local/bin
   copy:
-    # src: "{{ tempdir_loc.path }}/openshift-baremetal-install"
-    src: "{{ tempdir_loc }}/openshift-baremetal-install"
+    src: "{{ tempdir_loc }}/{{ cmd }}"
     dest: /usr/local/bin/
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
@@ -141,21 +128,20 @@
   become: true
   tags: extract
 
-- name: Get the openshift-baremetal-install from registry host into temp file on control machine
+- name: Get the install from registry host into temp file on control machine
   fetch:
     dest: /tmp/
     flat: true
-    # src: "{{ tempdir_loc.path }}/openshift-baremetal-install"
-    src: "{{ tempdir_loc }}/openshift-baremetal-install"
+    src: "{{ tempdir_loc }}/{{ cmd }}"
   when: registry_creation|bool
   delegate_to: "{{ groups['registry_host'][0] }}"
   tags:
     - extract
 
-- name: Copy the openshift-baremetal-install binary from control machine to the provisioner host
+- name: Copy the install binary from control machine to the provisioner host
   copy:
-    src: /tmp/openshift-baremetal-install
-    dest: "/usr/local/bin/openshift-baremetal-install"
+    src: /tmp/{{ cmd }}
+    dest: "/usr/local/bin/{{ cmd }}"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: 0755
@@ -166,9 +152,9 @@
   tags:
     - extract
 
-- name: Remove the temporary copy of the openshift-baremetal-install binary on control machine
+- name: Remove the temporary copy of the install binary on control machine
   file:
-    path: "/tmp/openshift-baremetal-install"
+    path: "/tmp/{{ cmd }}"
     state: absent
   when:
     - registry_creation|bool

--- a/roles/installer/tasks/23_rhcos_image_paths.yml
+++ b/roles/installer/tasks/23_rhcos_image_paths.yml
@@ -3,7 +3,7 @@
   block:
     - name: Get COMMIT_ID
       shell: |
-        /usr/local/bin/{{ cmd }} version | grep '^built from commit' | awk '{print $4}'
+        /usr/local/bin/{{ installer_cmd }} version | grep '^built from commit' | awk '{print $4}'
       register: commit_id
       tags: rhcospath
 
@@ -40,7 +40,7 @@
   block:
     - name: Extract rhcos.json
       shell: |
-        /usr/local/bin/{{ cmd }} coreos print-stream-json
+        /usr/local/bin/{{ installer_cmd }} coreos print-stream-json
       register: rhcos_json_stream
       retries: 3
       delay: 10

--- a/roles/installer/tasks/23_rhcos_image_paths.yml
+++ b/roles/installer/tasks/23_rhcos_image_paths.yml
@@ -3,7 +3,7 @@
   block:
     - name: Get COMMIT_ID
       shell: |
-        /usr/local/bin/openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}'
+        /usr/local/bin/{{ cmd }} version | grep '^built from commit' | awk '{print $4}'
       register: commit_id
       tags: rhcospath
 
@@ -40,7 +40,7 @@
   block:
     - name: Extract rhcos.json
       shell: |
-        /usr/local/bin/openshift-baremetal-install coreos print-stream-json
+        /usr/local/bin/{{ cmd }} coreos print-stream-json
       register: rhcos_json_stream
       retries: 3
       delay: 10

--- a/roles/installer/tasks/40_create_manifest.yml
+++ b/roles/installer/tasks/40_create_manifest.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create OpenShift Manifest
   shell: |
-    /usr/local/bin/openshift-baremetal-install --dir {{ dir }} create manifests
+    /usr/local/bin/{{ cmd }} --dir {{ dir }} create manifests
   tags: manifests
 
 - name: Ensure the manifests dir is owned by {{ ansible_user }}

--- a/roles/installer/tasks/40_create_manifest.yml
+++ b/roles/installer/tasks/40_create_manifest.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create OpenShift Manifest
   shell: |
-    /usr/local/bin/{{ cmd }} --dir {{ dir }} create manifests
+    /usr/local/bin/{{ installer_cmd }} --dir {{ dir }} create manifests
   tags: manifests
 
 - name: Ensure the manifests dir is owned by {{ ansible_user }}

--- a/roles/installer/tasks/55_customize_filesystem.yml
+++ b/roles/installer/tasks/55_customize_filesystem.yml
@@ -20,7 +20,7 @@
 
     - name: Create OpenShift Ignition Configs
       shell: |
-        /usr/local/bin/{{ cmd }} --dir {{ dir }} create ignition-configs
+        /usr/local/bin/{{ installer_cmd }} --dir {{ dir }} create ignition-configs
 
     - name: Copy Ignition Config Files
       copy:

--- a/roles/installer/tasks/55_customize_filesystem.yml
+++ b/roles/installer/tasks/55_customize_filesystem.yml
@@ -20,7 +20,7 @@
 
     - name: Create OpenShift Ignition Configs
       shell: |
-        /usr/local/bin/openshift-baremetal-install --dir {{ dir }} create ignition-configs
+        /usr/local/bin/{{ cmd }} --dir {{ dir }} create ignition-configs
 
     - name: Copy Ignition Config Files
       copy:

--- a/roles/installer/tasks/60_deploy_ocp.yml
+++ b/roles/installer/tasks/60_deploy_ocp.yml
@@ -13,7 +13,7 @@
 
 - name: Deploy OpenShift Cluster
   shell: |
-    /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug create cluster
+    /usr/local/bin/{{ cmd }} --dir {{ dir }} --log-level debug create cluster
   when:
     - increase_bootstrap_timeout is not defined
     - increase_install_timeout is not defined
@@ -23,7 +23,7 @@
   block:
     - name: Run OpenShift Cluster install as async task
       shell: |
-        /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug create cluster
+        /usr/local/bin/{{ cmd }} --dir {{ dir }} --log-level debug create cluster
       async: 3600
       poll: 0
       ignore_errors: true
@@ -37,7 +37,7 @@
 
     - name: Wait for Bootstrap Complete
       shell: |
-        /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug wait-for bootstrap-complete
+        /usr/local/bin/{{ cmd }} --dir {{ dir }} --log-level debug wait-for bootstrap-complete
       register: wait_for_bootstrap_result
       until: wait_for_bootstrap_result is succeeded
       retries: "{{ increase_bootstrap_timeout|default(1)|int }}"
@@ -45,7 +45,7 @@
 
     - name: Wait for Install Complete
       shell: |
-        /usr/local/bin/openshift-baremetal-install --dir {{ dir }} --log-level debug wait-for install-complete
+        /usr/local/bin/{{ cmd }} --dir {{ dir }} --log-level debug wait-for install-complete
       register: wait_for_install_result
       until: wait_for_install_result is succeeded
       retries: "{{ increase_install_timeout|default(1)|int }}"

--- a/roles/installer/tasks/60_deploy_ocp.yml
+++ b/roles/installer/tasks/60_deploy_ocp.yml
@@ -13,7 +13,7 @@
 
 - name: Deploy OpenShift Cluster
   shell: |
-    /usr/local/bin/{{ cmd }} --dir {{ dir }} --log-level debug create cluster
+    /usr/local/bin/{{ installer_cmd }} --dir {{ dir }} --log-level debug create cluster
   when:
     - increase_bootstrap_timeout is not defined
     - increase_install_timeout is not defined
@@ -23,7 +23,7 @@
   block:
     - name: Run OpenShift Cluster install as async task
       shell: |
-        /usr/local/bin/{{ cmd }} --dir {{ dir }} --log-level debug create cluster
+        /usr/local/bin/{{ installer_cmd }} --dir {{ dir }} --log-level debug create cluster
       async: 3600
       poll: 0
       ignore_errors: true
@@ -37,7 +37,7 @@
 
     - name: Wait for Bootstrap Complete
       shell: |
-        /usr/local/bin/{{ cmd }} --dir {{ dir }} --log-level debug wait-for bootstrap-complete
+        /usr/local/bin/{{ installer_cmd }} --dir {{ dir }} --log-level debug wait-for bootstrap-complete
       register: wait_for_bootstrap_result
       until: wait_for_bootstrap_result is succeeded
       retries: "{{ increase_bootstrap_timeout|default(1)|int }}"
@@ -45,7 +45,7 @@
 
     - name: Wait for Install Complete
       shell: |
-        /usr/local/bin/{{ cmd }} --dir {{ dir }} --log-level debug wait-for install-complete
+        /usr/local/bin/{{ installer_cmd }} --dir {{ dir }} --log-level debug wait-for install-complete
       register: wait_for_install_result
       until: wait_for_install_result is succeeded
       retries: "{{ increase_install_timeout|default(1)|int }}"

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -1,12 +1,9 @@
 ---
 # vars file for installer
 pullsecret_file: "{{ dir }}/pull-secret.txt"
-cmd: >-
-  {%- if release_version is version('4.16', ">=") and ansible_distribution_major_version == '8' -%}
-  openshift-install
-  {%- else -%}
-  openshift-baremetal-install
-  {%- endif -%}
+installer_cmd: >-
+  {{ release_version is version('4.16', '>=') and ansible_distribution_major_version == '8' |
+  ternary('openshift-install', 'openshift-baremetal-install') }}
 default_libvirt_pool_dir:
   - /var/lib/libvirt/images/
   - /var/lib/libvirt/openshift-images/

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -2,7 +2,7 @@
 # vars file for installer
 pullsecret_file: "{{ dir }}/pull-secret.txt"
 installer_cmd: >-
-  {{ (release_version is version('4.16', '>=') and ansible_distribution_major_version == '8') |
+  {{ release_version is version('4.16', '>=') |
   ternary('openshift-install', 'openshift-baremetal-install') }}
 default_libvirt_pool_dir:
   - /var/lib/libvirt/images/

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # vars file for installer
 pullsecret_file: "{{ dir }}/pull-secret.txt"
-cmd: >
+cmd: >-
   {% if release_version is version('4.16', ">=") and ansible_distribution_major_version == '8' -%}
   openshift-install
   {% else -%}

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -2,7 +2,7 @@
 # vars file for installer
 pullsecret_file: "{{ dir }}/pull-secret.txt"
 installer_cmd: >-
-  {{ release_version is version('4.16', '>=') and ansible_distribution_major_version == '8' |
+  {{ (release_version is version('4.16', '>=') and ansible_distribution_major_version == '8') |
   ternary('openshift-install', 'openshift-baremetal-install') }}
 default_libvirt_pool_dir:
   - /var/lib/libvirt/images/

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -1,7 +1,12 @@
 ---
 # vars file for installer
 pullsecret_file: "{{ dir }}/pull-secret.txt"
-cmd: openshift-baremetal-install
+cmd: >
+  {% if release_version is version('4.16', ">=") and ansible_distribution_major_version == '8' -%}
+  openshift-install
+  {% else -%}
+  openshift-baremetal-install
+  {% endif -%}
 default_libvirt_pool_dir:
   - /var/lib/libvirt/images/
   - /var/lib/libvirt/openshift-images/

--- a/roles/installer/vars/main.yml
+++ b/roles/installer/vars/main.yml
@@ -2,11 +2,11 @@
 # vars file for installer
 pullsecret_file: "{{ dir }}/pull-secret.txt"
 cmd: >-
-  {% if release_version is version('4.16', ">=") and ansible_distribution_major_version == '8' -%}
+  {%- if release_version is version('4.16', ">=") and ansible_distribution_major_version == '8' -%}
   openshift-install
-  {% else -%}
+  {%- else -%}
   openshift-baremetal-install
-  {% endif -%}
+  {%- endif -%}
 default_libvirt_pool_dir:
   - /var/lib/libvirt/images/
   - /var/lib/libvirt/openshift-images/

--- a/roles/mirror_ocp_release/README.md
+++ b/roles/mirror_ocp_release/README.md
@@ -12,6 +12,7 @@ If enabled, the role requires an container registry to mirror the OCP container 
 | mor_cache_dir                | /var/lib/dci-openshift-agent/releases | No       | Base directory that will hold the OCP version binaries and OS images                           |
 | mor_force                    | false                                 | No       | If passed as true, the role will re-download all the OCP release resources                     |
 | mor_install_type             | "ipi"                                 | No       | Mirrors image required for the install type (ipi, acm, assisted, sno, upi, vsphere)            |
+| mor_installer                | \<See Description\>                   | No       | Depending on the OCP 4.16+:openshift-install, 4.16-:openshift-baremetal-install                |
 | mor_mirror_container_images  | true                                  | No       | Mirror all container images from upstream container registries to the provided registry        |
 | mor_mirror_disk_images       | true                                  | No       | Download all disk images depending on which install type                                       |
 | mor_oc                       | undefined                             | Yes      | Path to the oc binary (stable is recommended).                                                 |

--- a/roles/mirror_ocp_release/defaults/main.yml
+++ b/roles/mirror_ocp_release/defaults/main.yml
@@ -2,6 +2,9 @@
 mor_base_version: "{{ mor_version.split('.')[:2] | join('.') }}"
 mor_cache_dir: "/var/lib/dci-openshift-agent/releases"
 mor_install_type: "ipi"
+mor_installer: >-
+  {{ mor_version is version('4.16', '>=') |
+  ternary('openshift-install', 'openshift-baremetal-install') }}
 mor_owner: "{{ ansible_user_uid }}"
 mor_group: "{{ ansible_user_gid }}"
 mor_force: false

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -11,7 +11,7 @@
   when:
     - mor_version is version("4.8", ">=")
   vars:
-    _cmd: >
+    _cmd: >-
       {% if ansible_distribution_major_version == '8' and mor_version is version("4.16", ">=") -%}
       openshift-install
       {% else -%}

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -10,15 +10,8 @@
 - name: "Write rhcos.json from command 4.8+"
   when:
     - mor_version is version("4.8", ">=")
-  vars:
-    _cmd: >-
-      {%- if ansible_distribution_major_version == '8' and mor_version is version("4.16", ">=") -%}
-      openshift-install
-      {%- else -%}
-      openshift-baremetal-install
-      {%- endif -%}
   ansible.builtin.shell: >
-    {{ mor_cache_dir }}/{{ mor_version }}/{{ _cmd }} coreos print-stream-json >
+    {{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }} coreos print-stream-json >
     {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json
   changed_when: true
 

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -7,26 +7,19 @@
   register: release_image
   changed_when: false
 
-- name: Write rhcos.json from command (4.16+)
-  when: mor_version is version("4.16", ">=")
-  containers.podman.podman_container:
-    name: extract-rhcos
-    image: quay.io/centos/centos:stream9
-    command:
-      - /bin/bash
-      - -c
-      - "/ocp/openshift-baremetal-install coreos print-stream-json > /ocp/rhcos.json"
-    rm: true
-    volumes:
-      - "{{ mor_cache_dir }}/{{ mor_version }}:/ocp"
-
-- name: "Write rhcos.json from command (4.8 - 4.15)"
-  ansible.builtin.shell: >
-    {{ mor_cache_dir }}/{{ mor_version }}/openshift-baremetal-install coreos print-stream-json >
-    {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json
+- name: "Write rhcos.json from command 4.8+"
   when:
-    - mor_version is version("4.16", "<")
     - mor_version is version("4.8", ">=")
+  vars:
+    _cmd: >
+      {% if ansible_distribution_major_version == '8' and mor_version is version("4.16", ">=") -%}
+      openshift-install
+      {% else -%}
+      openshift-baremetal-install
+      {% endif -%}
+  ansible.builtin.shell: >
+    {{ mor_cache_dir }}/{{ mor_version }}/{{ _cmd }} coreos print-stream-json >
+    {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json
   changed_when: true
 
 # TODO: Remove this block when 4.7 is no longer supported

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -12,11 +12,11 @@
     - mor_version is version("4.8", ">=")
   vars:
     _cmd: >-
-      {% if ansible_distribution_major_version == '8' and mor_version is version("4.16", ">=") -%}
+      {%- if ansible_distribution_major_version == '8' and mor_version is version("4.16", ">=") -%}
       openshift-install
-      {% else -%}
+      {%- else -%}
       openshift-baremetal-install
-      {% endif -%}
+      {%- endif -%}
   ansible.builtin.shell: >
     {{ mor_cache_dir }}/{{ mor_version }}/{{ _cmd }} coreos print-stream-json >
     {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json

--- a/roles/mirror_ocp_release/tasks/installer.yml
+++ b/roles/mirror_ocp_release/tasks/installer.yml
@@ -1,15 +1,19 @@
 ---
 - name: "Check if installer has been extracted"
   ansible.builtin.stat:
-    path: "{{ mor_cache_dir }}/{{ mor_version }}/openshift-baremetal-install"
+    path: "{{ mor_cache_dir }}/{{ mor_version }}/{{ item }}"
     get_checksum: false
   register: target
+  loop:
+    - openshift-baremetal-install
+    - openshift-install
   when:
-    - not mor_force  # we don't care to stat files if we're forcing
+    - not mor_force | bool # we don't care to stat files if we're forcing
 
 - name: "Extract installer command from release image"
   when:
-    - mor_force or not target.stat.exists
+    - ((mor_force | bool) or
+      (not target | json_query('results[*].stat.exists') | unique == [true]))
   ansible.builtin.command: >
     {{ mor_oc }} adm release extract
     --registry-config={{ mor_auths_file }}
@@ -26,10 +30,13 @@
 
 - name: "Make installer command readable from HTTP"
   ansible.builtin.file:
-    path: "{{ mor_cache_dir }}/{{ mor_version }}/openshift-baremetal-install"
+    path: "{{ mor_cache_dir }}/{{ mor_version }}/{{ item }}"
     state: file
     owner: "{{ mor_owner }}"
     group: "{{ mor_group }}"
     mode: "0755"
     setype: "httpd_sys_content_t"
+  loop:
+    - openshift-baremetal-install
+    - openshift-install
 ...

--- a/roles/mirror_ocp_release/tasks/installer.yml
+++ b/roles/mirror_ocp_release/tasks/installer.yml
@@ -8,18 +8,21 @@
     - not mor_force  # we don't care to stat files if we're forcing
 
 - name: "Extract installer command from release image"
+  when:
+    - mor_force or not target.stat.exists
   ansible.builtin.command: >
     {{ mor_oc }} adm release extract
     --registry-config={{ mor_auths_file }}
-    --command=openshift-baremetal-install
+    --command={{ item }}
     --from {{ mor_pull_url }}
     --to "{{ mor_cache_dir }}/{{ mor_version }}"
   register: extract_cmd
   until: extract_cmd is succeeded
   retries: 9
   delay: 10
-  when:
-    - mor_force or not target.stat.exists
+  loop:
+    - openshift-baremetal-install
+    - openshift-install
 
 - name: "Make installer command readable from HTTP"
   ansible.builtin.file:

--- a/roles/mirror_ocp_release/tasks/installer.yml
+++ b/roles/mirror_ocp_release/tasks/installer.yml
@@ -1,42 +1,32 @@
 ---
 - name: "Check if installer has been extracted"
   ansible.builtin.stat:
-    path: "{{ mor_cache_dir }}/{{ mor_version }}/{{ item }}"
+    path: "{{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }}"
     get_checksum: false
   register: target
-  loop:
-    - openshift-baremetal-install
-    - openshift-install
   when:
     - not mor_force | bool # we don't care to stat files if we're forcing
 
 - name: "Extract installer command from release image"
   when:
-    - ((mor_force | bool) or
-      (not target | json_query('results[*].stat.exists') | unique == [true]))
+    - mor_force | bool or not target.stat.exists
   ansible.builtin.command: >
     {{ mor_oc }} adm release extract
     --registry-config={{ mor_auths_file }}
-    --command={{ item }}
+    --command={{ mor_installer }}
     --from {{ mor_pull_url }}
     --to "{{ mor_cache_dir }}/{{ mor_version }}"
   register: extract_cmd
   until: extract_cmd is succeeded
   retries: 9
   delay: 10
-  loop:
-    - openshift-baremetal-install
-    - openshift-install
 
 - name: "Make installer command readable from HTTP"
   ansible.builtin.file:
-    path: "{{ mor_cache_dir }}/{{ mor_version }}/{{ item }}"
+    path: "{{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }}"
     state: file
     owner: "{{ mor_owner }}"
     group: "{{ mor_group }}"
     mode: "0755"
     setype: "httpd_sys_content_t"
-  loop:
-    - openshift-baremetal-install
-    - openshift-install
 ...

--- a/roles/mirror_ocp_release/tasks/unpack.yml
+++ b/roles/mirror_ocp_release/tasks/unpack.yml
@@ -20,21 +20,44 @@
   when:
     - mor_force or not unpacked.stat.exists
 
-- name: Extract el8 client for 4.16+
+- name: Tasks for el8 on 4.16+
   when:
     - ansible_distribution_major_version == '8'
     - mor_version is version("4.16", ">=")
-  ansible.builtin.command: >
-    {{ mor_oc }} adm release extract
-    --registry-config={{ mor_auths_file }}
-    --command=oc.rhel8
-    --from {{ mor_pull_url }}
-    --to "{{ mor_cache_dir }}/{{ mor_version }}" &&
-    mv -f "{{ mor_cache_dir }}/{{ mor_version }}/oc.rhel8"
-    "{{ mor_cache_dir }}/{{ mor_version }}/oc"
-  register: extract_cmd
-  until: extract_cmd is succeeded
-  retries: 9
-  delay: 10
+  block:
+    - name: Create temporary directory for oc client
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: _mor_tmp_dir.
+      register: _mor_tmp_dir
+
+    - name: Download required latest openshift client for el8 in 4.16+
+      ansible.builtin.unarchive:
+        src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz"
+        dest: "{{ _mor_tmp_dir.path }}"
+        remote_src: true
+        mode: "0755"
+      register: _mor_result
+      retries: 3
+      delay: 10
+      until: _mor_result is not failed
+
+    - name: Extract el8 client for 4.16+
+      ansible.builtin.command: >
+        {{ _mor_tmp_dir.path }}/oc adm release extract
+        --registry-config={{ mor_auths_file }}
+        --command=oc.rhel8
+        --from {{ mor_pull_url }}
+        --to "{{ mor_cache_dir }}/{{ mor_version }}"
+      register: _mor_extract_cmd
+      until: _mor_extract_cmd is succeeded
+      retries: 9
+      delay: 10
+      changed_when: false
+
+    - name: Delete temporary directory for oc client
+      ansible.builtin.file:
+        path: "{{ _mor_tmp_dir.path }}"
+        state: absent
 
 ...

--- a/roles/mirror_ocp_release/tasks/unpack.yml
+++ b/roles/mirror_ocp_release/tasks/unpack.yml
@@ -19,4 +19,22 @@
       - README.md
   when:
     - mor_force or not unpacked.stat.exists
+
+- name: Extract el8 client for 4.16+
+  when:
+    - ansible_distribution_major_version == '8'
+    - mor_version is version("4.16", ">=")
+  ansible.builtin.command: >
+    {{ mor_oc }} adm release extract
+    --registry-config={{ mor_auths_file }}
+    --command=oc.rhel8
+    --from {{ mor_pull_url }}
+    --to "{{ mor_cache_dir }}/{{ mor_version }}" &&
+    mv -f "{{ mor_cache_dir }}/{{ mor_version }}/oc.rhel8"
+    "{{ mor_cache_dir }}/{{ mor_version }}/oc"
+  register: extract_cmd
+  until: extract_cmd is succeeded
+  retries: 9
+  delay: 10
+
 ...


### PR DESCRIPTION
The baremetal installer (openshift-baremetal-install) drops support to el8 starting on 4.16. Another installer (openshift-install) provides support to it for el8. Doing a drop-in replacement when OCP release is 4.16+

For disconnected environments, when mirror the ocp release is required, extract both installers to be ready during the install.

---

- [x] TestDallas: ocp-4.16-vanilla  :arrow_right:   https://www.distributed-ci.io/jobs/5f87f994-b35b-44aa-afc9-f40a7cdfb5b7
- [x] TestBos2: virt 4.16 :arrow_right: https://www.distributed-ci.io/jobs/4aaa654a-0899-492f-9de8-d5dde40e390f 
- [x] TestBos2: virt 4.15 :arrow_right:  https://www.distributed-ci.io/jobs/4ae86ad0-4970-4b77-bf53-3a69b63815b2
- [x] TestDallas: ocp-4.15-vanilla :arrow_right:   https://www.distributed-ci.io/jobs/7b278fb8-d00a-44b2-abba-6fcb89c19fdf/jobStates
- [x] TestDallas: ocp-4.17-vanilla :arrow_right:  https://www.distributed-ci.io/jobs/94457317-f301-4aeb-90eb-5f8850344792/jobStates
---

TestBos2: virt
Test-Hints: no-check