### PR TITLE
Switch from hard-coded delays to variable in metallb_setup role

### DIFF
--- a/roles/metallb_setup/README.md
+++ b/roles/metallb_setup/README.md
@@ -27,6 +27,8 @@ NOTES:
 | mlb_ipv6_enabled       | false          | Boolean      | No          | If IPv6 Pools are defined for BGP, enable this boolean                   |
 | mlb_namespace          | metallb-system | String       | No          | Default name of the namespace to use to install operator resources       |
 | mlb_bfd_profile        | bfd-fastest    | String       | No          | Name of the BFD profile to use for BGP                                   |
+| mlb_wait_retries       | 18             | Int          | No          | How many times to retry OCP operations that fail |
+| mlb_wait_delay         | 10             | Int          | No          | How long to wait between retries of OCP operations that fail |
 | mlb_settings           | ""             | File Path    | No          | An optional YAML file with the variables listed above.                   |
 
 ## Role requirements for BGP mode

--- a/roles/metallb_setup/defaults/main.yml
+++ b/roles/metallb_setup/defaults/main.yml
@@ -5,4 +5,6 @@ mlb_bfd_profile: bfd-fastest
 mlb_ipv4_enabled: true
 mlb_ipv6_enabled: false
 mlb_action: install
+mlb_wait_delay: 10
+mlb_wait_retries: 18
 ...

--- a/roles/metallb_setup/tasks/pre-requisites.yml
+++ b/roles/metallb_setup/tasks/pre-requisites.yml
@@ -48,6 +48,13 @@
   loop:
     - mlb_ipaddr_pool
 
+- name: "Validate values of mlb_wait_* are positive integers"
+  ansible.builtin.assert:
+    that:
+      - mlb_wait_delay | int > 0
+      - mlb_wait_retries | int > 0
+    fail_msg: "The parameters mlb_wait_delay and mlb_wait_retries must both be integers"
+
 - name: "Confirm that MetalLB controller pods are Running"
   community.kubernetes.k8s_info:
     api_version: v1
@@ -57,8 +64,8 @@
       - control-plane = controller-manager
   register: pod_list
   until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
-  retries: 9
-  delay: 10
+  retries: "{{ mlb_wait_retries }}"
+  delay: "{{ mlb_wait_delay }}"
   no_log: true
 
 - name: "Validate parameter mlb_ipaddr_pool is a list"

--- a/roles/metallb_setup/tasks/setup-metallb.yml
+++ b/roles/metallb_setup/tasks/setup-metallb.yml
@@ -24,8 +24,8 @@
       - component = speaker
   register: pod_list
   until: pod_list | json_query('resources[*].status.phase')|unique == ["Running"]
-  retries: 18
-  delay: 10
+  retries: "{{ mlb_wait_retries }}"
+  delay: "{{ mlb_wait_delay }}"
   no_log: true
 
 - name: "Create MetalLB IP Address Pool"
@@ -41,8 +41,8 @@
         addresses: "{{ mlb_ipaddr_pool }}"
   register: address_pool
   until: address_pool is succeeded
-  retries: 6
-  delay: 10
+  retries: "{{ mlb_wait_retries }}"
+  delay: "{{ mlb_wait_delay }}"
   no_log: true
 
 - name: "Setup BGP mode objects"
@@ -68,8 +68,8 @@
             minimumTtl: 254
       register: bfdprof
       until: bfdprof is succeeded
-      retries: 6
-      delay: 10
+      retries: "{{ mlb_wait_retries }}"
+      delay: "{{ mlb_wait_delay }}"
       no_log: true
 
     - name: "Create MetalLB BGP Peers"
@@ -81,8 +81,8 @@
         loop_var: peer
       register: bgppeer
       until: bgppeer is succeeded
-      retries: 6
-      delay: 10
+      retries: "{{ mlb_wait_retries }}"
+      delay: "{{ mlb_wait_delay }}"
       no_log: true
 
     - name: "Create MetalLB BGP Advertisements"
@@ -107,8 +107,8 @@
         definition: "{{ bgpadvert }}"
       register: bgpadver
       until: bgpadver is succeeded
-      retries: 6
-      delay: 10
+      retries: "{{ mlb_wait_retries }}"
+      delay: "{{ mlb_wait_delay }}"
       no_log: true
 
 - name: "Create MetalLB L2 Advertisements"
@@ -125,8 +125,8 @@
           - "{{ mlb_setup_name | default('metallb') }}"
   register: l2adver
   until: l2adver is succeeded
-  retries: 6
-  delay: 10
+  retries: "{{ mlb_wait_retries }}"
+  delay: "{{ mlb_wait_delay }}"
   no_log: true
   when:
     - mlb_bgp_peers is undefined
@@ -138,7 +138,7 @@
     namespace: "{{ mlb_namespace }}"
   register: pod_list
   until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
-  retries: 9
-  delay: 10
+  retries: "{{ mlb_wait_retries }}"
+  delay: "{{ mlb_wait_delay }}"
   no_log: true
 ...


### PR DESCRIPTION
Introduces mlb_wait_retries and mlb_wait_delay with sane defaults.

This is needed in slower environments, and results in a faster turn-around than adjusting the individual static values by PR.

---

- [x] TestDallas:  ocp-4.15-vanilla - https://www.distributed-ci.io/jobs/4595ad37-24b6-4f87-ac6e-48ffb889b987/jobStates

---

Test-Hints: no-check