### PR TITLE
ignoring the --print-mirror-instructions for versions below 4.14

### DIFF
--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -30,7 +30,9 @@
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
     --to={{ mor_registry_url }}/{{ mor_registry_path }}
+    {% if mor_version is version('4.14.0', '>') %}
     --print-mirror-instructions={{ mor_is_type | lower }}
+    {% endif %}
   retries: 3
   delay: 10
   register: _mor_result


### PR DESCRIPTION
The option in oc adm mirror is not available before 4.14