### PR TITLE
Limit max OCP version in operator annotations by deprecated API check

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.15.EPOCH
+Version:        0.16.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.15.0
+version: 0.16.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/deprecated_api/tasks/get_api_request_counts_per_namespace.yml
+++ b/roles/deprecated_api/tasks/get_api_request_counts_per_namespace.yml
@@ -43,4 +43,27 @@
     ocp_filename: "{{ deprecated_api_logs.path }}/apirequestcounts_ocp_compatibility_{{ da_ns }}_junit.xml"
   ansible.builtin.set_fact:
     ocp_compatibility: "{{ da_removed_api | redhatci.ocp.ocp_compatibility(da_ocp_version, ocp_filename) }}"
+
+# 99.99 is used when the deprecated API check imposes no limitations
+- name: "Extract the OCP version up to which the workload is compatible in {{ da_ns }}"
+  ansible.builtin.set_fact:
+    da_current_ns_ocp_limit: "{{ max_compatible_version }}"
+  vars:
+    compatible_versions: >-
+      {{ ocp_compatibility | dict2items | selectattr('value', 'equalto', 'compatible') | map(attribute='key') | map('trim') | list }}
+    all_values: >-
+      {{ ocp_compatibility | dict2items | map(attribute='value') | list | unique }}
+    highest_compatible_version: >-
+      {{ compatible_versions | max | trim }}
+    max_compatible_version: >-
+      {{ "99.99" if all_values | length == 1 and 'compatible' in all_values else highest_compatible_version }}
+
+- name: Compare the OCP limit for the current ns with previously examined ns and select the min
+  ansible.builtin.set_fact:
+    da_max_compatible_ocp_version: >-
+      {%- if da_max_compatible_ocp_version is defined -%}
+        {{ da_current_ns_ocp_limit if da_current_ns_ocp_limit is version(da_max_compatible_ocp_version, '<') else da_max_compatible_ocp_version }}
+      {%- else -%}
+        {{ da_current_ns_ocp_limit }}
+      {%- endif %}
 ...

--- a/roles/preflight/README.md
+++ b/roles/preflight/README.md
@@ -21,6 +21,7 @@ catalog_url                       | https://catalog.redhat.com/api/containers/v1
 preflight_run_health_check      | true                                                 | Optional. Run health check on every container and generate oval reports both in xml and HTML formats.
 preflight_dci_all_components_are_ga | true                                             | Optional. Only submit test results when all components in the list `dci_ga_components_for_certification` are GA.
 max_images_per_batch | 1                                             | Optional. This variable allows the user to adjust the number of images processed per batch for running preflight in parallel. By default, it is set to `1`.
+validate_annotations_yaml | true | Optional. Enable or disable validation of operators' annotations.yaml against deprecated API check limitations.
 
 
 ## Variables to define for each operator in preflight_operators_to_certify

--- a/roles/preflight/tasks/test_validate_annotations.yml
+++ b/roles/preflight/tasks/test_validate_annotations.yml
@@ -1,0 +1,68 @@
+---
+- name: Retrieve annotations.yaml file from bundle image
+  ansible.builtin.shell:
+    cmd: >
+      podman cp
+      $(podman create --rm {{ operator.bundle_image }} bash):/metadata/annotations.yaml .
+    chdir: "{{ preflight_operator_artifacts.path }}"
+
+- name: Read annotations.yaml file
+  ansible.builtin.slurp:
+    src: "{{ preflight_operator_artifacts.path }}/annotations.yaml"
+  register: _preflight_annotations_file
+
+- name: Convert annotations.yaml content to string
+  ansible.builtin.set_fact:
+    preflight_annotations_content: "{{ _preflight_annotations_file['content'] | b64decode }}"
+
+# Possible formats of the OCP version range:
+# https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions
+- name: Extract OCP version range or pinned version from annotations.yaml
+  ansible.builtin.set_fact:
+    preflight_ocp_range: "{{ preflight_annotations_content | regex_search(preflight_range_pattern) | trim }}"
+  vars:
+    preflight_range_pattern: "com.redhat.openshift.versions:\\s*(=?.*)"
+
+# Range pattern "v4.11-v4.16" declares operator compatibility from 4.11 to 4.16, inclusive.
+# Pinned pattern "=v4.16" declares pinned compatibility with version 4.16.
+# Unlimited pattern "v4.16" declares compatibility with version 4.16 and all later versions.
+- name: Extract max OCP version from annotations.yaml
+  ansible.builtin.set_fact:
+    preflight_max_ocp: "{{ preflight_ocp_range | regex_replace('=v', 'v') | regex_search(preflight_max_pattern) | regex_replace('v', '') | regex_replace('.*-', '') }}"
+  vars:
+    preflight_max_pattern: "v[0-9]+\\.[0-9]+(-v[0-9]+\\.[0-9]+)?"
+
+# Handle OCP version validation when com.redhat.openshift.versions is defined in annotations.yaml
+# If not, just skip the validation.
+- name: Handle OCP version validation when com.redhat.openshift.versions is defined
+  when: preflight_max_ocp != 'None'
+  block:
+    - name: Check if OCP version is unlimited
+      ansible.builtin.set_fact:
+        preflight_unlimited_ocp_version: "{{
+          preflight_ocp_range is regex(preflight_unlimited_pattern)
+          and not (preflight_ocp_range is regex(preflight_range_pattern)
+          or preflight_ocp_range is regex(preflight_pinned_pattern)) }}"
+      vars:
+        preflight_range_pattern: ".*v[0-9]+\\.[0-9]+-v[0-9]+\\.[0-9]+.*"
+        preflight_pinned_pattern: ".*=v[0-9]+\\.[0-9]+.*"
+        preflight_unlimited_pattern: ".*v[0-9]+\\.[0-9]+.*"
+
+    - name: Ensure that unlimited OCP version declared in the annotations.yaml passing deprecated API check
+      ansible.builtin.fail:
+        msg: >-
+          Defined OCP range {{ preflight_ocp_range }} is invalid, there is a workload API deprecated in {{ da_max_compatible_ocp_version }}.
+          The incompatible API could be found in apirequestcounts_ocp_compatibility_*_junit.xml.
+      when:
+        - preflight_unlimited_ocp_version | bool
+        - da_max_compatible_ocp_version != '99.99'
+
+    - name: Compare max version from annotations.yaml with limitations by deprecated API check
+      ansible.builtin.fail:
+        msg: >-
+          Defined OCP range {{ preflight_ocp_range }} is invalid, there is a workload API deprecated in {{ da_max_compatible_ocp_version }}.
+          The incompatible API could be found in apirequestcounts_ocp_compatibility_*_junit.xml.
+      when:
+        - not preflight_unlimited_ocp_version | bool
+        - da_max_compatible_ocp_version is version(preflight_max_ocp, '<=')
+...

--- a/roles/preflight/tasks/tests_preflight_check_operator.yml
+++ b/roles/preflight/tasks/tests_preflight_check_operator.yml
@@ -116,6 +116,10 @@
   with_fileglob:
     - "{{ preflight_operator_artifacts.path }}/*"
 
+- name: Validate annotations.yaml
+  ansible.builtin.include_tasks: test_validate_annotations.yml
+  when: validate_annotations_yaml | default(true) | bool
+
 - name: Cleanup
   block:
     - name: Delete preflight namespace


### PR DESCRIPTION
build-depends: https://github.com/dci-labs/dallas-pipelines/pull/1200
build-depends: 32235

CheckDallasWorkload: preflight-green