### PR TITLE
create_vms & sushy | Allow disabling Secure Boot mode

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.11.EPOCH
+Version:        0.12.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -51,6 +51,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Wed Jul 10 2024 Ramon Perez <raperez@redhat.com> - 0.12.EPOCH-VERS
+- Version bump due to create_vms and setup_sushy_tools roles
+
 * Fri Jun 14 2024 Tony Garcia <tonyg@redhat.com> - 0.11.EPOCH-VERS
 - Version bump due to mirror_ocp_release role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.11.0
+version: 0.12.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/create_vms/defaults/main.yml
+++ b/roles/create_vms/defaults/main.yml
@@ -19,3 +19,12 @@ is_on_rhel9: "{{ (ansible_distribution_major_version == '9' and ansible_distribu
 
 # allowed modes: 'bridge', 'nat', using 'bridge' as default
 create_vms_network_mode: bridge
+
+# disable secure boot, false by default
+create_vms_disable_secure_boot: false
+
+# Path to default OVMF_VARS.fd file used for non secure boot
+create_vms_non_secure_ovmf_vars_path: /usr/share/edk2/ovmf/OVMF_VARS.fd
+
+# Path to default OVMF_VARS.fd file used for secure boot
+create_vms_secure_ovmf_vars_path: /usr/share/edk2/ovmf/OVMF_VARS.secboot.fd

--- a/roles/create_vms/tasks/provision_vms.yml
+++ b/roles/create_vms/tasks/provision_vms.yml
@@ -14,7 +14,40 @@
         state: directory
         recurse: yes
 
+    # `create_vms_x86_64_ovmf_code_path` variable is used in
+    # `create_vm.sh.j2` script
+    # Using the same logic that we have in setup_sushy_tools
+    # to be aligned
+    # Default behavior
+    - name: Set X86_64 OVMF code path (secure boot enabled)
+      when: not create_vms_disable_secure_boot | bool
+      block:
+        - name: Set X86_64 OVMF code path
+          ansible.builtin.set_fact:
+            create_vms_x86_64_ovmf_code_path: "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
+
+        - name: Check x86_64 OVMF code path
+          ansible.builtin.stat:
+            path: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+          register: _cv_ovmf_x86_64_code_stat
+
+        - name: Set x86_64 OVMF code path (legacy)
+          ansible.builtin.set_fact:
+            create_vms_x86_64_ovmf_code_path: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+          when:
+            - _cv_ovmf_x86_64_code_stat.stat.exists
+            - not _cv_ovmf_x86_64_code_stat.stat.islnk
+
+    # In case secure boot is disabled, OVMF code path must be
+    # "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+    - name: Set X86_64 OVMF code path (secure boot disabled)
+      ansible.builtin.set_fact:
+        create_vms_x86_64_ovmf_code_path: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+      when: create_vms_disable_secure_boot | bool
+
     - name: Create vm creation_scripts
+      vars:
+        create_vms_ovmf_vars_path: "/var/lib/libvirt/qemu/nvram/{{ item.name }}_VARS.fd"
       template:
         # community.libvirt.virt doesn't define the qcow image so it was chosen to use
         # virt-install. The reason we use a script is to aid with debugging on the host

--- a/roles/create_vms/templates/create_vm.sh.j2
+++ b/roles/create_vms/templates/create_vm.sh.j2
@@ -1,5 +1,10 @@
 #! /bin/bash
 
+{% if create_vms_disable_secure_boot %}
+# Copy VARS.fd file related to non secure boot mode if that's the case
+cp {{ create_vms_non_secure_ovmf_vars_path }} {{ create_vms_ovmf_vars_path }}
+{% endif %}
+
 virt-install \
     --virt-type=kvm \
     --name "{{ item.name }}" \
@@ -20,7 +25,12 @@ virt-install \
     --noautoconsole \
     --wait=-1 \
     {% if not is_on_rhel9 %}
-    --boot uefi \
+    {% if create_vms_disable_secure_boot %}
+    --boot loader={{ create_vms_x86_64_ovmf_code_path }},loader.readonly=yes,loader.secure='no',loader.type=pflash,nvram={{ create_vms_ovmf_vars_path }} \
+    {% else %}
+    --boot loader={{ create_vms_x86_64_ovmf_code_path }},loader.readonly=yes,loader.secure='yes',loader.type=pflash,nvram={{ create_vms_ovmf_vars_path }},nvram.template={{ create_vms_secure_ovmf_vars_path }} \
+    --features smm=on \
+    {% endif %}
     {% endif %}
     --events on_reboot=restart \
     --autostart \

--- a/roles/setup_sushy_tools/defaults/main.yml
+++ b/roles/setup_sushy_tools/defaults/main.yml
@@ -30,4 +30,8 @@ secure_sushy_tools: "{{ secure | default(true) }}"
 sushy_fqdn: "{{ ansible_fqdn }}"
 
 is_on_rhel9: "{{ (ansible_distribution_major_version == '9' and ansible_distribution == 'RedHat') | bool }}"
+
+# disable secure boot, false by default
+setup_sushy_tools_disable_secure_boot: false
+
 ...

--- a/roles/setup_sushy_tools/tasks/main.yml
+++ b/roles/setup_sushy_tools/tasks/main.yml
@@ -82,21 +82,32 @@
             privatekey_path: "{{ sushy_cert_dir }}/sushy_tools.key"
             cert_common_name: "{{ sushy_fqdn }}"
 
-    - name: Set X86_64 OVMF code path
-      set_fact:
-        sushy_x86_64_ovmf_code_path: "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
+    # Default behavior
+    - name: Set X86_64 OVMF code path (secure boot enabled)
+      when: not setup_sushy_tools_disable_secure_boot | bool
+      block:
+        - name: Set X86_64 OVMF code path
+          ansible.builtin.set_fact:
+            sst_sushy_x86_64_ovmf_code_path: "/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd"
 
-    - name: Check x86_64 OVMF code path
-      stat:
-        path: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
-      register: OVMF_X86_64_CODE_STAT
+        - name: Check x86_64 OVMF code path
+          ansible.builtin.stat:
+            path: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+          register: OVMF_X86_64_CODE_STAT
 
-    - name: Set x86_64 OVMF code path (legacy)
-      set_fact:
-        sushy_x86_64_ovmf_code_path: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
-      when:
-        - OVMF_X86_64_CODE_STAT.stat.exists
-        - not OVMF_X86_64_CODE_STAT.stat.islnk
+        - name: Set x86_64 OVMF code path (legacy)
+          ansible.builtin.set_fact:
+            sst_sushy_x86_64_ovmf_code_path: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+          when:
+            - OVMF_X86_64_CODE_STAT.stat.exists
+            - not OVMF_X86_64_CODE_STAT.stat.islnk
+
+    # In case secure boot is disabled, OVMF code path must be
+    # "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+    - name: Set X86_64 OVMF code path (secure boot disabled)
+      ansible.builtin.set_fact:
+        sst_sushy_x86_64_ovmf_code_path: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+      when: setup_sushy_tools_disable_secure_boot | bool
 
     - name: Create sushy-tools conf
       template:

--- a/roles/setup_sushy_tools/templates/sushy-emulator.conf.j2
+++ b/roles/setup_sushy_tools/templates/sushy-emulator.conf.j2
@@ -49,7 +49,7 @@ SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = {{ (sushy_ignore_boot_device | bool) | terna
 # system architecture
 SUSHY_EMULATOR_BOOT_LOADER_MAP = {
     u'UEFI': {
-        u'x86_64': u'{{ sushy_x86_64_ovmf_code_path }}',
+        u'x86_64': u'{{ sst_sushy_x86_64_ovmf_code_path }}',
         u'aarch64': u'/usr/share/AAVMF/AAVMF_CODE.fd'
     },
     u'Legacy': {


### PR DESCRIPTION
- This is required for some use cases, e.g. run tests with syscall iopl()
- Allowing to disable Secure Boot mode with a flag variable, false by default
- This affects to create_vms and setup_sushy_tools roles. Some variables needed to be updated to follow collections' best practices.
- Changed VM creation script, not using `--boot uefi` mode, just to be able to reuse the variables we're defining for the OVMF path. The proposed config for the "enabled secure boot" case is exactly what would be generated when using `--boot uefi` mode

Test-Hints: no-check

build-depends: 31929

- [x] ABI job with secure boot enabled - https://www.distributed-ci.io/jobs/c7f0114c-bb1c-44c3-a8b8-3c7cd166f775/jobStates?sort=date

```
$ sudo virsh dumpxml dciokd-worker-1
...
  <os>                                                      
    <type arch='x86_64' machine='pc-q35-rhel8.6.0'>hvm</type>                    
    <loader readonly='yes' secure='yes' type='pflash'>/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd</loader>
    <nvram template='/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd'>/var/lib/libvirt/qemu/nvram/dciokd-worker-1_VARS.fd</nvram>
    <boot dev='fd'/>
  </os>
  <features>
    <acpi/>
    <apic/>
    <smm state='on'/>
  </features>
...

$ ssh core@dciokd-worker-1.server06.partnerci.bos2.lab
...
---
[core@dciokd-worker-1 ~]$ dmesg | grep secure
[    0.000000] secureboot: Secure boot enabled
[    0.012221] secureboot: Secure boot enabled
```

- [x] ABI job with secure boot disabled - https://www.distributed-ci.io/jobs/a7155ff1-2f16-4889-9707-341b4ad4fddc/jobStates?sort=date

```
$ sudo virsh dumpxml dciokd-worker-1
...
  <os>
    <type arch='x86_64' machine='pc-q35-rhel8.6.0'>hvm</type>
    <loader readonly='yes' secure='no' type='pflash'>/usr/share/OVMF/OVMF_CODE.secboot.fd</loader>
    <nvram>/var/lib/libvirt/qemu/nvram/dciokd-worker-1_VARS.fd</nvram>
    <boot dev='fd'/>
  </os>
  <features>
    <acpi/>
    <apic/>
  </features>
...

$ ssh core@dciokd-worker-1.server03.partnerci.bos2.lab
...
---
[core@dciokd-worker-1 ~]$ dmesg | grep secure
[    0.000000] secureboot: Secure boot disabled
[    0.012947] secureboot: Secure boot disabled
```