### PR TITLE
Add support for insecure registries

### DIFF
--- a/roles/acm_hypershift/README.md
+++ b/roles/acm_hypershift/README.md
@@ -51,7 +51,8 @@ At this time the role supports creating the OpenShift required endpoints under t
 | ah_hcp_cli_path         |                                           | No        | Path to the hcp CLI, if `ah_download_cli` the role will get the binary from the Management Cluster
 | ah_ssh_key              | `sshKey` from Management cluster          | No        | SSH key to be added to the `authorized_keys` file in NodePool's instances
 | ah_disconnected         | False                                     | No        | Defines if the management cluster is in a disconnected (air-gapped) environment
-| ah_control_plane_availability_policy | HighlyAvailable              | No        | ControllerAvailabilityPolicy specifies the availability policy applied to critical control plane components. Options: HighlyAvailable, SingleReplica |
+| ah_control_plane_availability_policy | HighlyAvailable              | No        | ControllerAvailabilityPolicy specifies the availability policy applied to critical control plane components. Options: HighlyAvailable, SingleReplica
+| ah_allow_insecure_registry | True                                   | No        | Allow interacting with registries that are using an unknown CA certificate
 
 ## Disconnected control planes
 

--- a/roles/acm_hypershift/defaults/main.yml
+++ b/roles/acm_hypershift/defaults/main.yml
@@ -9,5 +9,6 @@ ah_hc_annotations: ""
 ah_node_memory: 8Gi
 ah_node_pool_replicas: 2
 ah_no_log: true
+ah_allow_insecure_registry: true
 cpo_annotation: ""
 ...

--- a/roles/acm_hypershift/tasks/kvirt-disconnected.yml
+++ b/roles/acm_hypershift/tasks/kvirt-disconnected.yml
@@ -6,6 +6,9 @@
       set -x -o pipefail ;
       oc adm release info
       {{ ah_release_image }}
+      {%- if ah_allow_insecure_registry | bool %}
+      --insecure
+      {%- endif %}
       --registry-config={{ ah_pullsecret_file }} |
       grep -w hypershift |
       awk '{print $2}'
@@ -40,6 +43,9 @@
   ansible.builtin.command: >
     skopeo inspect
     --no-tags
+    {%- if ah_allow_insecure_registry | bool %}
+    --tls-verify=false
+    {%- endif %}
     docker://{{ cpo_image_path }}
   no_log: true
   register: skopeo_result
@@ -56,6 +62,9 @@
       --confirm
       --file /release-manifests/0000_50_installer_coreos-bootimages.yaml
       --registry-config={{ ah_pullsecret_file }}
+      {%- if ah_allow_insecure_registry | bool %}
+      --insecure
+      {%- endif %}
   retries: 3
   delay: 10
   register: hs_boot_images
@@ -92,6 +101,9 @@
       {{ kvirt_rhcos_digest }}
       {{ local_registry_path }}:{{ rhcos_tag }}
       --registry-config={{ ah_pullsecret_file }}
+      {%- if ah_allow_insecure_registry | bool %}
+      --insecure
+      {%- endif %}
   retries: 3
   delay: 10
   register: hs_boot_images

--- a/roles/acm_hypershift/tasks/main.yml
+++ b/roles/acm_hypershift/tasks/main.yml
@@ -60,6 +60,9 @@
       set -x -o pipefail;
       oc adm release info
       {{ ah_release_image }}
+      {%- if ah_allow_insecure_registry | bool %}
+      --insecure
+      {%- endif %}
       --output json
       --registry-config={{ ah_pullsecret_file }} |
       jq -r .metadata.version

--- a/roles/mirror_ocp_release/README.md
+++ b/roles/mirror_ocp_release/README.md
@@ -23,6 +23,8 @@ If enabled, the role requires an container registry to mirror the OCP container 
 | mor_version                  | undefined                             | Yes      | An OpenShift version number e.g. 4.10.45                                                       |
 | mor_webserver_url            | undefined                             | Yes      | URL of the web server where the installation artifact are stored                               |
 | mor_write_custom_config      | true                                  | No       | Writes the OCP configuration files and sets the custom URL facts                               |
+| mor_allow_insecure_registry  | true                                  | No       | Allow interacting with registries that are using an unknown CA certificate                     |
+
 
 ## Requirements
 

--- a/roles/mirror_ocp_release/defaults/main.yml
+++ b/roles/mirror_ocp_release/defaults/main.yml
@@ -15,6 +15,7 @@ mor_mirror_disk_images: true
 mor_mirror_container_images: true
 mor_write_custom_config: true
 mor_registry_path: "ocp-{{ mor_base_version }}/{{ mor_version }}"
+mor_allow_insecure_registry: true
 # Required images according install type
 mor_ipi:
  - openstack

--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -4,6 +4,9 @@
     skopeo inspect
     --no-tags
     --authfile {{ mor_auths_file }}
+    {%- if mor_allow_insecure_registry | bool %}
+    --tls-verify=false
+    {%- endif %}
     docker://{{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
   register: _mor_release_image
   failed_when: false
@@ -16,12 +19,19 @@
     --from={{ ocp_release_data['container_image'] | quote }}
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
     --to={{ mor_registry_url }}/{{ mor_registry_path }}
+    {%- if mor_allow_insecure_registry | bool %}
+    --insecure
+    {%- endif %}
   retries: 3
   delay: 10
   register: _mor_result
   until: _mor_result.rc == 0
   changed_when: _mor_result.rc == 0
-  when: _mor_release_image.rc != 0 or mor_force | bool
+  when:
+    - _mor_release_image is defined
+    - _mor_release_image.rc is defined
+    - _mor_release_image.rc != 0
+      or mor_force | bool
 
 - name: Generate Image Source manifest
   ansible.builtin.command: >-
@@ -31,6 +41,9 @@
     --to-release-image={{ mor_registry_url }}/{{ mor_registry_path }}:{{ mor_version }}
     --to={{ mor_registry_url }}/{{ mor_registry_path }}
     {{ mor_version is version("4.14", "<") | ternary("--dry-run", "--print-mirror-instructions=" + mor_is_type | lower ) }}
+    {%- if mor_allow_insecure_registry | bool %}
+    --insecure
+    {%- endif %}
   retries: 3
   delay: 10
   register: _mor_result

--- a/roles/mirror_ocp_release/tasks/registry.yml
+++ b/roles/mirror_ocp_release/tasks/registry.yml
@@ -28,9 +28,9 @@
   until: _mor_result.rc == 0
   changed_when: _mor_result.rc == 0
   when:
-    - _mor_release_image is defined
-    - _mor_release_image.rc is defined
-    - _mor_release_image.rc != 0
+    - (_mor_release_image is defined and
+      _mor_release_image.rc is defined and
+      _mor_release_image.rc != 0)
       or mor_force | bool
 
 - name: Generate Image Source manifest

--- a/roles/prune_catalog/README.md
+++ b/roles/prune_catalog/README.md
@@ -15,7 +15,7 @@ pc_expire              | No       | false                                       
 pc_expire_time         | No       | 5h                                            | The amount of time to set for the expiration label
 pc_maintainer          | No       | redhatci.ocp                                  | Value for catalog's image maintainer label
 pc_ignore_pull_errors  | No       | false                                         | Makes the role fail if the image to prune is not available
-
+pc_allow_insecure_registry | No   | true                                          | Allow interacting with registries that are using an unknown CA certificate
 ## Requirements
 
 The following application must be already present on the system.

--- a/roles/prune_catalog/defaults/main.yml
+++ b/roles/prune_catalog/defaults/main.yml
@@ -5,4 +5,5 @@ pc_expire_time: 5h
 pc_opm_auths: "/usr/share/dci-openshift-agent/utils/opm-auths"
 pc_maintainer: "redhatci.ocp"
 pc_ignore_pull_errors: false
+pc_allow_insecure_registry: true
 ...

--- a/roles/prune_catalog/tasks/main.yml
+++ b/roles/prune_catalog/tasks/main.yml
@@ -11,16 +11,18 @@
       - pc_destination_catalog | length > 0
     fail_msg: "At least one of the parameters requirements is missing"
 
-- name: "Check if image is pullable - {{ pc_source_catalog }} "
-  ansible.builtin.shell: >
-    if [ -n "$DOCKER_CONFIG" ]; then
-      skopeo inspect --no-tags \
-      --authfile "$DOCKER_CONFIG/config.json" \
-      --tls-verify=false docker://{{ pc_source_catalog }}
-    else
-      skopeo inspect --no-tags \
-      --tls-verify=false docker://{{ pc_source_catalog }}
-    fi
+- name: "Check if image is pullable - {{ pc_source_catalog }}"
+  vars:
+    docker_config_defined: "{{ DOCKER_CONFIG is defined }}"
+  ansible.builtin.command: >
+    skopeo inspect --no-tags
+    {%- if pc_allow_insecure_registry | bool %}
+    --tls-verify=false
+    {%- endif %}
+    {%- if docker_config_defined | bool %}
+    --authfile "$DOCKER_CONFIG/config.json"
+    {%- endif %}
+    docker://{{ pc_source_catalog }}
   register: skopeo_result
   changed_when: skopeo_result.rc == 0
   retries: 3
@@ -67,13 +69,11 @@
         mode: "0755"
 
     - name: "Render the source catalog"
-      vars:
-        opm_auths: "/usr/share/dci-openshift-agent/utils/opm-auths"
       ansible.builtin.shell:
         chdir: "{{ pc_tmp_dir }}"
         cmd: >
           set -x;
-          {{ opm_auths }}
+          {{ pc_opm_auths }}
           {{ pc_opm_cmd }} render {{ pc_source_catalog }} >
           index-packages
       register: prune_result

--- a/roles/prune_catalog/tasks/main.yml
+++ b/roles/prune_catalog/tasks/main.yml
@@ -12,14 +12,12 @@
     fail_msg: "At least one of the parameters requirements is missing"
 
 - name: "Check if image is pullable - {{ pc_source_catalog }}"
-  vars:
-    docker_config_defined: "{{ DOCKER_CONFIG is defined }}"
   ansible.builtin.command: >
     skopeo inspect --no-tags
     {%- if pc_allow_insecure_registry | bool %}
     --tls-verify=false
     {%- endif %}
-    {%- if docker_config_defined | bool %}
+    {%- if lookup('ansible.builtin.env', 'DOCKER_CONFIG') | length %}
     --authfile "$DOCKER_CONFIG/config.json"
     {%- endif %}
     docker://{{ pc_source_catalog }}


### PR DESCRIPTION
- Allow interaction with registries using an unknown CA. Default is set as already in place in other roles.
- In catalog_prune role, allowing to override the opm_auths wrapper.

TestDallas: ocp-4.14-vanilla