### PR TITLE
Generate IDMS instruction if OCP >= 4.14

### DIFF
--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -11,7 +11,7 @@
 
 - name: Mirror release images to local registry
   ansible.builtin.command: >-
-    {{ mor_oc }}/oc adm release mirror
+    {{ mor_oc }} adm release mirror
     --registry-config={{ mor_auths_file }}
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
@@ -25,7 +25,7 @@
 
 - name: Generate Image Source manifest
   ansible.builtin.command: >-
-    {{ mor_oc }}/oc adm release mirror
+    {{ mor_oc }} adm release mirror
     --registry-config={{ mor_auths_file }}
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}

--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -11,7 +11,7 @@
 
 - name: Mirror release images to local registry
   ansible.builtin.command: >-
-    {{ mor_oc }} adm release mirror
+    {{ mor_cache_dir }}/{{ mor_version }}/oc adm release mirror
     --registry-config={{ mor_auths_file }}
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
@@ -30,7 +30,7 @@
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
     --to={{ mor_registry_url }}/{{ mor_registry_path }}
-    --print-mirror-instructions={{ mor_is_type | lower }}
+    {{ mor_version is version("4.14", "<") | ternary("", "--print-mirror-instructions=" + mor_is_type | lower ) }}
   retries: 3
   delay: 10
   register: _mor_result

--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -11,7 +11,7 @@
 
 - name: Mirror release images to local registry
   ansible.builtin.command: >-
-    {{ mor_cache_dir }}/{{ mor_version }}/oc adm release mirror
+    {{ mor_oc }}/oc adm release mirror
     --registry-config={{ mor_auths_file }}
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
@@ -25,7 +25,7 @@
 
 - name: Generate Image Source manifest
   ansible.builtin.command: >-
-    {{ mor_cache_dir }}/{{ mor_version }}/oc adm release mirror
+    {{ mor_oc }}/oc adm release mirror
     --registry-config={{ mor_auths_file }}
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}

--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -30,7 +30,7 @@
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
     --to={{ mor_registry_url }}/{{ mor_registry_path }}
-    {{ mor_version is version("4.14", "<") | ternary("", "--print-mirror-instructions=" + mor_is_type | lower ) }}
+    {{ mor_version is version("4.14", "<") | ternary("--dry-run", "--print-mirror-instructions=" + mor_is_type | lower ) }}
   retries: 3
   delay: 10
   register: _mor_result

--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -25,7 +25,7 @@
 
 - name: Generate Image Source manifest
   ansible.builtin.command: >-
-    {{ mor_oc }} adm release mirror
+    {{ mor_cache_dir }}/{{ mor_version }}/oc adm release mirror
     --registry-config={{ mor_auths_file }}
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}


### PR DESCRIPTION
The stable version supports printing mirroring instructions

Test-hints: no-check

---

- [x] OCP 4.12 - https://www.distributed-ci.io/jobs/f24a3ad8-494e-4642-b35f-52dee78624ec?sort=date&task=85b54fb1-ad50-4289-b5a7-845b37d83842
- [x]  OCP 4.14 - https://www.distributed-ci.io/jobs/2886cf52-81a4-40f9-a252-27486d6b8c8f/jobStates?sort=date&task=b377b129-b667-4124-a4d0-1faac2323620
