### PR TITLE
Switch to latest upcoming image

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   ansible-lint:
     name: Ansible-lint Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -150,7 +150,7 @@ jobs:
 
   check-all-dependencies-are-merged:
     name: "Check all dependencies are merged"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
 
       - name: Check all dependent Pull Requests are merged
@@ -161,7 +161,7 @@ jobs:
 
   check-docs:
     name: Check version, documentation and README
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
GHA image ubuntu-latest will switch from 22.04 to 24.04 in August. Switching to use the upcoming latest version[0]

[0] https://github.com/actions/runner-images/issues/9691#issuecomment-2063926929

---

Test-hints: no-check