### PR TITLE
Use IDMS if the cluster has support for them

### DIFF
--- a/roles/operator_sdk/tasks/mirroring.yml
+++ b/roles/operator_sdk/tasks/mirroring.yml
@@ -39,10 +39,10 @@
     {{ oo_index }};
     podman rmi {{ oo_index }}
 
-- name: Find ImageDigestMirrorSet in the cluster
+- name: Check if IDMS is supported
   community.kubernetes.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: ImageDigestMirrorSet
+    kind: CustomResourceDefinition
+    name: imagedigestmirrorsets.config.openshift.io
   register: idms_res
 
 - name: Mirror generated catalog

--- a/roles/preflight/tasks/mirroring.yml
+++ b/roles/preflight/tasks/mirroring.yml
@@ -43,10 +43,10 @@
     {{ oo_index }};
     podman rmi {{ oo_index }}
 
-- name: Find ImageDigestMirrorSet in the cluster
+- name: Check if IDMS is supported
   community.kubernetes.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: ImageDigestMirrorSet
+    kind: CustomResourceDefinition
+    name: imagedigestmirrorsets.config.openshift.io
   register: idms_res
 
 - name: Mirror generated catalog


### PR DESCRIPTION
We should be check if IDMS is supported, at this time we check if there are already IDMS applied to the cluster

build-depends: 31696

CheckDallasWorkload: preflight-green