### PR TITLE
ACM - No log for listing CSV

### DIFF
--- a/roles/acm_setup/tasks/validation.yml
+++ b/roles/acm_setup/tasks/validation.yml
@@ -6,11 +6,13 @@
       - hub_os_images is defined
       - hub_os_images | type_debug == 'list'
       - hub_os_images | length
+
 - name: "Get Storage Classes"
   community.kubernetes.k8s_info:
     api_version: v1
     kind: StorageClass
   register: storage_class
+  no_log: true
 
 - name: "Fail when there is no storage class available"
   ansible.builtin.fail:
@@ -46,6 +48,7 @@
   register: current_csvs
   retries: 5
   delay: 5
+  no_log: true
 
 - name: "Fail if ACM csv is not present"
   vars:


### PR DESCRIPTION
Logging all CVS data from a cluster that has multiple operators installed will generate a big ansible log, so disabling it.

TestBos2: virt-prega