### PR TITLE
sriov_config | Add OCPBUGS-32139 workaround

### DIFF
--- a/roles/sriov_config/tasks/create_node_policies.yml
+++ b/roles/sriov_config/tasks/create_node_policies.yml
@@ -1,4 +1,6 @@
 ---
+# OCPBUGS-32139 workaround suggests to retry the creation of the SRIOV policy if failing.
+# Trying this during 1 minute in case any of them fails.
 - name: Create SriovNetworkNodePolicy
   community.kubernetes.k8s:
     definition: "{{ lookup('template', 'templates/sriov-network-node-policy.yml.j2') }}"
@@ -6,6 +8,10 @@
   loop_control:
     loop_var: sriov
     label: "{{ sriov.resource }}"
+  retries: 6
+  delay: 10
+  register: _sc_node_policy_retry
+  until: _sc_node_policy_retry.error is not defined
   when: sriov.node_policy is defined
 
 - name: Check for SRIOV Node Policy


### PR DESCRIPTION
We have started to see [this issue](https://issues.redhat.com/browse/OCPBUGS-32139) in some SRIOV-based deployments. This is not 100% reproducible but it is happening now from time to time. Example [here](https://www.distributed-ci.io/jobs/e7c9b138-ee53-41d5-80ce-d7ccaf801f6f/jobStates?sort=date&task=f6d1f3e3-77e4-4de9-815c-5f0e8e1c003a).

Proposed workaround is retry applying SRIOV policies. Just doing this.

Test-Hints: no-check