### PR TITLE
ZTP | Create OCP pull secret from hub cluster, refactor of some code

### DIFF
--- a/roles/configure_ztp_gitops_apps/tasks/main.yaml
+++ b/roles/configure_ztp_gitops_apps/tasks/main.yaml
@@ -101,13 +101,15 @@
         replace: "{{ czga_policies_namespace }}"
 
     - name: Add namespace to the policies-app-project.yaml
-      ansible.builtin.lineinfile:
+      ansible.builtin.blockinfile:
         path: "{{ temp_dir.path }}/ztp/argocd/deployment/policies-app-project.yaml"
-        line: "{{ item }}"
+        block: |
+          {% filter indent(width=2, first=true) %}
+          - namespace: '{{ czga_policies_namespace }}'
+            server: '*'
+          {% endfilter %}
         insertafter: destinations.*
-      loop:
-        - "  - namespace: '{{ czga_policies_namespace }}'"
-        - "    server: '*'"
+        marker: ""
 
     - name: Replace path in policies-app.yaml
       ansible.builtin.replace:
@@ -132,7 +134,6 @@
         path: "{{ temp_dir.path }}/ztp/argocd/deployment/policies-app.yaml"
         line: "      allowEmpty: true"
         insertafter: selfHeal.*
-
 
     ## Add adaptation due to https://issues.redhat.com/browse/CNF-7840
     ## based on https://redhat-internal.slack.com/archives/C02EG99MR9C/p1679006883470389?thread_ts=1678887461.410819&cid=C02EG99MR9C
@@ -173,6 +174,35 @@
         merge_type:
           - merge
         definition: "{{ lookup('file', temp_dir.path + '/ztp/argocd/deployment/disable-cluster-proxy-addon.json') | from_json }}"
+
+    # Before launching the SiteConfig, provide the OCP pull secret extracted from the hub cluster
+    # For this, we need to create the cluster namespace in advance
+    - name: Create the Spoke cluster namespace
+      community.kubernetes.k8s:
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ czga_clusters_namespace }}"
+
+    - name: Save pull-secret in a variable
+      ansible.builtin.slurp:
+        src: "{{ temp_dir.path }}/temp-pull-secret.json"
+      register: _czga_encoded_pull_secret
+      no_log: true
+
+    - name: Create the Spoke cluster pull-secret
+      community.kubernetes.k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: assisted-deployment-pull-secret
+            namespace: "{{ czga_clusters_namespace }}"
+          type: kubernetes.io/dockerconfigjson
+          data:
+            .dockerconfigjson: "{{ _czga_encoded_pull_secret['content'] }}"
+      no_log: true
 
     - name: Run the policies and cluster apps
       ansible.builtin.shell: |

--- a/roles/gitops_configure_repo/tasks/main.yaml
+++ b/roles/gitops_configure_repo/tasks/main.yaml
@@ -8,7 +8,7 @@
       - gcr_ztp_gitops_repo is defined
       - gcr_ztp_gitops_repo | length > 0
 
-- name: Add Git repository SSH key to argoCD
+- name: Add ssh_known_hosts to ArgoCD
   community.kubernetes.k8s:
     api_version: v1
     kind: ConfigMap
@@ -19,9 +19,11 @@
         app.kubernetes.io/name: argocd-cm
         app.kubernetes.io/part-of: argocd
       data:
-        gcr_ssh_known_hosts: |
+        ssh_known_hosts: |
           {{ gcr_ssh_known_hosts }}
-  when: gcr_ssh_known_hosts is defined
+  when:
+    - gcr_ssh_known_hosts is defined
+    - gcr_ssh_known_hosts | length > 0
   no_log: true
 
 - name: Register key


### PR DESCRIPTION
Test-Hints: no-check

----

- Create OCP pull secret from hub cluster (currently it's not created, we rely on what's provided in the git repo, but we would need to update it if the hub cluster changes)
- Refactor of some code: `ssh_known_hosts` var in ConfigMap.
- Properly update policies-app-project.yaml file

I will not launch automatic tests for this, I'll run them manually since the scenario to test this is a bit tricky.