### PR TITLE
Disable jinja spacing in ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -21,6 +21,7 @@ skip_list:
 
 warn_list:
   - ignore-errors
+  - jinja[spacing]   # multiline is not working https://github.com/ansible/ansible-lint/discussions/3015
   - no-changed-when
   - yaml[line-length]
 ...

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,8 +51,8 @@ jobs:
           # export diff sans headers
           diff -u0 branch.output main.output | tail -n +3 > diff.raw
           # Get warnings out of the diff
-          grep -P '\(warning\)(\x1B\[0m)?$' diff.raw > diff.warnings
-          grep -vP '\(warning\)(\x1B\[0m)?$' diff.raw > diff.output
+          grep -P '\x1B\[33m|\(warning\)(\x1B\[0m)?$' diff.raw > diff.warnings
+          grep -vP '\x1B\[33m|\(warning\)(\x1B\[0m)?$' diff.raw > diff.output
           echo "## Improvements over main branch:" | tee -a ${GITHUB_STEP_SUMMARY}
           echo '```diff' >> ${GITHUB_STEP_SUMMARY}
           grep '^+' diff.output |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,7 +69,7 @@ jobs:
           echo '```' >> ${GITHUB_STEP_SUMMARY}
           echo "## Warnings from main branch:" | tee -a ${GITHUB_STEP_SUMMARY}
           echo '```diff' >> ${GITHUB_STEP_SUMMARY}
-          grep '^-' diff.warning |
+          grep '^-' diff.warnings |
             sed -e 's/^-/-WARNING: /' |
             sed -r 's/\x1B\[[0-9]{1,2}(;[0-9]{1,2})?[mGK]//g' |
             tee -a ${GITHUB_STEP_SUMMARY}


### PR DESCRIPTION
The jinja spacing check is not working as expected in multiline, our code base has many mulit-line jinja templates that is being flagged because of this check.
https://github.com/ansible/ansible-lint/discussions/3015

---

TestDallas: ocp-4.14-vanilla
Test-Hint: no-check