### PR TITLE
Add dry-run to mirror_catalog role

### DIFF
--- a/roles/mirror_catalog/README.md
+++ b/roles/mirror_catalog/README.md
@@ -4,15 +4,16 @@ Mirrors a catalog and its related images. Produces a file that can be used to se
 
 ## Role Variables
 
-Name            | Required | Type     | Default | Description
---------------- | -------- | -------- | ------- | -----------
-mc_oc_tool_path | Yes      | string   |         | The path to the oc<sup>1</sup> binary, e.g. '/path/to/oc'
-mc_catalog      | Yes      | string   |         | The Fully Qualified Artifact Reference, e.g. 'example.com/namespace/web:v1.0'
-mc_registry     | Yes      | string   |         | The registry where the catalog will be mirrored, e.g. 'registry.example.com' or 'reg.example.com:4443'
-mc_pullsecret   | No       | string   | ""      | The credential file to pull and/or push the images, e.g. '/path/to/pullsecret.json'
-mc_is_type      | No       | string   | icsp    | The type of image source to use, choose between icsp (imageContentsourcePolicy) (default) or idms (imageDigestMirrorSet).
-mc_continue_on_error|  No  | boolean  | false   | Continue even if there if there are errors during mirroring
-mc_allow_unsecure_registry| No| boolean| true   | Allow mirror from/to insecure registries
+Name                       | Required | Type    | Default | Description
+-------------------------- | -------- | ------- | ------- | -----------
+mc_oc_tool_path            | Yes      | string  |         | The path to the oc<sup>1</sup> binary, e.g. '/path/to/oc'
+mc_catalog                 | Yes      | string  |         | The Fully Qualified Artifact Reference, e.g. 'example.com/namespace/web:v1.0'
+mc_registry                | Yes      | string  |         | The registry where the catalog will be mirrored, e.g. 'registry.example.com' or 'reg.example.com:4443'
+mc_pullsecret              | No       | string  | ""      | The credential file to pull and/or push the images, e.g. '/path/to/pullsecret.json'
+mc_is_type                 | No       | string  | icsp    | The type of image source to use, choose between icsp (imageContentsourcePolicy) (default) or idms (imageDigestMirrorSet).
+mc_continue_on_error       | No       | boolean | false   | Continue even if there if there are errors during mirroring
+mc_manifest_only           | No       | boolean | false   | Calculate the manifests required for mirroring, but do not actually mirror image content.
+mc_allow_unsecure_registry | No       | boolean | true    | Allow mirror from/to insecure registries
 
 <sup>1</sup> It's recommended to use a [stable version of oc](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/)
 

--- a/roles/mirror_catalog/README.md
+++ b/roles/mirror_catalog/README.md
@@ -14,6 +14,7 @@ mc_is_type                 | No       | string  | icsp    | The type of image so
 mc_continue_on_error       | No       | boolean | false   | Continue even if there if there are errors during mirroring
 mc_manifest_only           | No       | boolean | false   | Calculate the manifests required for mirroring, but do not actually mirror image content.
 mc_allow_unsecure_registry | No       | boolean | true    | Allow mirror from/to insecure registries
+mc_max_components          | No       | int     | 3       | The maximum number of path components allowed in a destination mapping, `quay.io/org/repo` has two components.
 
 <sup>1</sup> It's recommended to use a [stable version of oc](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/)
 

--- a/roles/mirror_catalog/defaults/main.yml
+++ b/roles/mirror_catalog/defaults/main.yml
@@ -3,4 +3,5 @@ mc_is_type: "icsp"
 mc_continue_on_error: false
 mc_allow_unsecure_registry: true
 mc_manifest_only: false
+mc_max_components: 3
 ...

--- a/roles/mirror_catalog/defaults/main.yml
+++ b/roles/mirror_catalog/defaults/main.yml
@@ -2,4 +2,5 @@
 mc_is_type: "icsp"
 mc_continue_on_error: false
 mc_allow_unsecure_registry: true
+mc_manifest_only: false
 ...

--- a/roles/mirror_catalog/tasks/main.yml
+++ b/roles/mirror_catalog/tasks/main.yml
@@ -56,6 +56,9 @@
       {% endif %}
       --max-components=3
       --continue-on-error={{ mc_continue_on_error }}
+      {% if mc_manifest_only | bool %}
+      --manifests-only=true
+      {% endif %}
       {% if mc_pullsecret is defined %}
       --registry-config {{ mc_pullsecret }}
       {% endif %}

--- a/roles/mirror_catalog/tasks/main.yml
+++ b/roles/mirror_catalog/tasks/main.yml
@@ -54,7 +54,7 @@
       {% if mc_allow_unsecure_registry | bool %}
       --insecure
       {% endif %}
-      --max-components=3
+      --max-components={{ mc_max_components | int }}
       --continue-on-error={{ mc_continue_on_error }}
       {% if mc_manifest_only | bool %}
       --manifests-only=true


### PR DESCRIPTION
In some cases is useful to only generate the manifests without actually mirroring images of a catalog. With this new option, mc_manifest_only is possible to only generate the manifest files.

---

- [x] TestDallas: ocp-4.15-vanilla - https://www.distributed-ci.io/jobs/f0531dd6-8b81-4250-954e-28bd8f29b405/jobStates

---

Test-Hints: no-check