### PR TITLE
Define provisioner packages for el8/el9

### DIFF
--- a/roles/node_prep/vars/main.yml
+++ b/roles/node_prep/vars/main.yml
@@ -3,7 +3,7 @@
 # the ternary states if provision host has no online access
 # just verify the python3-crypto, python3-pyghmi packages are present
 # otherwise attempt to install them from trunk.rdoproject.org
-package_list:
+el8_packages:
   - "{{ firewall }}"
   - tar
   - libvirt
@@ -20,6 +20,25 @@ package_list:
   - policycoreutils-python3
   - "{{ (check_url.status == -1) | ternary('python3-crypto','https://trunk.rdoproject.org/rhel8-master/deps/latest/Packages/python3-crypto-2.6.1-18.el8ost.x86_64.rpm') }}"
   - "{{ (check_url.status == -1) | ternary('python3-pyghmi','https://trunk.rdoproject.org/rhel8-master/deps/latest/Packages/python3-pyghmi-1.0.22-2.el8ost.noarch.rpm') }}"
+
+el9_packages:
+  - "{{ firewall }}"
+  - tar
+  - libvirt
+  - qemu-kvm
+  - python3-devel
+  - jq
+  - ipmitool
+  - python3-libvirt
+  - python3-lxml
+  - python3-pyyaml
+  - NetworkManager-libnm
+  - nm-connection-editor
+  - python3-libsemanage
+  - python3-policycoreutils
+  - python3-pyghmi
+
+package_list: "{{ (ansible_distribution_major_version == '9') | ternary(el9_packages, el8_packages) }}"
 
 cache_package_list:
   - podman


### PR DESCRIPTION
el9 packages have slightly different name and not all seems to be required

---

Provisioner with el9:
- [x] OCP-4.14 - https://www.distributed-ci.io/jobs/f2ee382a-58a8-47d2-a8b9-3338d9ae1573
- [x]  OCP-4.16 - https://www.distributed-ci.io/jobs/70c4327b-a728-44f6-a137-b04fb30e089d

Provisioner with el8:

- [x] OCP-4.15 - https://www.distributed-ci.io/jobs/ef7953e4-b0f7-40a9-b21d-16d71d7a4601

---
TestBos2: virt
Test-Hints: no-check
