### PR TITLE
Fix version validation as the pull request #316 broke the version che…

### DIFF
--- a/roles/node_prep/tasks/10_validation.yml
+++ b/roles/node_prep/tasks/10_validation.yml
@@ -295,37 +295,42 @@
   tags: validation
 
 - name: Validations for IPv6 VIPs in OCP >= 4.12
+  when:
+    - release_version is ansible.builtin.version('4.12', '>=')
+    - ipv6_enabled | bool
+    - dualstack_baremetal | bool
+    - dualstack_vips | bool
   block:
     - name: Verify DNS records for Wildcard (Ingress) IPv6 VIP
-      set_fact:
-        ingressvip6: "{{ lookup('dig', 'foo.apps.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"
+      ansible.builtin.set_fact:
+        ingressvip6: "{{ lookup('dig', 'foo.apps.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"  # noqa: redhat-ci[no-role-prefix]
       when: ((ingressvip6 is undefined) or (ingressvip6|length == 0))
       tags:
         - always
         - validation
 
     - name: Verify DNS records for API IPv6 VIP
-      set_fact:
-        apivip6: "{{ lookup('dig', 'api.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"
+      ansible.builtin.set_fact:
+        apivip6: "{{ lookup('dig', 'api.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"  # noqa: redhat-ci[no-role-prefix]
       when: ((apivip6 is undefined) or (apivip6|length == 0))
       tags:
         - always
         - validation
 
     - name: Display API IPv6 VIP
-      debug:
+      ansible.builtin.debug:
         msg: "The API IPv6 VIP is {{ apivip6 }}"
         verbosity: 2
       tags: validation
 
     - name: Display Ingress IPv6 VIP
-      debug:
+      ansible.builtin.debug:
         msg: "The Wildcard (Ingress) IPv6 VIP is {{ ingressvip6 }}"
         verbosity: 2
       tags: validation
 
     - name: Fail if incorrect API IPv6 VIP
-      fail:
+      ansible.builtin.fail:
         msg: "The API IPv6 VIP seems to be incorrect. Value was NXDOMAIN or empty string."
       when: (apivip6 == 'NXDOMAIN') or (apivip6|length == 0)
       tags:
@@ -333,17 +338,12 @@
         - validation
 
     - name: Fail if incorrect Ingress IPv6 VIP
-      fail:
+      ansible.builtin.fail:
         msg: "The Ingress IPv6 VIP seems to be incorrect. Value was NXDOMAIN or empty string."
       when: (ingressvip6 == 'NXDOMAIN') or (ingressvip6|length == 0)
       tags:
         - always
         - validation
-  when:
-    - release_version is ansible.builtin.version('4.12', '>=')
-    - ipv6_enabled | bool
-    - dualstack_baremetal | bool
-    - dualstack_vips | bool
 
 - name: Fail if dual-stack is requested and build does not support it
   fail:

--- a/roles/node_prep/tasks/10_validation.yml
+++ b/roles/node_prep/tasks/10_validation.yml
@@ -138,57 +138,6 @@
     - always
     - validation
 
-- name: Validations for IPv6 VIPs in OCP >= 4.12
-  block:
-    - name: Verify DNS records for Wildcard (Ingress) IPv6 VIP
-      set_fact:
-        ingressvip6: "{{ lookup('dig', 'foo.apps.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"
-      when: ((ingressvip6 is undefined) or (ingressvip6|length == 0))
-      tags:
-        - always
-        - validation
-
-    - name: Verify DNS records for API IPv6 VIP
-      set_fact:
-        apivip6: "{{ lookup('dig', 'api.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"
-      when: ((apivip6 is undefined) or (apivip6|length == 0))
-      tags:
-        - always
-        - validation
-
-    - name: Display API IPv6 VIP
-      debug:
-        msg: "The API IPv6 VIP is {{ apivip6 }}"
-        verbosity: 2
-      tags: validation
-
-    - name: Display Ingress IPv6 VIP
-      debug:
-        msg: "The Wildcard (Ingress) IPv6 VIP is {{ ingressvip6 }}"
-        verbosity: 2
-      tags: validation
-
-    - name: Fail if incorrect API IPv6 VIP
-      fail:
-        msg: "The API IPv6 VIP seems to be incorrect. Value was NXDOMAIN or empty string."
-      when: (apivip6 == 'NXDOMAIN') or (apivip6|length == 0)
-      tags:
-        - always
-        - validation
-
-    - name: Fail if incorrect Ingress IPv6 VIP
-      fail:
-        msg: "The Ingress IPv6 VIP seems to be incorrect. Value was NXDOMAIN or empty string."
-      when: (ingressvip6 == 'NXDOMAIN') or (ingressvip6|length == 0)
-      tags:
-        - always
-        - validation
-  when:
-    - version is ansible.builtin.version('4.12', '>=')
-    - ipv6_enabled | bool
-    - dualstack_baremetal | bool
-    - dualstack_vips | bool
-
 - name: Set release_url for development envs
   set_fact:
     release_url: "{{ (webserver_url|length) | ternary(webserver_url, 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview') }}"
@@ -344,6 +293,57 @@
     msg: "release version {{ release_version }}"
     verbosity: 2
   tags: validation
+
+- name: Validations for IPv6 VIPs in OCP >= 4.12
+  block:
+    - name: Verify DNS records for Wildcard (Ingress) IPv6 VIP
+      set_fact:
+        ingressvip6: "{{ lookup('dig', 'foo.apps.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"
+      when: ((ingressvip6 is undefined) or (ingressvip6|length == 0))
+      tags:
+        - always
+        - validation
+
+    - name: Verify DNS records for API IPv6 VIP
+      set_fact:
+        apivip6: "{{ lookup('dig', 'api.{{ cluster |quote }}.{{ domain | quote }}.', 'qtype=AAAA' ) }}"
+      when: ((apivip6 is undefined) or (apivip6|length == 0))
+      tags:
+        - always
+        - validation
+
+    - name: Display API IPv6 VIP
+      debug:
+        msg: "The API IPv6 VIP is {{ apivip6 }}"
+        verbosity: 2
+      tags: validation
+
+    - name: Display Ingress IPv6 VIP
+      debug:
+        msg: "The Wildcard (Ingress) IPv6 VIP is {{ ingressvip6 }}"
+        verbosity: 2
+      tags: validation
+
+    - name: Fail if incorrect API IPv6 VIP
+      fail:
+        msg: "The API IPv6 VIP seems to be incorrect. Value was NXDOMAIN or empty string."
+      when: (apivip6 == 'NXDOMAIN') or (apivip6|length == 0)
+      tags:
+        - always
+        - validation
+
+    - name: Fail if incorrect Ingress IPv6 VIP
+      fail:
+        msg: "The Ingress IPv6 VIP seems to be incorrect. Value was NXDOMAIN or empty string."
+      when: (ingressvip6 == 'NXDOMAIN') or (ingressvip6|length == 0)
+      tags:
+        - always
+        - validation
+  when:
+    - release_version is ansible.builtin.version('4.12', '>=')
+    - ipv6_enabled | bool
+    - dualstack_baremetal | bool
+    - dualstack_vips | bool
 
 - name: Fail if dual-stack is requested and build does not support it
   fail:


### PR DESCRIPTION
…ck as the format is values such as 'latest-4.3' or 'latest-4.4'

---

- [x] OCP 4.12 (disconnected) -  https://www.distributed-ci.io/jobs/0b7fca44-7463-41c1-8eb1-ab7faffb5d47/jobStates
- [x] OCP 4.15 (disconnected) - https://www.distributed-ci.io/jobs/60f00124-3404-4e18-ad00-cb37a07838de
- [x] OCP 4.15 (connected) - https://www.distributed-ci.io/jobs/494e1bae-55f9-4f3e-9a91-38e91ecdf0a1/jobStates

---

Test-Hints: no-check