### PR TITLE
Aligning the ZTP related roles with CI ztphub role

### DIFF
--- a/roles/acm_setup/defaults/main.yml
+++ b/roles/acm_setup/defaults/main.yml
@@ -10,4 +10,5 @@ hub_db_volume_size: 40Gi
 hub_fs_volume_size: 50Gi
 hub_img_volume_size: 40Gi
 hub_vm_external_network: true
+hub_skip_verify_tls: false
 ...

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -181,6 +181,8 @@
 
 - name: "Update the provisioning resource to watch all Namespaces"
   community.kubernetes.k8s:
+    merge_type:
+      - merge
     definition:
       apiVersion: metal3.io/v1alpha1
       kind: Provisioning
@@ -188,6 +190,7 @@
         name: provisioning-configuration
       spec:
         watchAllNamespaces: true
+        disableVirtualMediaTLS: true
 
 - name: "Get cluster version"
   community.kubernetes.k8s_info:
@@ -258,6 +261,10 @@
       metadata:
         name: agent
         namespace: multicluster-engine
+        {% if hub_skip_verify_tls %}
+        annotations:
+          unsupported.agent-install.openshift.io/assisted-image-service-skip-verify-tls: "true"
+        {% endif %}
       spec:
         databaseStorage:
       {% if hub_sc is defined %}


### PR DESCRIPTION
@sshnaidm crated the [PR 262](https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/262) contributing the role ztphub, which overlaps with some of the already existing roles.
This PR is to align the existing roles with the requirements observed in the ztphub role.