### PR TITLE
Remove packages from RDO repo

### DIFF
--- a/roles/installer/tasks/59_power_off_cluster_servers.yml
+++ b/roles/installer/tasks/59_power_off_cluster_servers.yml
@@ -1,8 +1,9 @@
 ---
 - name: Power OFF nodes
+  tags: powerservers
   block:
     - name: Create list of hosts that are going to be powered off via IPMI
-      add_host:
+      ansible.builtin.add_host:
         groups: poweroff_hosts
         hostname: "{{ item }}"
         inventory_dir: "{{ hostvars[item].inventory_dir }}"
@@ -19,21 +20,22 @@
         - "{{ groups.workers | default([]) }}"
 
     - name: Power off hosts via IPMI
-      ipmi_power:
-        name: "{{ hostvars[item]['ipmi_address'] }}"
-        user: "{{ hostvars[item]['ipmi_user'] }}"
-        password: "{{ hostvars[item]['ipmi_password'] }}"
-        port: "{{ hostvars[item]['ipmi_port'] | default(623) }}"
-        state: false
-      register: power_off_hosts
-      until: power_off_hosts is not failed
+      ansible.builtin.command: >
+        ipmitool -I lanplus -H {{ hostvars[item]['ipmi_address'] }}
+        -L ADMINISTRATOR -U {{ hostvars[item]['ipmi_user'] }}
+        -R7 -N 5 -P {{ hostvars[item]['ipmi_password'] }}
+        -p {{ hostvars[item]['ipmi_port'] | default(623) }}
+        power off
+      register: _installer_power_off_hosts
+      until: _installer_power_off_hosts is not failed
       retries: 10
       delay: 5
       with_items: "{{ groups['poweroff_hosts'] }}"
       when: groups['poweroff_hosts'] is defined
-  tags: powerservers
+      changed_when: false
 
 - name: Power Off via Redfish
+  tags: powerservers
   community.general.redfish_command:
     category: Systems
     command: PowerGracefulShutdown
@@ -54,5 +56,4 @@
       )
     )
   loop: "{{ groups['dell_hosts_redfish'] | default([]) + groups['hp_hosts_redfish'] | default([]) }}"
-  tags: powerservers
 ...

--- a/roles/node_prep/vars/main.yml
+++ b/roles/node_prep/vars/main.yml
@@ -1,8 +1,5 @@
 ---
 # vars file for node_prep
-# the ternary states if provision host has no online access
-# just verify the python3-crypto, python3-pyghmi packages are present
-# otherwise attempt to install them from trunk.rdoproject.org
 el8_packages:
   - "{{ firewall }}"
   - tar
@@ -18,8 +15,7 @@ el8_packages:
   - nm-connection-editor
   - libsemanage-python3
   - policycoreutils-python3
-  - "{{ (check_url.status == -1) | ternary('python3-crypto','https://trunk.rdoproject.org/rhel8-master/deps/latest/Packages/python3-crypto-2.6.1-18.el8ost.x86_64.rpm') }}"
-  - "{{ (check_url.status == -1) | ternary('python3-pyghmi','https://trunk.rdoproject.org/rhel8-master/deps/latest/Packages/python3-pyghmi-1.0.22-2.el8ost.noarch.rpm') }}"
+  - python3-pyghmi
 
 el9_packages:
   - "{{ firewall }}"

--- a/roles/node_prep/vars/main.yml
+++ b/roles/node_prep/vars/main.yml
@@ -2,37 +2,37 @@
 # vars file for node_prep
 el8_packages:
   - "{{ firewall }}"
-  - tar
-  - libvirt
-  - qemu-kvm
-  - python3-devel
-  - jq
   - ipmitool
-  - python3-libvirt
-  - python3-lxml
-  - python3-yaml
+  - jq
+  - libsemanage-python3
+  - libvirt
   - NetworkManager-libnm
   - nm-connection-editor
-  - libsemanage-python3
   - policycoreutils-python3
+  - python3-devel
+  - python3-libvirt
+  - python3-lxml
   - python3-pyghmi
+  - python3-yaml
+  - qemu-kvm
+  - tar
 
 el9_packages:
   - "{{ firewall }}"
-  - tar
-  - libvirt
-  - qemu-kvm
-  - python3-devel
-  - jq
   - ipmitool
-  - python3-libvirt
-  - python3-lxml
-  - python3-pyyaml
+  - jq
+  - libvirt
   - NetworkManager-libnm
   - nm-connection-editor
+  - python3-devel
   - python3-libsemanage
+  - python3-libvirt
+  - python3-lxml
   - python3-policycoreutils
   - python3-pyghmi
+  - python3-pyyaml
+  - qemu-kvm
+  - tar
 
 package_list: "{{ (ansible_distribution_major_version == '9') | ternary(el9_packages, el8_packages) }}"
 


### PR DESCRIPTION
The RDO repo has been removed after a maintenance for removal of centos8[0][1], switching to install the pyghmi package through the available repositories (not available in CentOS) python3-crypt is not needed by the latest python3-pyghmi package.

Removed the ipmi_power module that required those specific packages as it breaks "talking" to vBMC. Switching to ipmitool that works and removes the need of keeping those deprecated packages.


[0] https://lists.rdoproject.org/archives/list/dev@lists.rdoproject.org/thread/NTG4PWBTQ6KBD2JRGNUVMCFYMVX4LODP/
[1] https://lists.rdoproject.org/archives/list/dev@lists.rdoproject.org/thread/Q3AD6A5B3RM5ENAN6MCXICCVTQJYNLTD/

---

Test-Hints: no-check