### PR TITLE
Do not require ocp_version when running deprecated_api role in a standalone mode

### DIFF
--- a/roles/deprecated_api/README.md
+++ b/roles/deprecated_api/README.md
@@ -23,8 +23,7 @@ The role requires the following:
 | Parameter               | Choices/Defaults      | Comments                                             |
 |-------------------------|-----------------------|------------------------------------------------------|
 | `kubeconfig`            | `~/.kube/config.json` | Path to an existing Kubernetes config file to be used by k8s_info dependency. If not provided, the OpenShift client will attempt to load the default configuration file from `~/.kube/config.json`. Can also be specified via `K8S_AUTH_KUBECONFIG` environment variable.                                                                                                |
-| `deprecated_namespaces` | `undefined`           | Optional. List of namespaces the role will check for deprecated APIs. Typically, it should include the namespaces where you deploy the workload. If left undefined, the role will check all namespaces, excluding those starting with the `openshift` and `kube-` prefixes.                                                |
-| `ocp_version`           | `"4.9"/"4.10"/etc`    | OpenShift version currently running on your cluster. |
+| `deprecated_api_namespaces` | `undefined`           | Optional. List of namespaces the role will check for deprecated APIs. Typically, it should include the namespaces where you deploy the workload. If left undefined, the role will check all namespaces, excluding those starting with the `openshift` and `kube-` prefixes.                                                |
 | `deprecated_api_logs.path` | `/tmp`             | Optional. Directory to store the output JUnit file containing the 'Workload Compatibility with OCP Versions' test suite.                                                              |
 
 # Examples
@@ -33,8 +32,6 @@ The role requires the following:
 - name: Detect to-be-removed APIs in all namespaces excluding ones starting with openshift and kube
   include_role:
     name: redhatci.ocp.deprecated_api
-  vars:
-    ocp_version: "4.9"
 ```
 
 ```
@@ -42,7 +39,6 @@ The role requires the following:
   include_role:
     name: redhatci.ocp.deprecated_api
   vars:
-    ocp_version: "4.9"
     deprecated_api_logs:
       path: "/path/to/my/log/folder"
 ```

--- a/roles/deprecated_api/tasks/ensure_ocp_version.yml
+++ b/roles/deprecated_api/tasks/ensure_ocp_version.yml
@@ -1,0 +1,19 @@
+---
+- name: "Set da_ocp_version to ocp_version if defined"
+  ansible.builtin.set_fact:
+    da_ocp_version: "{{ ocp_version }}"
+  when: ocp_version is defined
+
+- name: "Get cluster version"
+  community.kubernetes.k8s_info:
+    api: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  register: _deprecated_api_cluster_version
+  when: ocp_version is not defined
+
+- name: "Set OCP version in major.minor format"
+  ansible.builtin.set_fact:
+    da_ocp_version: "{{ _deprecated_api_cluster_version.resources[0].status.desired.version.split('.')[:2] | join('.') }}"
+  when: ocp_version is not defined
+...

--- a/roles/deprecated_api/tasks/get_api_request_counts_per_namespace.yml
+++ b/roles/deprecated_api/tasks/get_api_request_counts_per_namespace.yml
@@ -1,20 +1,20 @@
 ---
-- name: "Get API request counts for a workload ns {{ deprecated_ns }}"
+- name: "Get API request counts for a workload ns {{ da_ns }}"
   community.kubernetes.k8s_info:
     kind: APIRequestCount
-    namespace: "{{ deprecated_ns }}"
+    namespace: "{{ da_ns }}"
   register: deprecated_api_apirequestcount
   no_log: true
 
-- name: "Extract deprecated and to-be-deprecated API for {{ deprecated_ns }}"
+- name: "Extract deprecated and to-be-deprecated API for {{ da_ns }}"
   vars:
     query: "resources[*].{name: metadata.name, removedInRelease: status.removedInRelease}[?removedInRelease != null]"
-  set_fact:
-    deprecated_api_removed_api: "{{ deprecated_api_apirequestcount | json_query(query) | flatten | unique }}"
+  ansible.builtin.set_fact:
+    da_removed_api: "{{ deprecated_api_apirequestcount | json_query(query) | flatten | unique }}"
 
-- name: "Compute OCP compatibility of the workload API for {{ deprecated_ns }}"
+- name: "Compute OCP compatibility of the workload API for {{ da_ns }}"
   vars:
-    ocp_filename: "{{ deprecated_api_logs.path }}/apirequestcounts_ocp_compatibility_{{ deprecated_ns }}_junit.xml"
+    ocp_filename: "{{ deprecated_api_logs.path }}/apirequestcounts_ocp_compatibility_{{ da_ns }}_junit.xml"
   set_fact:
-    ocp_compatibility: "{{ deprecated_api_removed_api | redhatci.ocp.ocp_compatibility(ocp_version, ocp_filename) }}"
+    ocp_compatibility: "{{ da_removed_api | redhatci.ocp.ocp_compatibility(da_ocp_version, ocp_filename) }}"
 ...

--- a/roles/deprecated_api/tasks/main.yml
+++ b/roles/deprecated_api/tasks/main.yml
@@ -1,20 +1,23 @@
 ---
-- name: Discover all namespaces
+- name: "Ensure OCP version to be set"
+  ansible.builtin.include_tasks: ensure_ocp_version.yml
+
+- name: "Discover all namespaces"
   community.kubernetes.k8s_info:
     kind: Namespace
-  register: cluster_namespaces
+  register: _da_cluster_namespaces
 
-- name: Build namespace list excluding namespaces starting with openshift and kube
-  set_fact:
-    all_namespaces: "{{ cluster_namespaces.resources
+- name: "Build namespace list excluding namespaces starting with openshift and kube"
+  ansible.builtin.set_fact:
+    da_all_namespaces: "{{ _da_cluster_namespaces.resources
                       | map(attribute='metadata.name')
                       | select('match', '^(?!openshift|kube-).*')
                       | list }}"
 
-- name: Loop over deprecated_namespaces to get API request counts
+- name: "Loop over deprecated_namespaces to get API request counts"
   ansible.builtin.include_tasks: get_api_request_counts_per_namespace.yml
   # Check all namespaces by default unless otherwise requested
-  loop: "{{ deprecated_namespaces | default(all_namespaces) }}"
+  loop: "{{ deprecated_api_namespaces | default(da_all_namespaces) }}"
   loop_control:
-    loop_var: deprecated_ns
+    loop_var: da_ns
 ...


### PR DESCRIPTION
TestDallasWorkload: preflight-green