### PR TITLE
get_image_hash | Retry the obtention of the image hash

### DIFF
--- a/roles/get_image_hash/tasks/get_image_hash.yml
+++ b/roles/get_image_hash/tasks/get_image_hash.yml
@@ -5,6 +5,9 @@
     shell: "skopeo inspect --authfile {{ local_pull_secret_path }} docker://{{ item.value.url }}"
     register: result
     changed_when: false
+    until: result.rc == 0
+    retries: 5
+    delay: 5
 
   - name: Update hashes
     set_fact:


### PR DESCRIPTION
TestBos2: assisted-abi

------

Just found an isolated case in a DCI job where this task was failing due to an error 502: https://www.distributed-ci.io/jobs/a21087d8-873a-45f7-bc00-db9e4e1b24a1/jobStates?sort=date&task=0ae3cf40-9b88-4987-91e9-363faebffd21, but mostly passing in most of the cases.

Adding some retries to mitigate these isolated cases where this may fail.