### PR TITLE
Fix issues with Sanity Check (stable-2.9)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,6 +107,24 @@ jobs:
         run: |
           set -x
           EXCLUDE="--exclude hack/"
+          # Container image used with stable-2.9 is disabled by default in Docker v26.0
+          # because of "Pushing and pulling with image manifest v2 schema 1"
+          # This feature will be definitely removed in Docker v27.0
+          # See https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1
+          # Workaround (while not using v27.0): declare DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE with a non-empty value
+          # See https://docs.docker.com/config/daemon/systemd/ for providing environment variables to Docker daemon
+          if [ "${{ matrix.ansible }}" == "stable-2.9" ]; then
+            DOCKER_SERVICE_DIR="/etc/systemd/system/docker.service.d"
+            sudo mkdir -p $DOCKER_SERVICE_DIR
+
+            echo '[Service]' | sudo tee -a $DOCKER_SERVICE_DIR/deprecated-pull-schema.conf > /dev/null
+            echo 'Environment="DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE=true"' | sudo tee -a $DOCKER_SERVICE_DIR/deprecated-pull-schema.conf > /dev/null
+
+            sudo systemctl daemon-reload
+            sudo systemctl restart docker
+
+            sudo systemctl show --property=Environment docker
+          fi          
           git checkout -b branch
           git fetch --unshallow origin main
           # extract all the supported python versions from the error message, excluding 3.5


### PR DESCRIPTION
Test-Hints: no-check

-----

Image used with Sanity Check (stable-2.9) is now affected by this feature marked as disabled by default in the Podman engine version used in our checks (v26.0): [Pushing and pulling with image manifest v2 schema 1](https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1)

Example: https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/9495369221/job/26167465226?pr=336

```
Run set -x
+ EXCLUDE='--exclude hack/'
+ git checkout -b branch
Switched to a new branch 'branch'
+ git fetch --unshallow origin main
From https://github.com/redhatci/ansible-collection-redhatci-ocp
 * branch            main       -> FETCH_HEAD
 * [new branch]      main       -> origin/main
++ ansible-test sanity --exclude hack/ --verbose --docker --python 1.0 --color --coverage --failure-ok
++ grep -Po 'invalid.*?\K'\''3.*\d'\'''
++ sed -e 's/3.5 //g'
++ tr -d ','\'''
+ PY_VERS='3.6 3.7 3.8'
+ tee -a branch.output
+ for version in $PY_VERS
+ ansible-test sanity --exclude hack/ --verbose --docker --python 3.6 --color --coverage --failure-ok
Run command: docker images quay.io/ansible/default-test-container:1.10.1 --format '{{json .}}'
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
Run command: docker pull quay.io/ansible/default-test-container:1.10.1
1.10.1: Pulling from ansible/default-test-container
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/ansible/default-test-container:1.10.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
WARNING: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1". Waiting a few seconds before trying again.
ERROR: Failed to pull docker image "quay.io/ansible/default-test-container:1.10.1".
+ git checkout main
Switched to a new branch 'main'
branch 'main' set up to track 'origin/main'.
Error: Process completed with exit code 1.
```

Workaround proposed here is to use `DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE` environment variable to be able to pull the image used in 2.9. This will be removed on Docker v27.0, so we'll need to recheck this at some point, but at least this is for unblocking the current PRs that cannot be merged.