### PR TITLE
always install the latest version of the operator

### DIFF
--- a/roles/rhoai/vars/main.yml
+++ b/roles/rhoai/vars/main.yml
@@ -6,10 +6,10 @@ rhoai_default_operator_map:
     namespace: openshift-servicemesh
   serverless:
     package: serverless-operator
-    channel: stable-1.32
+    channel: stable
     namespace: openshift-serverless
   rhods:
     package: rhods-operator
-    channel: stable-2.8
+    channel: fast
     namespace: redhat-ods-operator
 ...


### PR DESCRIPTION
Remove the version from the channel to be able to install the latest version of the operator in Openshift

Test-hints: no-check