### PR TITLE
HCP - Patch registry overrides

### DIFF
--- a/roles/acm_hypershift/tasks/delete-cluster.yml
+++ b/roles/acm_hypershift/tasks/delete-cluster.yml
@@ -15,8 +15,21 @@
       --name={{ ah_cluster_generated_name }}
       --namespace={{ ah_clusters_ns }}
       --infra-id={{ ah_cluster_generated_name }}
-      --cluster-grace-period 0
   changed_when: false
   when:
     - hosted_cluster.resources | length == 1
+
+- name: Wait for HCP to be deleted
+  community.kubernetes.k8s_info:
+    api_version: hypershift.openshift.io/v1beta1
+    kind: HostedCluster
+    namespace: "{{ ah_clusters_ns }}"
+    name: "{{ ah_cluster_generated_name }}"
+  retries: 10
+  delay: 6
+  register: _hosted_cluster
+  until:
+    - _hosted_cluster is defined
+    - _hosted_cluster.resources is defined
+    - _hosted_cluster.resources | length == 0
 ...

--- a/roles/acm_hypershift/tasks/download-cli.yml
+++ b/roles/acm_hypershift/tasks/download-cli.yml
@@ -50,4 +50,8 @@
 - name: Set hcp cli path
   ansible.builtin.set_fact:
     ah_hcp_cli_path: "{{ ah_tmp_dir }}/hcp"
+
+- name: Set oc cli path
+  ansible.builtin.set_fact:
+    ah_oc_cli_path: "{{ ah_tmp_dir }}/oc"
 ...

--- a/roles/acm_hypershift/tasks/kvirt-disconnected.yml
+++ b/roles/acm_hypershift/tasks/kvirt-disconnected.yml
@@ -4,7 +4,7 @@
     chdir: "{{ ah_tmp_dir }}"
     cmd: >
       set -x -o pipefail ;
-      oc adm release info
+      {{ ah_oc_cli_path }} adm release info
       {{ ah_release_image }}
       --registry-config={{ ah_pullsecret_file }} |
       grep -w hypershift |
@@ -34,24 +34,25 @@
 
 - name: Set Control-Plane Operator annotation
   ansible.builtin.set_fact:
-    cpo_annotation: "hypershift.openshift.io/control-plane-operator-image={{ cpo_image_path }} "
+    # cpo_annotation: "hypershift.openshift.io/control-plane-operator-image={{ cpo_image_path }} "
+    cpo_annotation: "hypershift.openshift.io/release-image=quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e7508c7a1e7129100988dae0c28cf26c11369128f18dc095f93b834fdb080b2c "
 
-- name: Fail if Control-Plane Operator image is not pullable from local registry
-  ansible.builtin.command: >
-    skopeo inspect
-    --no-tags
-    docker://{{ cpo_image_path }}
-  no_log: true
-  register: skopeo_result
-  changed_when: false
-  failed_when: skopeo_result.rc != 0
+# - name: Fail if Control-Plane Operator image is not pullable from local registry
+#   ansible.builtin.command: >
+#     skopeo inspect
+#     --no-tags
+#     docker://{{ cpo_image_path }}
+#   no_log: true
+#   register: skopeo_result
+#   changed_when: false
+#   failed_when: skopeo_result.rc != 0
 
 - name: Extract the RHCOS images file
   ansible.builtin.shell:
     chdir: "{{ ah_tmp_dir }}"
     cmd: >
       set -x;
-      oc image extract
+      {{ ah_oc_cli_path }} image extract
       {{ ah_release_image }}
       --confirm
       --file /release-manifests/0000_50_installer_coreos-bootimages.yaml
@@ -88,9 +89,9 @@
     chdir: "{{ ah_tmp_dir }}"
     cmd: >
       set -x;
-      oc image mirror
+      {{ ah_oc_cli_path }} image mirror
       {{ kvirt_rhcos_digest }}
-      {{ local_registry_path }}:{{ rhcos_tag }}
+      registry.dfwt5g.lab:4443/ocp-4.14/4.14.0-0.nightly-2024-05-10-212837:{{ rhcos_tag }}
       --registry-config={{ ah_pullsecret_file }}
   retries: 3
   delay: 10

--- a/roles/acm_hypershift/tasks/main.yml
+++ b/roles/acm_hypershift/tasks/main.yml
@@ -29,26 +29,71 @@
     cmd: >
       set -x -o pipefail;
       mkdir -p idms icsp;
-      for f in $(oc get imageContentSourcePolicy -o name); do
-        oc get ${f} -o yaml > icsp/$(basename ${f}).yaml;
+      for f in $({{ ah_oc_cli_path }} get imageContentSourcePolicy -o name); do
+        {{ ah_oc_cli_path }} get ${f} -o yaml > icsp/$(basename ${f}).yaml;
       done;
       for f in icsp/*.yaml; do
-        oc adm migrate icsp ${f} --dest-dir idms;
+        {{ ah_oc_cli_path }} adm migrate icsp ${f} --dest-dir idms;
       done;
       for f in idms/*.yaml; do
         sed -i '/creationTimestamp\|generation\|resourceVersion\|uid\|annotations\|last-applied-configuration/d' "${f}";
       done;
-      oc apply --force --overwrite=true -f idms
+      {{ ah_oc_cli_path }} apply --force --overwrite=true -f idms
   register: migration_result
   changed_when: migration_result.rc != 0
   when:
     - mc_icsp is defined
     - mc_icsp.resources | length > 0
 
+- name: Get Management ICSP
+  community.kubernetes.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ImageDigestMirrorSet
+  register: mc_idms
+
+- name: "Patch hypershift operator registry overrides"
+  ansible.builtin.shell:
+    cmd: |
+      REGISTRY_OVERRIDES=$({{ ah_oc_cli_path }} get idms -A -o=json | jq -r '.items[].spec.imageDigestMirrors[] | .source+"="+.mirrors[0]' | tr '\n' ',' | sed 's/.$//')
+      EXISTING_ARGS=$({{ ah_oc_cli_path }} get deployment -n hypershift operator -o=jsonpath='{.spec.template.spec.containers[?(@.name=="operator")].args}' | tr -d '[]')
+      if [[ ! "$EXISTING_ARGS" =~ --registry-overrides= ]]; then
+        NEW_ARGS="${EXISTING_ARGS},\"--registry-overrides=${REGISTRY_OVERRIDES}\""
+      else
+        NEW_ARGS=$(echo "${EXISTING_ARGS}" | sed "s#(--registry-overrides=)[^\"]+#--registry-overrides=${REGISTRY_OVERRIDES}#")
+      fi
+      {{ ah_oc_cli_path }} patch deployment -n hypershift operator \
+      --type=json \
+      -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args", "value": ['"${NEW_ARGS}"']}]'
+  register: _patch_result
+  changed_when: _patch_result.rc != 0
+  when:
+    - mc_idms is defined
+    - mc_idms.resources | length > 0
+    - ah_disconnected | bool
+
+- name: pause
+  pause:
+    minutes: 1
+
+- name: Check for Cluster-Plane Operator pods to be running
+  vars:
+    status_query: "resources[*].status.conditions[?type=='Ready'].status"
+  community.kubernetes.k8s_info:
+    kind: Pod
+    namespace: "hypershift"
+  register: cpo_pods
+  until:
+    - cpo_pods is defined
+    - cpo_pods.resources is defined
+    - cpo_pods.resources | length > 0
+    - cpo_pods | json_query(status_query) | flatten | unique == ["True"]
+  retries: 30
+  delay: 10
+
 - name: Get management cluster facts
   ansible.builtin.include_tasks: get-mc-facts.yml
 
-- name: "Validate the target a release image"
+- name: "Validate the target release image"
   ansible.builtin.assert:
     that:
       - ah_release_image is defined
@@ -58,7 +103,7 @@
     chdir: "{{ ah_tmp_dir }}"
     cmd: >
       set -x -o pipefail;
-      oc adm release info
+      {{ ah_oc_cli_path }} adm release info
       {{ ah_release_image }}
       --output json
       --registry-config={{ ah_pullsecret_file }} |


### PR DESCRIPTION
- Patch the hypershfit operator deployment with registry overridden in format source=target, this allows the ignition server to get the corresponding image digests required during the deployment.

Test-Hints: no-check