### PR TITLE
Select RHEL version for oc stable binary in SNO and UPI installers

### DIFF
--- a/roles/sno_installer/tasks/10_get_oc.yml
+++ b/roles/sno_installer/tasks/10_get_oc.yml
@@ -101,7 +101,7 @@
   vars:
     ocp_stable_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
   ansible.builtin.unarchive:
-    src: "{{ ocp_stable_url }}/stable/openshift-client-linux.tar.gz"
+    src: "{{ ocp_stable_url }}/stable/openshift-client-linux-amd64-rhel{{ ansible_distribution_major_version }}.tar.gz"
     dest: "{{ sno_tmp_dir.path }}"
     remote_src: true
     mode: "0755"

--- a/roles/upi_installer/tasks/10_get_oc.yml
+++ b/roles/upi_installer/tasks/10_get_oc.yml
@@ -99,7 +99,7 @@
   vars:
     ocp_stable_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
   ansible.builtin.unarchive:
-    src: "{{ ocp_stable_url }}/stable/openshift-client-linux.tar.gz"
+    src: "{{ ocp_stable_url }}/stable/openshift-client-linux-amd64-rhel{{ ansible_distribution_major_version }}.tar.gz"
     dest: "{{ upi_tmp_dir.path }}"
     remote_src: true
     mode: "0755"


### PR DESCRIPTION
Since OCP 4.16 became GA, oc stable binary is now based on that release and it is expecting GLIBC library to be present, which is only delivered in RHEL9.

To keep compatibility with RHEL8 servers, using stable binary but indicating the RHEL version to use.


TestBos2Sno: sno