### PR TITLE
cnf_cert | Updating certsuite call for HEAD version

### DIFF
--- a/roles/cnf_cert/tasks/pre-run.yml
+++ b/roles/cnf_cert/tasks/pre-run.yml
@@ -110,10 +110,7 @@
     - name: Build the tnf image locally
       ansible.builtin.shell: |
         set -x
-        podman build -t {{ tnf_image }} \
-        --build-arg TNF_VERSION={{ tnf_version_image }} \
-        --build-arg TNF_SRC_URL=https://github.com/test-network-function/cnf-certification-test \
-        --build-arg OPENSHIFT_VERSION={{ ocp_version_full }} .
+        podman build -t {{ tnf_image }} .
       args:
         chdir: "{{ tnf_dir }}"
 

--- a/roles/cnf_cert/tasks/tests.yml
+++ b/roles/cnf_cert/tasks/tests.yml
@@ -73,19 +73,21 @@
       vars:
         tnf_partner_repo: "{{ (dci_local_registry | length) | ternary(dci_local_registry, 'quay.io') }}/testnetworkfunction"
         support_image: "debug-partner:{{ support_image_version }}"
+        certsuite_binary: "{{ (test_network_function_version == 'HEAD') | ternary('./certsuite', './cnf-certification-test/certsuite') }}"
+        container_file_path: "{{ (test_network_function_version == 'HEAD') | ternary('/usr/certsuite', '/usr/tnf') }}"
         container_command: |
-          ./cnf-certification-test/certsuite run \
+          {{ certsuite_binary }} run \
           {% if tnf_labels | length > 0 %}
           --label-filter='{{ tnf_labels }}' \
           {% endif %}
           {% if tnf_dockercfg_path is defined %}
-          --preflight-dockerconfig=/usr/tnf/config/config.json \
+          --preflight-dockerconfig={{ container_file_path }}/config/config.json \
           --allow-preflight-insecure=${TNF_ALLOW_PREFLIGHT_INSECURE:-false} \
           {% endif %}
-          --output-dir=/usr/tnf/results \
+          --output-dir={{ container_file_path }}/results \
           --offline-db=/usr/offline-db \
-          --config-file=/usr/tnf/config/tnf_config.yml \
-          --kubeconfig=/usr/tnf/config/kubeconfig \
+          --config-file={{ container_file_path }}/config/tnf_config.yml \
+          --kubeconfig={{ container_file_path }}/config/kubeconfig \
           --tnf-image-repository={{ tnf_partner_repo }} \
           --tnf-debug-image={{ support_image }} \
           --create-xml-junit-file=${TNF_ENABLE_XML_CREATION:-true} \
@@ -99,13 +101,14 @@
         podman run \
         --rm \
         --network host \
-        -v {{ tnf_dir }}/config_files:/usr/tnf/config:Z \
-        -v {{ tnf_dir }}/result_files:/usr/tnf/results:Z \
+        -v {{ tnf_dir }}/config_files:{{ container_file_path }}/config:Z \
+        -v {{ tnf_dir }}/result_files:{{ container_file_path }}/results:Z \
         {{ tnf_image }} \
         {{ container_command }}
       register: _cc_output
       no_log: true
 
+  always:
     - name: Save output in a file
       ansible.builtin.copy:
         content: "{{ _cc_output.stdout }}"


### PR DESCRIPTION
TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[]

- [x] tnf stable (launched here) - https://www.distributed-ci.io/jobs/e8affb28-1e4e-442d-81cc-a8bd5b288d0f/jobStates?sort=date
- [x] tnf unstable (launched from https://github.com/test-network-function/cnf-certification-test/pull/2181) - https://www.distributed-ci.io/jobs/a8ac738d-2c8d-4fe5-ab85-aa693bdba711/jobStates?sort=date

----

- Adapting the code to the new way of launching certsuite, included in https://github.com/test-network-function/cnf-certification-test/pull/2181
- Using an `always` clause to always retrieve the output from tnf exec
- Removed extra arguments when building the tnf container image for PR testing, they seem to be no longer needed