### PR TITLE
dci-merge | Fix extraction of test commands

### DIFF
--- a/hack/dci-merge.sh
+++ b/hack/dci-merge.sh
@@ -71,17 +71,17 @@ for PR in $PRS; do
         # extract TestBos2 commands
         if grep -qE "^\s*TestBos2:\s*" <<< "$DESC"; then
             # shellcheck disable=SC2001,SC2086
-            CMD+=("$(sed -e 's/^\s*TestBos2:\s*//' <<< $DESC)")
+            CMD+=("$(sed -ne 's/^\s*TestBos2:\s*//p' <<< $DESC)")
         fi
         # extract TestBos2Sno commands
         if grep -qE "^\s*TestBos2Sno:\s*" <<< "$DESC"; then
             # shellcheck disable=SC2001,SC2086
-            CMD_SNO+=("$(sed -e 's/^\s*TestBos2Sno:\s*//' <<< $DESC)")
+            CMD_SNO+=("$(sed -ne 's/^\s*TestBos2Sno:\s*//p' <<< $DESC)")
         fi
         # extract TestBos2Baremetal commands
         if grep -qE "^\s*TestBos2Baremetal:\s*" <<< "$DESC"; then
             # shellcheck disable=SC2001,SC2086
-            CMD_SNO_BM+=("$(sed -e 's/^\s*TestBos2Baremetal:\s*//' <<< $DESC)")
+            CMD_SNO_BM+=("$(sed -ne 's/^\s*TestBos2Baremetal:\s*//p' <<< $DESC)")
         fi
     fi
 done


### PR DESCRIPTION
Test-Hints: no-check

TLDR: if PR description has multiple lines and not including Test[X] entries, they're taken as input for CMD argument, then the merge job fails, as it's happening with https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/333. See this [DCI merge action](https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/9412795382/job/25928311578):

```
++ curl -s '-HAccept: application/vnd.github.v3+json' '-HAuthorization: token ***' https://api.github.com/repos/redhatci/ansible-collection-redhatci-ocp/pulls/333
++ jq -r .body
+ DESC='TestBos2: virt

Some of them was bug some of them change to be more ansible format and some of them changed to modules'
...
+ dci-queue schedule vpool -- env GITHUB_TOKEN=*** STATUSES_URL=https://api.github.com/repos/redhatci/ansible-collection-redhatci-ocp/statuses/c4309070e854b8f3db3a9e5c4672cf684d1a9d82 DCI_QUEUE_RESOURCE=@RESOURCE /usr/share/dci-pipeline/test-runner /var/lib/dci-openshift-agent/github/ansible-collection-redhatci-ocp-mq-c4309070e854b8f3db3a9e5c4672cf684d1a9d82 $'virt\r' $'\r' Some of them was bug some of them change to be more ansible format and some of them changed to modules
```

CMD should only retrieve the command after Test[X] and nothing more.