### PR TITLE
DNM - Assisted - Increase time to start cluster installation

### DIFF
--- a/roles/install_cluster/tasks/main.yml
+++ b/roles/install_cluster/tasks/main.yml
@@ -197,7 +197,7 @@
   when: install | bool == True
 
 
-- name: Allow up to 5 minutes for cluster to begin installing
+- name: Allow up to 10 minutes for cluster to begin installing
   uri:
     url: "{{ URL_ASSISTED_INSTALLER_CLUSTER }}"
     method: GET
@@ -208,6 +208,6 @@
   when: install | bool == True
   register: cluster_output
   until: cluster_output.json.status in cluster_installation_states
-  retries: 5
+  retries: 10
   delay: 60
 ...


### PR DESCRIPTION
Recent deployment are taking more time to start the installation. No issues in the install requirements are shown.

TestBos2: assisted