### PR TITLE
Migration of nfv-example-cnf-deploy roles to redhatci.ocp.collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Name | Description
 [redhatci.ocp.deprecated_api](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/deprecated_api/README.md) | Extracts deprecated API calls in a cluster
 [redhatci.ocp.destroy_vms](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/destroy_vms/README.md) | Destroys libvirt network, storage pools and the KVM Nodes and the network bridge connection.
 [redhatci.ocp.display_deployment_plan](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/display_deployment_plan/README.md) | Displays the crucible deployment plan and waits for user confirmation.
-[redhatci.ocp.efi_boot_mgr](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/efi_boot_mgr/README.md) | Remove the non-active UEFI boot entries from OCP nodes.
+[redhatci.ocp.efi_boot_mgr](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/efi_boot_mgr/README.md) | Removes the non-active UEFI boot entries from OCP nodes.
+[redhatci.ocp.example_cnf_deploy](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/example_cnf_deploy/README.md) | Deploys the example-cnf workload on top of an OpenShift cluster
 [redhatci.ocp.extract_openshift_installer](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/extract_openshift_installer/README.md) | Extracts openshift_installer binary from the release image.
 [redhatci.ocp.generate_agent_iso](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/generate_agent_iso/README.md) | Creates the boot ISO using OpenShift_installer's agent sub-command
 [redhatci.ocp.generate_discovery_iso](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/generate_discovery_iso/README.md) | Creates the discovery ISO for a pre-existing cluster definition using a pre-existing on-prem assisted installer

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.16.EPOCH
+Version:        0.17.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -51,6 +51,12 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Fri Sep  6 2024 Ramon Perez <raperez@redhat.com> - 0.17.EPOCH-VERS
+- Version bump for example_cnf_deploy role
+
+* Wed Aug 28 2024 Tatiana Krishtop <tkrishto@redhat.com> - 0.16.EPOCH-VERS
+- Limit max OCP version in operator annotations by deprecated API check
+
 * Wed Jul 31 2024 Tony Garcia <tonyg@redhat.com> - 0.15.EPOCH-VERS
 - Version bump for mirror_images role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.16.0
+version: 0.17.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/plugins/modules/packet_missing.py
+++ b/plugins/modules/packet_missing.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: packet_missing
+
+short_description: Organize packet missing events
+
+version_added: "2.9"
+
+description:
+    - Organize the packet missing and recovery events to find packet loss
+
+options:
+    matched:
+        description:
+            - K8S Event resource list for packet matches
+        required: true
+        type: list
+    dropped:
+        description:
+            - K8S Event resource list for packet dropped
+        required: true
+        type: list
+    strict:
+        description:
+            - Whether to uset strict checking on events or ignore short differences
+        required: false
+        type: bool
+        default: false
+
+author:
+    - Saravanan KR (@krsacme)
+'''
+
+EXAMPLES = '''
+# Parse event list
+- name: prase event list
+  packet_missing:
+    matched: []
+    dropped: []
+    strict: no
+
+'''
+
+RETURN = '''
+message:
+    description: The output message that the test module generates
+    type: str
+    returned: always
+missing:
+    description: List of instances where the packet missing is observed
+    type: list
+    returned: always
+'''
+
+import traceback
+
+from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from dateutil.parser import parse
+except ImportError:
+    HAS_PARSE = False
+    PARSE_ERROR = traceback.format_exc()
+else:
+    HAS_PARSE = True
+    PARSE_ERROR = None
+
+
+def get_missing_list(module, result):
+
+    matched = module.params['matched']
+    dropped = module.params['dropped']
+    strict = module.params['strict']
+    combine = sorted(matched + dropped, key=lambda x: parse(x['eventTime']))
+    result['count'] = len(combine)
+    if len(combine) < 2:
+        result['message'] = "Event list length is lesser thatn 2"
+        return False
+    if combine[0]['reason'] == 'PacketMatched':
+        del combine[0]
+    if combine[0]['reason'] != 'PacketDropped':
+        result['message'] = "First event should be dropped"
+        return False
+
+    missing = []
+    for i in range(0, len(combine), 2):
+        if combine[i]['reason'] != 'PacketDropped' and len(combine) > (i + 1):
+            result['warning'] = ("Resson %s is not valid" % combine[i]['reason'])
+            if combine[i + 1]['reason'] == 'PacketDropped':
+                del combine[i]
+            continue
+
+        # Handle when the last event is PacketDropped (no recovery event)
+        if len(combine) == (i + 1):
+            missing.append({'start': combine[i]['eventTime'], 'duration': -1})
+            result['warning'] = "Last event is dropped"
+            break
+
+        if combine[i + 1]['reason'] != 'PacketMatched':
+            result['message'] = ("Reason %s is not valid for followed event" % combine[i + 1]['reason'])
+            return False
+
+        dropped_time = parse(combine[i]['eventTime'])
+        matched_time = parse(combine[i + 1]['eventTime'])
+        diff = matched_time - dropped_time
+        diff_seconds = diff.total_seconds()
+        if not strict and int(diff_seconds) <= 1:
+            continue
+        obj = {}
+        obj['start'] = combine[i]['eventTime']
+        obj['duration'] = diff_seconds
+        missing.append(obj)
+
+    result['missing'] = missing
+    if missing:
+        result['message'] = "Packet miss found"
+    elif not strict and missing:
+        result['message'] = "No packet miss during migration"
+    else:
+        result["message"] = "No packet miss"
+    return True
+
+
+def run_module():
+    module_args = dict(
+        matched=dict(type='list', required=True),
+        dropped=dict(type='list', required=True),
+        strict=dict(type='bool', required=False, default=False)
+    )
+
+    result = dict(
+        changed=False,
+        missing=[],
+        message=''
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    if not HAS_PARSE:
+        module.fail_json(
+            msg=missing_required_lib('parse'),
+            exception=PARSE_ERROR)
+
+    result['strict'] = module.params['strict']
+    if len(module.params['matched']) == 0:
+        module.fail_json(msg='matched event list param is empty', **result)
+    elif len(module.params['dropped']) == 0:
+        result['changed'] = True
+        result["message"] = "No packet miss"
+    else:
+        response = get_missing_list(module, result)
+        if response:
+            result['changed'] = True
+        else:
+            result['failed'] = True
+
+    module.exit_json(**result)
+
+
+def main():
+
+    run_module()
+
+
+if __name__ == '__main__':
+
+    main()

--- a/plugins/requirements.txt
+++ b/plugins/requirements.txt
@@ -1,0 +1,1 @@
+dateutil

--- a/roles/catalog_source/README.md
+++ b/roles/catalog_source/README.md
@@ -3,15 +3,17 @@
 A Role to deploy an OLM-based CatalogSource
 
 ## Parameters
-Name             | Required | Default        | Description
------------------|----------| ---------------|-------------
-cs_name          | Yes      |                | Name of the CatalogSource to create
-cs_image         | Yes      |                | Catalog Image URL
-cs_namespace     | No       | openshift-marketplace  | Namespace where the CatalogSource will be defined
-cs_publisher     | No       | Third Party    | CatalogSource publisher
-cs_type          | No       | grpc           | CatalogSource type
+Name               | Required | Default        | Description
+-------------------|----------| ---------------|-------------
+cs_name            | Yes      |                | Name of the CatalogSource to create
+cs_image           | Yes      |                | Catalog Image URL
+cs_namespace       | No       | openshift-marketplace  | Namespace where the CatalogSource will be defined
+cs_publisher       | No       | Third Party    | CatalogSource publisher
+cs_type            | No       | grpc           | CatalogSource type
+cs_update_strategy | No       | {}             | CatalogSource update strategy
 
 ## Example of usage
+
 ```yaml
 - name: "Create a CatalogSource"
   ansible.builtin.include_role:
@@ -21,6 +23,9 @@ cs_type          | No       | grpc           | CatalogSource type
     cs_namespace: "openshift-marketplace"
     cs_image: "registry.redhat.io/redhat/redhat-operator-index:v4.12"
     cs_publisher: "Red Hat"
+    cs_update_strategy:
+      registryPoll:
+        interval: 30m
 ```
 
 ## Authentication

--- a/roles/catalog_source/defaults/main.yml
+++ b/roles/catalog_source/defaults/main.yml
@@ -2,4 +2,6 @@
 cs_namespace: openshift-marketplace
 cs_publisher: "Third party"
 cs_type: grpc
+cs_update_strategy: {}
+
 ...

--- a/roles/catalog_source/tasks/main.yml
+++ b/roles/catalog_source/tasks/main.yml
@@ -24,6 +24,7 @@
         image: "{{ cs_image }}"
         publisher: "{{ cs_publisher }}"
         sourceType: "{{ cs_type }}"
+        updateStrategy: "{{ cs_update_strategy }}"
 
 - name: Wait for CatalogSource to be Ready
   community.kubernetes.k8s_info:

--- a/roles/example_cnf_deploy/README.md
+++ b/roles/example_cnf_deploy/README.md
@@ -1,0 +1,190 @@
+# example_cnf_deploy
+
+This role allows the deployment of example-cnf on OCP, a DPDK based application. See the main project [here](https://github.com/openshift-kni/example-cnf)
+
+## Prerequisites
+
+OpenShift 4 Cluster with at least 3 worker nodes should be deployed with additional operators:
+
+- SR-IOV operator should be deployed and necessary resources for `SriovNetworkNodePolicy` and `SriovNetwork` should be created with target namespace (default namespace used to deploy example-cnf is `example-cnf`).
+- Node Tuning Operator should be deployed and a `PerformanceProfile` should be created.
+
+Also, exported `kubeconfig` file is required to run the Ansible tasks on the target cluster.
+
+## Variables
+
+| Variable                              | Default                                                                                         | Required | Description                                                                                     |
+|---------------------------------------|-------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------------------------|
+| ecd_action                            | None                                                                                            | yes      | Defines which actions to perform. Possible values: ['catalog', 'deploy', 'validate', 'deploy_extra_trex', 'draining'] |
+| ecd_cnf_namespace                     | example-cnf                                                                                     | no       | Name of the namespace where example-cnf is deployed |
+| ecd_registry_url                      | quay.io                                                                                         | no       | Registry URL |
+| ecd_repo_name                         | rh-nfv-int                                                                                      | no       | Repository name |
+| ecd_catalog_name                      | nfv-example-cnf-catalog                                                                         | no       | Catalog name |
+| ecd_operator_version                  | ""                                                                                              | yes      | Version of the index to be used |
+| ecd_catalog_image                     | "{{ ecd_registry_url }}/{{ ecd_repo_name }}/{{ ecd_catalog_name }}:{{ ecd_operator_version }}"  | no       | Index image to be used |
+| ecd_image_pull_policy                 | IfNotPresent                                                                                    | no       | Pull policy used for the images to be deployed |
+| ecd_oc_path                           | /usr/local/bin/oc                                                                               | no       | File path to find the oc binary |
+| ecd_opm_path                          | /usr/local/bin/opm                                                                              | no       | File path to find the opm binary |
+| ecd_job_logs_path                     | /tmp                                                                                            | no       | File path to find the logs folder |
+| ecd_enable_lb                         | true                                                                                            | no       | Enable LoadBalancer, to deploy TestPMD LoadBalancer |
+| ecd_enable_mac_fetch                  | true                                                                                            | no       | Enable MAC fetch, which implies the creation of the CNFAppMac CR |
+| ecd_enable_testpmd                    | true                                                                                            | no       | Enable TestPMD, also known as CNFApp |
+| ecd_enable_trex                       | true                                                                                            | no       | Enable TRex server, to send traffic to TestPMD |
+| ecd_enable_trex_app                   | true                                                                                            | no       | Enable TRex application, to manage the creation of TRex jobs and profiles |
+| ecd_testpmd_channel                   | alpha                                                                                           | no       | TestPMD operators channel |
+| ecd_trex_channel                      | alpha                                                                                           | no       | TRex operator channel |
+| ecd_trex_mac_list                     | ["20:04:0f:f1:89:01","20:04:0f:f1:89:02"]                                                       | no       | Static MAC addresses used by TRex |
+| ecd_lb_gen_port_mac_list              | ["40:04:0f:f1:89:01","40:04:0f:f1:89:02"]                                                       | no       | Static MAC addresses used by the LoadBalancer in its connection with TRex |
+| ecd_lb_cnf_port_mac_list              | ["60:04:0f:f1:89:01","60:04:0f:f1:89:02"]                                                       | no       | Static MAC addresses used by the LoadBalancer in its connection with CNFApp |
+| ecd_testpmd_app_mac_list              | ["80:04:0f:f1:89:01","80:04:0f:f1:89:02"]                                                       | no       | Static MAC addresses used by CNFApp |
+| ecd_cnf_app_networks                  | []                                                                                              | yes      | Connection between LB-CNF in LB mode (or TRex-CNF in direct mode) |
+| ecd_packet_generator_networks         | []                                                                                              | yes      | Connection between TRex-LB in LB mode (not used in direct mode). Required in LB mode |
+| ecd_networks_testpmd_app              | []                                                                                              | no       | Networks for the CNF, including the hardcoded MAC addresses for direct mode case |
+| ecd_termination_grace_period_seconds  | 30                                                                                              | no       | Termination grace period for TestPMD |
+| ecd_trex_test_config                  | []                                                                                              | no       | TRex test configuration. See an example below |
+| ecd_trex_cr_name                      | trexconfig                                                                                      | no       | Name of the TRex CR |
+| ecd_trex_app_cr_name                  | trex-app                                                                                        | no       | Name of the TRexApp CR |
+| ecd_trex_duration                     | 120                                                                                             | no       | Main TRexApp job duration. If set to -1, it will run in continuous burst mode |
+| ecd_default_trex_duration             | 1800                                                                                            | no       | Default duration of TRex execution |
+| ecd_packet_rate                       | 10kpps                                                                                          | no       | Default packet rate from TRex |
+| ecd_trex_core_count                   | 0                                                                                               | no       | Variable that can be used to restrict the cores that TRex uses to create tx queues |
+| ecd_trex_continuous_mode              | false                                                                                           | no       | If set to true, the automation behaves as if TRex job is deployed in continuous mode |
+| ecd_trex_tests_wait                   | true                                                                                            | no       | If set to true, wait until the end of the profile duration before continue |
+| ecd_trex_app_run_passed               | false                                                                                           | no       | By default, till having a positive result, it is supposed that TRex job failed |
+| ecd_trex_job_failed                   | false                                                                                           | no       | Track if TRex job has failed or not |
+| ecd_trex_tests_skip_failures          | false                                                                                           | no       | If set to true, even if TRex job fails, the job will progress |
+| ecd_try_running_migration_tests       | true                                                                                            | no       | The idea is always to try to run the migration test, unless TRex job failed before |
+| ecd_numa_aware_topology               | None                                                                                            | no       | If defined, allows to provide the NUMA aware topology for LoadBalancer, TestPMD and TRexServer CRs |
+| ecd_high_perf_runtime                 | None                                                                                            | no       | If defined, allows to provide the RuntimeClass name for LoadBalancer, TestPMD, TRexApp and TRexServer CRs |
+| ecd_trex_app_version                  | None                                                                                            | yes      | TRexApp version, required in deploy_extra_trex action |
+
+## SR-IOV configuration
+
+Here is an example of the `SriovNetworkNodePolicy` and `SriovNetwork` configuration that can be passed to [redhatci.ocp.sriov_config](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/sriov_config/README.md) role. Note the proper network configuration must be applied to your network devices to match with the SR-IOV configuration proposed:
+
+```yaml
+---
+sriov_network_configs:
+  - resource: intel_numa0_res1
+    node_policy:
+      name: intel-numa0-policy1
+      device_type: vfio-pci
+      is_rdma: false
+      mtu: 9000
+      nic_selector:
+        device_id: 158b
+        pf_names:
+          - ens2f0#0-7
+        vendor: "8086"
+      node_selector:
+        node-role.kubernetes.io/worker: ""
+      num_vfs: 16
+      priority: 99
+  - resource: intel_numa0_res1
+    network:
+      name: intel-numa0-net1
+      network_namespace: example-cnf
+      spoof_chk: "off"
+      trust: "on"
+      vlan: 407
+      capabilities: '{"mac": true}'
+```
+
+## TRex extra profiles
+
+These profiles can be configured by using the `ecd_trex_test_config` variable, so that you can manage to launch several TRexApp jobs with different TRex setups:
+
+```yaml
+# When duration is '-1', the trex will run in continous burst mode
+ecd_trex_test_config:
+  - name: pkt-64-10kpps
+    packet_size: 64
+    packet_rate: 10kpps
+    duration: 120
+    trex_profile_name: ''
+    trex_profile_path: ''
+    trex_profile_cm_name: ''
+```
+
+## Actions
+
+Each action allows you to do different operations with the example-cnf workload:
+
+- catalog: builds the example-cnf catalog.
+- deploy: allows you to deploy the example-cnf operators and workloads.
+- validate: performs validations to the example-cnf workloads to address specific scenarios, e.g. validations after cluster upgrade.
+- deploy_extra_trex: gives you the chance to create a new TRex job, in an already deployed example-cnf instance.
+- draining: while a TRex job is running, runs a node cordoning-draining, selecting the node where TestPMD is running, then it measures the downtime in the TRex job and the packet loss. Only used in direct mode.
+
+### Examples
+
+- catalog action:
+
+```yaml
+---
+- name: Deploy NFV Example CNF catalog
+  vars:
+    ecd_action: "catalog"
+    ecd_operator_version: "{{ operator_version }}"
+  include_role:
+    name: redhatci.ocp.example_cnf_deploy
+```
+
+- deploy action:
+
+```yaml
+---
+- name: Deploy the Example CNF applications
+  vars:
+    ecd_action: "deploy"
+    ecd_cnf_app_networks:
+      - name: intel-numa0-net1
+        count: 1
+      - name: intel-numa0-net2
+        count: 1
+    ecd_packet_generator_networks:
+      - name: intel-numa0-net3
+        count: 1
+      - name: intel-numa0-net4
+        count: 1
+    ecd_operator_version: "latest"
+    ecd_high_perf_runtime: "performance-blueprint"
+  include_role:
+    name: redhatci.ocp.example_cnf_deploy
+```
+
+- validate action:
+
+```yaml
+---
+- name: Run migration test
+  vars:
+    ecd_action: "validate"
+  include_role:
+    name: redhatci.ocp.example_cnf_deploy
+```
+
+- deploy_extra_trex action:
+
+```yaml
+---
+- name: Run a new TRex job
+  vars:
+    ecd_action: "deploy_extra_trex"
+    ecd_trex_app_cr_name: "trex-app-new"
+    ecd_trex_app_version: "trex-app-version"
+  include_role:
+    name: redhatci.ocp.example_cnf_deploy
+```
+
+- draining action:
+
+```yaml
+---
+- name: "Perform node draining process"
+  vars:
+    ecd_action: "draining"
+    ecd_trex_app_cr_name: "trex-app-new"
+  include_role:
+    name: redhatci.ocp.example_cnf_deploy
+```

--- a/roles/example_cnf_deploy/defaults/main.yml
+++ b/roles/example_cnf_deploy/defaults/main.yml
@@ -1,0 +1,115 @@
+---
+
+# Default namespace
+ecd_cnf_namespace: example-cnf
+
+# Catalog/Image-related variables
+ecd_registry_url: quay.io
+ecd_repo_name: rh-nfv-int
+ecd_catalog_name: nfv-example-cnf-catalog
+ecd_operator_version: ""
+ecd_catalog_image: "{{ ecd_registry_url }}/{{ ecd_repo_name }}/{{ ecd_catalog_name }}:{{ ecd_operator_version }}"
+ecd_image_pull_policy: IfNotPresent
+
+# Default path for binaries
+ecd_oc_path: /usr/local/bin/oc
+ecd_opm_path: /usr/local/bin/opm
+
+# Logs folder
+ecd_job_logs_path: /tmp
+
+# Operators/apps to enable
+ecd_enable_lb: true
+ecd_enable_mac_fetch: true
+ecd_enable_testpmd: true
+ecd_enable_trex: true
+ecd_enable_trex_app: true
+
+# Operator installation
+ecd_testpmd_channel: alpha
+ecd_trex_channel: alpha
+
+# Static MAC addresses used by the deployed workloads
+ecd_trex_mac_list:
+  - "20:04:0f:f1:89:01"
+  - "20:04:0f:f1:89:02"
+ecd_lb_gen_port_mac_list:
+  - "40:04:0f:f1:89:01"
+  - "40:04:0f:f1:89:02"
+ecd_lb_cnf_port_mac_list:
+  - "60:04:0f:f1:89:01"
+  - "60:04:0f:f1:89:02"
+## These ones are only used in the direct mode case
+ecd_testpmd_app_mac_list:
+  - "80:04:0f:f1:89:01"
+  - "80:04:0f:f1:89:02"
+
+# Variables for gathering the network info from the scenario
+## Connection between LB-CNF in LB mode (or TRex-CNF in direct mode)
+ecd_cnf_app_networks: []
+## Connection between TRex-LB in LB mode (not used in direct mode)
+ecd_packet_generator_networks: []
+## Networks for the CNF, including the hardcoded MAC addresses for direct mode case
+ecd_networks_testpmd_app: []
+
+# RuntimeClass that should be used for running DPDK application,
+# if the var is empty, the annotation irq-load-balancing.crio.io: "disable" is not applied
+# ecd_high_perf_runtime: "performance-blueprint-profile"
+
+# Testpmd related variables
+
+## Termination grace period for testpmd
+ecd_termination_grace_period_seconds: 30
+
+# TRex related variables
+
+## Test configuration
+## When duration is '-1', the trex will run in continous burst mode
+##  - name: pkt-64-10kpps
+##    packet_size: 64
+##    packet_rate: 10kpps
+##    duration: 120
+##    trex_profile_name: ''
+##    trex_profile_path: ''
+##    trex_profile_cm_name: ''
+ecd_trex_test_config: []
+
+## Name of the TRex CR
+ecd_trex_cr_name: trexconfig
+
+## Name of the TRexApp CR
+ecd_trex_app_cr_name: trex-app
+
+## Main TRexApp job duration. If set to -1, it will run in continuous burst mode
+ecd_trex_duration: 120
+
+## Default duration of TRex execution
+ecd_default_trex_duration: 1800
+
+## Default packet rate from TRex
+ecd_packet_rate: 10kpps
+
+## Some nics like x540 supports only 2 queues, as number of cores will be
+## used to create tx queues, restrict the cores to the trex parameter as per need
+## 540 nics require this value to be set to 2
+ecd_trex_core_count: 0
+
+## If set to true, the automation behaves as if TRex job is deployed in continuous mode,
+## even if ecd_trex_duration is not -1. This is to leave a job running with a given duration
+## to perform some extra checks in different jobs.
+ecd_trex_continuous_mode: false
+
+## If set to true, wait until the end of the profile duration before continue
+ecd_trex_tests_wait: true
+
+## By default, till having a positive result, it is supposed that TRex job failed
+ecd_trex_app_run_passed: false
+
+## Track if TRex job has failed or not
+ecd_trex_job_failed: false
+
+## If set to true, even if TRex job fails, the job will progress
+ecd_trex_tests_skip_failures: false
+
+## The idea is always to try to run the migration test, unless TRex job failed before
+ecd_try_running_migration_tests: true

--- a/roles/example_cnf_deploy/scripts/get-example-cnf-status.sh
+++ b/roles/example_cnf_deploy/scripts/get-example-cnf-status.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+#
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# Description: A shell script that collects logs and information from the
+# workloads deployed by example-cnf
+
+set -x
+
+echo "--- Pod status ---"
+echo
+echo "> Pod list"
+$OC_BINARY get pods -n "$APP_NAMESPACE" -o wide
+echo
+
+APP_PODS=$($OC_BINARY get pods -n "$APP_NAMESPACE" -o custom-columns=POD:.metadata.name --no-headers)
+for POD in $APP_PODS; do
+    echo ">> Details of pod $POD"
+    echo
+    echo ">>> Description of pod $POD"
+    $OC_BINARY describe pod -n "$APP_NAMESPACE" "$POD"
+    echo
+    echo ">>> JSON output of pod $POD"
+    $OC_BINARY get pod -n "$APP_NAMESPACE" "$POD" -o json
+    echo
+    echo ">>> Logs from pod $POD"
+    $OC_BINARY logs -n "$APP_NAMESPACE" "$POD"
+    echo
+done
+
+echo
+echo "--- CR status ---"
+CRS="cnfappmac loadbalancer testpmd trexconfig trexapp"
+for CR in $CRS; do 
+   echo "> Status of $CR"
+   $OC_BINARY get "$CR" -n "$APP_NAMESPACE"
+   echo
+   $OC_BINARY get "$CR" -n "$APP_NAMESPACE" -o json
+done
+
+echo
+echo "--- SRIOV resources status ---"
+echo "> SRIOV pod list"
+$OC_BINARY get pods -n "$SRIOV_NAMESPACE" -o wide
+echo
+
+SRIOV_RESOURCES="sriovnetworknodepolicy sriovnetworknodestate sriovnetwork"
+for SRIOV_RESOURCE in $SRIOV_RESOURCES; do 
+    echo "> Status of $SRIOV_RESOURCE"
+    $OC_BINARY get "$SRIOV_RESOURCE" -n "$SRIOV_NAMESPACE"
+    echo
+    $OC_BINARY get "$SRIOV_RESOURCE" -n "$SRIOV_NAMESPACE" -o json
+done
+
+echo
+echo "--- NetworkAttachmentDefinition resources status ---"
+echo "> NetworkAttachmentDefinition list"
+$OC_BINARY get network-attachment-definition -n "$APP_NAMESPACE" -o wide
+echo
+
+NET_ATTACH_DEFS=$($OC_BINARY get network-attachment-definition -n "$APP_NAMESPACE" -o custom-columns=NAME:.metadata.name --no-headers)
+for NET_ATTACH_DEF in $NET_ATTACH_DEFS; do
+    echo ">> JSON output of NetworkAttachmentDefinition $NET_ATTACH_DEF"
+    $OC_BINARY get network-attachment-definition -n "$APP_NAMESPACE" "$NET_ATTACH_DEF" -o json
+    echo
+done
+
+echo
+echo "End of script"

--- a/roles/example_cnf_deploy/tasks/catalog.yml
+++ b/roles/example_cnf_deploy/tasks/catalog.yml
@@ -1,0 +1,43 @@
+---
+- name: "Check if Operator version is defined"
+  ansible.builtin.assert:
+    that:
+      - ecd_operator_version is defined
+      - ecd_operator_version | length
+
+- name: "Check if catalogsource crd is present"
+  community.kubernetes.k8s_info:
+    kind: CustomResourceDefinition
+    name: catalogsources.operators.coreos.com
+  register: _ecd_crd_info
+  retries: 1
+  delay: 5
+  until: _ecd_crd_info.resources|length != 0
+  failed_when: _ecd_crd_info.resources|length == 0
+
+- name: "Inspect index image"
+  ansible.builtin.shell:
+    cmd: >
+      skopeo inspect docker://{{ ecd_catalog_image }}
+  register: _ecd_skopeo_inspect
+  until: _ecd_skopeo_inspect.rc == 0
+  retries: 5
+  delay: 5
+
+- name: "Get index digest"
+  ansible.builtin.set_fact:
+    ecd_index_digest: "{{ _ecd_skopeo_inspect.stdout | from_json | json_query('Digest') }}"
+
+- name: "Create a CatalogSource for example-cnf"
+  ansible.builtin.include_role:
+    name: redhatci.ocp.catalog_source
+  vars:
+    cs_name: "{{ ecd_catalog_name }}"
+    cs_namespace: "openshift-marketplace"
+    cs_image: "{{ ecd_registry_url }}/{{ ecd_repo_name }}/{{ ecd_catalog_name }}@{{ ecd_index_digest }}"
+    cs_publisher: "Red Hat"
+    cs_update_strategy:
+      registryPoll:
+        interval: 30m
+
+...

--- a/roles/example_cnf_deploy/tasks/deploy.yml
+++ b/roles/example_cnf_deploy/tasks/deploy.yml
@@ -1,0 +1,39 @@
+---
+- name: "Find versions from the catalog"
+  ansible.builtin.shell:
+    cmd: >
+      set -e -o pipefail;
+      {{ ecd_opm_path }} render
+      {{ ecd_catalog_image }} |
+      jq -r '.relatedImages[].image'
+  args:
+    executable: /bin/bash
+  register: _ecd_catalog_data_cmd
+  retries: 1
+  delay: 5
+  until:
+    - _ecd_catalog_data_cmd.rc == 0
+
+- name: "Set trex-app version from the catalog"
+  ansible.builtin.set_fact:
+    ecd_trex_app_version: "{{ item }}"
+  when: '"trex-container-app@" in item'
+  loop: "{{ _ecd_catalog_data_cmd.stdout_lines }}"
+
+- name: "Set trex-server version from the catalog"
+  ansible.builtin.set_fact:
+    ecd_trex_server_version: "{{ item }}"
+  when: '"trex-container-server@" in item'
+  loop: "{{ _ecd_catalog_data_cmd.stdout_lines }}"
+
+- name: "Set testpmd-lb version from the catalog"
+  ansible.builtin.set_fact:
+    ecd_testpmd_app_version: "{{ item }}"
+  when: '"testpmd-container-app-testpmd@" in item'
+  loop: "{{ _ecd_catalog_data_cmd.stdout_lines }}"
+
+- name: "Installation of example-cnf operators"
+  ansible.builtin.include_tasks: deploy/sub.yml
+
+- name: "Deployment of example-cnf applications"
+  ansible.builtin.include_tasks: deploy/app.yml

--- a/roles/example_cnf_deploy/tasks/deploy/app.yml
+++ b/roles/example_cnf_deploy/tasks/deploy/app.yml
@@ -1,0 +1,168 @@
+---
+# NetworkAttachmentDefintions should be created on the namespace, it
+# will be created by sriov operator, when SriovNetwork resource is created
+- name: "Check for net-attach-def presence in the namespace"
+  community.kubernetes.k8s_info:
+    api_version: k8s.cni.cncf.io/v1
+    kind: NetworkAttachmentDefinition
+    namespace: "{{ ecd_cnf_namespace }}"
+  register: _ecd_net_list
+  until: _ecd_net_list.resources | length > 0
+  retries: 9
+  delay: 10
+
+- name: "Get the clusterversion info"
+  community.kubernetes.k8s_info:
+    kind: ClusterVersion
+  register: _ecd_cluster_version
+
+- name: "Fail ClusterVersion when is not available"
+  ansible.builtin.fail:
+    msg: "ClusterVersion object version is not available"
+  when: _ecd_cluster_version.resources[0].spec.channel|length == 0
+
+- name: "Get all nodes"
+  community.kubernetes.k8s_info:
+    kind: Node
+  register: _ecd_nodes
+  no_log: true
+
+- name: "Fail when the minimum workers are not met"
+  ansible.builtin.fail:
+    msg: "Minimum 2 worker nodes are required to run example-cnf applications"
+  when: "_ecd_nodes.resources|length < 2"
+
+- name: "Fail when packet generator network is not available"
+  ansible.builtin.fail:
+    msg: "'ecd_packet_generator_networks' is required when deployed with LB"
+  when:
+    - "ecd_enable_lb|bool"
+    - "ecd_packet_generator_networks|length == 0"
+
+- name: "Fail when cnf app networks is not available"
+  ansible.builtin.fail:
+    msg: "'ecd_cnf_app_networks' is required"
+  when:
+    - "ecd_cnf_app_networks|length == 0"
+
+- name: "Set facts of modifying networks"
+  ansible.builtin.set_fact:
+    ecd_pack_nw: []
+    ecd_cnf_nw: []
+  when: ecd_enable_lb|bool
+
+- name: "Create packet gen network list for lb with hardcoded macs"
+  ansible.builtin.set_fact:
+    ecd_pack_nw: "{{ ecd_pack_nw + [ item | combine({'mac': ecd_lb_gen_port_mac_list[idx:idx+item.count]})] }}"
+  loop: "{{ ecd_packet_generator_networks }}"
+  loop_control:
+    index_var: idx
+  when: ecd_enable_lb|bool
+
+- name: "Create cnf app network list for lb with hardcoded macs"
+  ansible.builtin.set_fact:
+    ecd_cnf_nw: "{{ ecd_cnf_nw + [ item | combine({'mac': ecd_lb_cnf_port_mac_list[idx:idx+item.count]})] }}"
+  loop: "{{ ecd_cnf_app_networks }}"
+  loop_control:
+    index_var: idx
+  when: ecd_enable_lb|bool
+
+- name: "Include lb tasks"
+  ansible.builtin.include_tasks: deploy/lb-app.yml
+  when: ecd_enable_lb|bool
+
+# In this case, do not include hardcoded MAC addresses
+- name: "(LB mode) Set local fact for cnf-app pod networks"
+  ansible.builtin.set_fact:
+    ecd_networks_testpmd_app: "{{ ecd_cnf_app_networks }}"
+  when: ecd_enable_lb|bool
+
+# In this case, include hardcoded MAC addresses
+- name: "(Direct mode) Create network list for cnfapp with hardcoded macs"
+  ansible.builtin.set_fact:
+    ecd_networks_testpmd_app: "{{ ecd_networks_testpmd_app + [item | combine({'mac': ecd_testpmd_app_mac_list[idx:idx+item.count]})] }}"
+  loop: "{{ ecd_cnf_app_networks }}"
+  loop_control:
+    index_var: idx
+  when: not ecd_enable_lb|bool
+
+- name: "Create cr for cnf application"
+  community.kubernetes.k8s:
+    definition: "{{ lookup('template', 'testpmd-cr.yaml.j2') }}"
+
+- name: "Check testpmd pod count to be greater than 0"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Pod
+    label_selectors:
+      - example-cnf-type=cnf-app
+  register: _ecd_testpmd_pods
+  retries: 60
+  delay: 5
+  until:
+    - _ecd_testpmd_pods.resources|length > 0
+
+# At least confirm that the first testpmd pod is up and running
+- name: "Check testpmd pod status to be running"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Pod
+    label_selectors:
+      - example-cnf-type=cnf-app
+  register: _ecd_testpmd_pods
+  vars:
+    ecd_container_state_running_query: "resources[0].status.containerStatuses[?name=='testpmd'].state.running"
+    ecd_container_started_query: "resources[0].status.containerStatuses[?name=='testpmd'].started"
+    ecd_container_ready_query: "resources[0].status.containerStatuses[?name=='testpmd'].ready"
+    ecd_container_state_running: "{{ _ecd_testpmd_pods | json_query(ecd_container_state_running_query) }}"
+    ecd_container_started: "{{ _ecd_testpmd_pods | json_query(ecd_container_started_query) }}"
+    ecd_container_ready: "{{ _ecd_testpmd_pods | json_query(ecd_container_ready_query) }}"
+  retries: 60
+  delay: 5
+  until:
+    - _ecd_testpmd_pods.resources[0].status.phase == 'Running'
+    - ecd_container_state_running | length > 0
+    - ecd_container_started | length > 0
+    - ecd_container_started[0] | bool
+    - ecd_container_ready | length > 0
+    - ecd_container_ready[0] | bool
+
+- name: "Check cnfappmac resource (created by testpmd app) count to be greater than 0"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: CNFAppMac
+  register: _ecd_cnfappmac
+  retries: 120
+  delay: 5
+  until:
+    - _ecd_cnfappmac.resources is defined
+    - _ecd_cnfappmac.resources|length > 0
+
+# CNFAppMac and testpmd pods share the same name, so we can use it for doing
+# some extra checks
+- name: "Check that at least the cnfappmac resource for the first testpmd pod has the required data"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: CNFAppMac
+    name: "{{ _ecd_testpmd_pods.resources[0].metadata.name }}"
+  register: _ecd_first_cnfappmac
+  retries: 120
+  delay: 5
+  until:
+    - _ecd_first_cnfappmac.resources is defined
+    - _ecd_first_cnfappmac.resources|length > 0
+    - _ecd_first_cnfappmac.resources[0].spec.resources is defined
+    - _ecd_first_cnfappmac.resources[0].spec.resources|length > 0
+
+- name: "Trex cr block"
+  ansible.builtin.include_tasks: trex/retry-trex.yml
+  when: ecd_enable_trex|bool
+
+# We need to check ecd_trex_continuous_mode here to avoid running extra tests, where we would have two or
+# more possible TRex jobs that are running in continuous burst mode.
+- name: "Trex additional tests"
+  ansible.builtin.include_tasks: trex/tests.yml
+  when:
+    - ecd_enable_trex_app|bool
+    - ecd_trex_test_config|length > 0
+    - not ecd_trex_continuous_mode|bool

--- a/roles/example_cnf_deploy/tasks/deploy/lb-app.yml
+++ b/roles/example_cnf_deploy/tasks/deploy/lb-app.yml
@@ -1,0 +1,29 @@
+---
+- name: "Create cr for loadbalancer"
+  community.kubernetes.k8s:
+    definition: "{{ lookup('template', 'lb-cr.yaml.j2') }}"
+
+- name: "Check loadbalancer pod status to be running"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Pod
+    label_selectors:
+      - example-cnf-type=lb-app
+  register: _ecd_lb_pods
+  vars:
+    ecd_container_state_running_query: "resources[0].status.containerStatuses[?name=='loadbalancer'].state.running"
+    ecd_container_started_query: "resources[0].status.containerStatuses[?name=='loadbalancer'].started"
+    ecd_container_ready_query: "resources[0].status.containerStatuses[?name=='loadbalancer'].ready"
+    ecd_container_state_running: "{{ _ecd_lb_pods | json_query(ecd_container_state_running_query) }}"
+    ecd_container_started: "{{ _ecd_lb_pods | json_query(ecd_container_started_query) }}"
+    ecd_container_ready: "{{ _ecd_lb_pods | json_query(ecd_container_ready_query) }}"
+  retries: 60
+  delay: 5
+  until:
+    - _ecd_lb_pods.resources | length == 1
+    - _ecd_lb_pods.resources[0].status.phase == 'Running'
+    - ecd_container_state_running | length > 0
+    - ecd_container_started | length > 0
+    - ecd_container_started[0] | bool
+    - ecd_container_ready | length > 0
+    - ecd_container_ready[0] | bool

--- a/roles/example_cnf_deploy/tasks/deploy/sub.yml
+++ b/roles/example_cnf_deploy/tasks/deploy/sub.yml
@@ -1,0 +1,42 @@
+---
+- name: "Set list of example-cnf operators to be installed"
+  ansible.builtin.set_fact:
+    ecd_operators:
+      - name: cnf-app-mac-operator
+        namespace: "{{ ecd_cnf_namespace }}"
+        channel: "{{ ecd_testpmd_channel }}"
+        source: "{{ ecd_catalog_name }}"
+        enable: "{{ ecd_enable_mac_fetch | bool}}"
+      - name: testpmd-lb-operator
+        namespace: "{{ ecd_cnf_namespace }}"
+        channel: "{{ ecd_testpmd_channel }}"
+        source: "{{ ecd_catalog_name }}"
+        enable: "{{ ecd_enable_lb | bool}}"
+      - name: testpmd-operator
+        namespace: "{{ ecd_cnf_namespace }}"
+        channel: "{{ ecd_testpmd_channel }}"
+        source: "{{ ecd_catalog_name }}"
+        enable: "{{ ecd_enable_testpmd | bool}}"
+      - name: trex-operator
+        namespace: "{{ ecd_cnf_namespace }}"
+        channel: "{{ ecd_trex_channel }}"
+        source: "{{ ecd_catalog_name }}"
+        enable: "{{ ecd_enable_trex | bool}}"
+
+- name: "Install enabled operators"
+  vars:
+    operator: "{{ ecd_operator.name }}" # noqa: redhat-ci[no-role-prefix]
+    source: "{{ ecd_operator.source }}" # noqa: redhat-ci[no-role-prefix]
+    namespace: "{{ ecd_operator.namespace }}" # noqa: redhat-ci[no-role-prefix]
+    channel: "{{ ecd_operator.channel | default(omit) }}" # noqa: redhat-ci[no-role-prefix]
+    operator_group_name: example-cnf-operator-group # noqa: redhat-ci[no-role-prefix]
+    install_approval: "Automatic" # noqa: redhat-ci[no-role-prefix]
+    operator_group_spec: # noqa: redhat-ci[no-role-prefix]
+      targetNamespaces: # noqa: redhat-ci[no-role-prefix]
+        - "{{ ecd_operator.namespace }}"
+  ansible.builtin.include_role:
+    name: redhatci.ocp.olm_operator
+  loop: "{{ ecd_operators }}"
+  loop_control:
+    loop_var: ecd_operator
+  when: ecd_operator.enable

--- a/roles/example_cnf_deploy/tasks/deploy_extra_trex.yml
+++ b/roles/example_cnf_deploy/tasks/deploy_extra_trex.yml
@@ -1,0 +1,4 @@
+---
+# Directly call to retry-trex.yml playbook
+- name: "Deploy an extra TRex job"
+  ansible.builtin.include_tasks: trex/retry-trex.yml

--- a/roles/example_cnf_deploy/tasks/draining.yml
+++ b/roles/example_cnf_deploy/tasks/draining.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Gather facts
+  ansible.builtin.include_tasks: draining/gather-facts.yml
+
+- name: Drain the worker node where testpmd is running
+  ansible.builtin.include_tasks: draining/node-draining.yml
+
+- name: Validate allocation of new testpmd pod
+  ansible.builtin.include_tasks: draining/testpmd-validation.yml
+
+- name: Validate TRex job
+  ansible.builtin.include_tasks: draining/trex-validation.yml

--- a/roles/example_cnf_deploy/tasks/draining/gather-facts.yml
+++ b/roles/example_cnf_deploy/tasks/draining/gather-facts.yml
@@ -1,0 +1,23 @@
+---
+
+- name: "Get testpmd-app pod"
+  community.kubernetes.k8s_info:
+    kind: Pod
+    namespace: "{{ ecd_cnf_namespace }}"
+    label_selectors:
+      - example-cnf-type=cnf-app
+  register: _ecd_cnf_pod
+
+- name: "Get trex-server pod"
+  community.kubernetes.k8s_info:
+    kind: Pod
+    namespace: "{{ ecd_cnf_namespace }}"
+    label_selectors:
+      - example-cnf-type=pkt-gen
+  register: _ecd_pktgen_pod
+
+- name: "Retrieve context information from testpmd and trex pods"
+  ansible.builtin.set_fact:
+    ecd_cnf_existing_node: "{{ _ecd_cnf_pod.resources[0].spec.nodeName }}"
+    ecd_cnf_existing_pod: "{{ _ecd_cnf_pod.resources[0].metadata.name }}"
+    ecd_pktgen_existing_node: "{{ _ecd_pktgen_pod.resources[0].spec.nodeName }}"

--- a/roles/example_cnf_deploy/tasks/draining/node-draining.yml
+++ b/roles/example_cnf_deploy/tasks/draining/node-draining.yml
@@ -1,0 +1,23 @@
+---
+
+- name: "Cordon the node where testpmd-app is running"
+  ansible.builtin.shell: |
+    {{ ecd_oc_path }} adm cordon {{ ecd_cnf_existing_node }}
+
+- name: "Wait until node changes to SchedulingDisabled status"
+  ansible.builtin.shell: >
+    set -eo pipefail;
+    {{ ecd_oc_path }} get nodes --no-headers=true |
+    grep {{ ecd_cnf_existing_node }}
+  register: _ecd_nodes
+  until: '"SchedulingDisabled" in _ecd_nodes.stdout'
+  retries: 6
+  delay: 10
+
+# Not really needing a complete draining, just removing testpmd-app pod
+# Running this in asynchronous mode, then we will wait until pod is deleted
+- name: "Drain the node to remove testpmd-app pod"
+  ansible.builtin.shell: |
+    {{ oc_tool_path }} adm drain {{ ecd_cnf_existing_node }} --pod-selector example-cnf-type=cnf-app --delete-emptydir-data
+  async: 60
+  poll: 0

--- a/roles/example_cnf_deploy/tasks/draining/testpmd-validation.yml
+++ b/roles/example_cnf_deploy/tasks/draining/testpmd-validation.yml
@@ -1,0 +1,62 @@
+---
+
+- name: "Wait until testpmd-app pod is deleted from the drained node"
+  community.kubernetes.k8s_info:
+    kind: Pod
+    namespace: "{{ ecd_cnf_namespace }}"
+    name: "{{ ecd_cnf_existing_pod }}"
+  register: _ecd_cnf_pod
+  until: _ecd_cnf_pod.resources|length == 0
+  retries: 24
+  delay: 5
+
+- name: "Get timestamp to save the time when testpmd-app was removed"
+  ansible.builtin.shell: |
+    /usr/bin/date +%s
+  register: _ecd_timestamp_pod_deletion
+
+- name: "Wait until new testpmd-app pod is allocated in a new worker node"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Pod
+    label_selectors:
+      - example-cnf-type=cnf-app
+  register: _ecd_cnf_pod
+  vars:
+    ecd_container_state_running_query: "resources[0].status.containerStatuses[?name=='testpmd'].state.running"
+    ecd_container_started_query: "resources[0].status.containerStatuses[?name=='testpmd'].started"
+    ecd_container_ready_query: "resources[0].status.containerStatuses[?name=='testpmd'].ready"
+    ecd_container_state_running: "{{ _ecd_cnf_pod | json_query(ecd_container_state_running_query) }}"
+    ecd_container_started: "{{ _ecd_cnf_pod | json_query(ecd_container_started_query) }}"
+    ecd_container_ready: "{{ _ecd_cnf_pod | json_query(ecd_container_ready_query) }}"
+  retries: 12
+  delay: 10
+  until:
+    - _ecd_cnf_pod.resources[0].status.phase == 'Running'
+    - ecd_container_state_running | length > 0
+    - ecd_container_started | length > 0
+    - ecd_container_started[0] | bool
+    - ecd_container_ready | length > 0
+    - ecd_container_ready[0] | bool
+
+- name: "Get timestamp to save the time when testpmd-app was recreated"
+  ansible.builtin.shell: |
+    /usr/bin/date +%s
+  register: _ecd_timestamp_pod_recreation
+
+- name: "Retrieve context information from new testpmd pod"
+  ansible.builtin.set_fact:
+    ecd_cnf_new_node: "{{ _ecd_cnf_pod.resources[0].spec.nodeName }}"
+    ecd_cnf_new_pod: "{{ _ecd_cnf_pod.resources[0].metadata.name }}"
+
+- name: "Confirm that a new testpmd-app pod has been created, and in a different worker node"
+  ansible.builtin.assert:
+    that:
+      - ecd_cnf_new_node != ecd_cnf_existing_node
+      - ecd_cnf_new_node != ecd_pktgen_existing_node
+      - ecd_cnf_new_pod != ecd_cnf_existing_pod
+    fail_msg: "New testpmd-app pod does not match the conditions defined to consider it is a new one"
+
+- name: "Uncordon the node after finishing the draining and rescheduling process"
+  ansible.builtin.shell: |
+    {{ oc_tool_path }} adm uncordon {{ ecd_cnf_existing_node }}

--- a/roles/example_cnf_deploy/tasks/draining/trex-validation.yml
+++ b/roles/example_cnf_deploy/tasks/draining/trex-validation.yml
@@ -1,0 +1,100 @@
+---
+
+- name: "Extract TRexApp job duration"
+  block:
+    - name: Retrieve TRexApp information
+      community.kubernetes.k8s_info:
+        api_version: examplecnf.openshift.io/v1
+        kind: TRexApp
+        namespace: "{{ ecd_cnf_namespace }}"
+        name: "{{ ecd_trex_app_cr_name }}"
+      register: _ecd_trex_app_cr
+
+    # If continuous burst mode is activated, then set up a default value to avoid issues in next tasks.
+    # TODO: follow a different procedure for continuous burst mode if provided.
+    - name: Retrieve duration from TRexApp job
+      vars:
+        _ecd_trex_retrieved_duration: "{{ _ecd_trex_app_cr.resources[0].spec.duration }}"
+      ansible.builtin.set_fact:
+        ecd_trex_duration: "{{ (_ecd_trex_retrieved_duration == -1)|ternary(ecd_default_trex_duration,_ecd_trex_retrieved_duration) }}"
+
+- name: "Wait for the TRex app TestCompleted event"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Event
+    field_selectors:
+      - "reason==TestCompleted"
+      - "involvedObject.name={{ ecd_trex_app_cr_name }}"
+  register: _ecd_trex_event
+  retries: "{{ (ecd_trex_duration|int/2)|round|int }}"
+  delay: 10
+  until: _ecd_trex_event.resources|length > 0
+
+- name: "Wait for the TRex app TestPassed or TestFailed event"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Event
+    field_selectors: "involvedObject.name={{ ecd_trex_app_cr_name }}"
+  register: _ecd_trex_result
+  retries: 5
+  delay: 5
+  until: "_ecd_trex_result.resources | selectattr('reason', 'in', ['TestPassed', 'TestFailed']) | list | length > 0"
+
+- name: "Determine if TRexApp job has failed"
+  ansible.builtin.set_fact:
+    ecd_trex_job_failed: true
+  when:
+    - _ecd_trex_result is defined
+    - _ecd_trex_result.resources is defined
+    - "'TestFailed' in _ecd_trex_result.resources | map(attribute='reason') | list"
+
+# Only if TRexApp job passed
+- name: "Wait for the TRex app PacketMatched event"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Event
+    field_selectors:
+      - "reason==PacketMatched"
+      - "involvedObject.name={{ ecd_trex_app_cr_name }}"
+  register: _ecd_trex_result
+  retries: "{{ (ecd_trex_duration|int/2)|round|int }}"
+  delay: 5
+  until: "_ecd_trex_result.resources | length > 0"
+  when:
+    - not ecd_trex_job_failed|bool
+
+- name: "Retrieve TRex app logs"
+  community.kubernetes.k8s_log:
+    namespace: "{{ ecd_cnf_namespace }}"
+    label_selectors:
+      - example-cnf-type=pkt-gen-app
+      - job-name=job-{{ ecd_trex_app_cr_name }}
+  register: _ecd_trex_app_logs
+  ignore_errors: true
+
+- name: "Store logs when jobs_logs is defined"
+  ansible.builtin.copy:
+    content: "{{ _ecd_trex_app_logs.log }}"
+    dest: "{{ ecd_job_logs_path }}/{{ ecd_trex_app_cr_name }}.log"
+    mode: "0755"
+  when: not _ecd_trex_app_logs.failed
+  ignore_errors: true
+
+- name: "Calculate the downtime for TRex job execution"
+  vars:
+    _ecd_pod_deletion_time: "{{ _ecd_timestamp_pod_deletion.stdout }}"
+    _ecd_pod_recreation_time: "{{ _ecd_timestamp_pod_recreation.stdout }}"
+    _ecd_pod_downtime: "{{ _ecd_pod_recreation_time|float - _ecd_pod_deletion_time|float }}"
+    _ecd_trex_downtime_unit: "{{ _ecd_pod_downtime|float / ecd_trex_duration|float }}"
+  ansible.builtin.set_fact:
+    ecd_trex_downtime_seconds: "{{ _ecd_pod_downtime }}"
+    ecd_trex_downtime_percentage: "{{ _ecd_trex_downtime_unit|float * 100.0 }}"
+
+- name: "Create a file to save downtime value"
+  ansible.builtin.copy:
+    dest: "{{ ecd_job_logs_path }}/trex-downtime.log"
+    content: "Downtime is {{ ecd_trex_downtime_seconds }} seconds, \
+      representing the {{ ecd_trex_downtime_percentage }} % of TRex \
+      job duration, which is {{ ecd_trex_duration }} seconds"
+    mode: "0755"
+  ignore_errors: true

--- a/roles/example_cnf_deploy/tasks/main.yml
+++ b/roles/example_cnf_deploy/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: "Requirements validation for example-cnf actions"
+  ansible.builtin.assert:
+    that:
+      - ecd_action is defined
+      - ecd_action in ['catalog', 'deploy', 'validate', 'deploy_extra_trex', 'draining']
+
+- name: "Deploy Example CNF catalog"
+  ansible.builtin.include_tasks: catalog.yml
+  when: ecd_action == 'catalog'
+
+- name: "Deploy Example CNF App"
+  ansible.builtin.include_tasks: deploy.yml
+  when: ecd_action == 'deploy'
+
+- name: "Validate Example CNF App"
+  ansible.builtin.include_tasks: validate.yml
+  when: ecd_action == 'validate'
+
+- name: "Deploy an extra TRex job"
+  ansible.builtin.include_tasks: deploy_extra_trex.yml
+  when: ecd_action == 'deploy_extra_trex'
+
+- name: "Drain - Example CNF"
+  ansible.builtin.include_tasks: draining.yml
+  when: ecd_action == 'draining'

--- a/roles/example_cnf_deploy/tasks/trex/app.yml
+++ b/roles/example_cnf_deploy/tasks/trex/app.yml
@@ -1,0 +1,180 @@
+---
+- name: Check if there is a TRexServer already created
+  community.kubernetes.k8s_info:
+    api_version: examplecnf.openshift.io/v1
+    kind: TRexConfig
+    namespace: "{{ ecd_cnf_namespace }}"
+    name: "{{ ecd_trex_cr_name }}"
+  register: _ecd_trexconfig_cr
+
+# If there is a TRexServer CR created, then do not create a new one
+- name: Create and check TRexServer CR
+  when: _ecd_trexconfig_cr.resources|length == 0
+  block:
+    - name: Set local fact for trex pod networks
+      ansible.builtin.set_fact:
+        ecd_networks_trex: []
+        ecd_packet_gen_net: "{{ ecd_packet_generator_networks if ecd_enable_lb | bool else ecd_cnf_app_networks }}"
+
+    - name: Create network list for trex with hardcoded macs
+      ansible.builtin.set_fact:
+        ecd_networks_trex: "{{ ecd_networks_trex + [ item | combine({'mac': ecd_trex_mac_list[idx:idx+item.count]})] }}"
+      loop: "{{ ecd_packet_gen_net }}"
+      loop_control:
+        index_var: idx
+
+    - name: Create CR for trex server
+      community.kubernetes.k8s:
+        definition: "{{ lookup('template', 'trex-server-cr.yaml.j2') }}"
+
+    - name: Check TRex pod status to be running
+      community.kubernetes.k8s_info:
+        namespace: "{{ ecd_cnf_namespace }}"
+        kind: Pod
+        label_selectors:
+          - example-cnf-type=pkt-gen
+      register: _ecd_trex_result
+      vars:
+        ecd_container_state_running_query: "resources[0].status.containerStatuses[?name=='trex-server'].state.running"
+        ecd_container_started_query: "resources[0].status.containerStatuses[?name=='trex-server'].started"
+        ecd_container_ready_query: "resources[0].status.containerStatuses[?name=='trex-server'].ready"
+        ecd_container_state_running: "{{ _ecd_trex_result | json_query(ecd_container_state_running_query) }}"
+        ecd_container_started: "{{ _ecd_trex_result | json_query(ecd_container_started_query) }}"
+        ecd_container_ready: "{{ _ecd_trex_result | json_query(ecd_container_ready_query) }}"
+      retries: 60
+      delay: 5
+      until:
+        - _ecd_trex_result.resources | length == 1
+        - _ecd_trex_result.resources[0].status.phase == 'Running'
+        - ecd_container_state_running | length > 0
+        - ecd_container_started | length > 0
+        - ecd_container_started[0] | bool
+        - ecd_container_ready | length > 0
+        - ecd_container_ready[0] | bool
+
+- name: Get logs from example-cnf deployment before starting the job
+  environment:
+    OC_BINARY: "{{ ecd_oc_path }}"
+    APP_NAMESPACE: "{{ ecd_cnf_namespace }}"
+    SRIOV_NAMESPACE: openshift-sriov-network-operator
+  ansible.builtin.script:
+    cmd: >
+      ../../scripts/get-example-cnf-status.sh > example-cnf-pre-job-status.log
+  args:
+    chdir: "{{ ecd_job_logs_path }}"
+  ignore_errors: true
+  no_log: true
+
+- name: TRexApp block
+  when: ecd_enable_trex_app | bool
+  block:
+    - name: Set TRex app duration
+      ansible.builtin.set_fact:
+        ecd_duration: "{{ ecd_trex_duration }}"
+
+    - name: Create CR for TRex app
+      vars:
+        ecd_packet_rate: 10kpps
+        ecd_packet_size: 64
+      community.kubernetes.k8s:
+        definition: "{{ lookup('template', 'trex-app-cr.yaml.j2') }}"
+
+    - name: Wait for TRex app CR to be created
+      ansible.builtin.shell: |
+        {{ ecd_oc_path }} get trexapp.examplecnf.openshift.io -o yaml -n {{ ecd_cnf_namespace }} {{ ecd_trex_app_cr_name }}
+      register: _ecd_trex_app_cr_installation
+      retries: 30
+      delay: 10
+      until:
+        - "'True' in _ecd_trex_app_cr_installation.stdout"
+        - "'Running' in _ecd_trex_app_cr_installation.stdout"
+        - "'Successful' in _ecd_trex_app_cr_installation.stdout"
+
+    - name: Wait for the TRex app TestStarted event
+      community.kubernetes.k8s_info:
+        namespace: "{{ ecd_cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==TestStarted"
+          - "involvedObject.name={{ ecd_trex_app_cr_name }}"
+      register: trex_event
+      retries: "{{ (ecd_duration | int / 2)| round | int }}"
+      delay: 5
+      until: trex_event.resources | length > 0
+
+    # Omit this check if we are running TRex job in continuous mode
+    - name: Wait for the TRex app TestCompleted event
+      community.kubernetes.k8s_info:
+        namespace: "{{ ecd_cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==TestCompleted"
+          - "involvedObject.name={{ ecd_trex_app_cr_name }}"
+      register: _ecd_trex_event
+      retries: "{{ (ecd_duration | int / 2)| round | int }}"
+      delay: 5
+      until: _ecd_trex_event.resources|length > 0
+      when: not ecd_trex_continuous_mode|bool
+
+    # Omit this check if we are running TRex job in continuous mode
+    - name: Wait for the TRex app TestPassed or TestFailed event
+      community.kubernetes.k8s_info:
+        namespace: "{{ ecd_cnf_namespace }}"
+        kind: Event
+        field_selectors: "involvedObject.name={{ ecd_trex_app_cr_name }}"
+      register: ecd_trex_result
+      retries: 5
+      delay: 5
+      until: "ecd_trex_result.resources | selectattr('reason', 'in', ['TestPassed', 'TestFailed']) | list | length > 0"
+      when: not ecd_trex_continuous_mode|bool
+
+    - name: Get logs from example-cnf deployment after running the job
+      environment:
+        OC_BINARY: "{{ ecd_oc_path }}"
+        APP_NAMESPACE: "{{ ecd_cnf_namespace }}"
+        SRIOV_NAMESPACE: openshift-sriov-network-operator
+      ansible.builtin.script:
+        cmd: >
+          ../../scripts/get-example-cnf-status.sh > example-cnf-post-job-status.log
+      args:
+        chdir: "{{ ecd_job_logs_path }}"
+      ignore_errors: true
+      no_log: true
+
+    # Omit this check if we are running TRex job in continuous mode
+    - name: Fail if TestFailed event is present
+      ansible.builtin.fail:
+        msg: "TestFailed event detected"
+      when:
+        - ecd_trex_result is defined
+        - ecd_trex_result.resources is defined
+        - "'TestFailed' in ecd_trex_result.resources | map(attribute='reason') | list"
+        - not ecd_trex_tests_skip_failures|bool
+        - not ecd_trex_continuous_mode|bool
+
+    # Omit this check if we are running TRex job in continuous mode
+    - name: Wait for the TRex app PacketMatched event
+      community.kubernetes.k8s_info:
+        namespace: "{{ ecd_cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==PacketMatched"
+          - "involvedObject.name={{ ecd_trex_app_cr_name }}"
+      register: ecd_trex_result
+      retries: "{{ (ecd_duration|int/2)|round|int }}"
+      delay: 5
+      until: "ecd_trex_result.resources | length > 0"
+      when:
+        - not ecd_trex_tests_skip_failures|bool
+        - not ecd_trex_continuous_mode|bool
+
+    # Omit this check if we are running TRex job in continuous mode
+    - name: Set TRex run status if passed
+      ansible.builtin.set_fact:
+        ecd_trex_app_run_passed: true
+      when:
+        - ecd_trex_result is defined
+        - ecd_trex_result.resources is defined
+        - ecd_trex_result.resources | length > 0
+        - not ecd_trex_continuous_mode|bool
+...

--- a/roles/example_cnf_deploy/tasks/trex/job.yml
+++ b/roles/example_cnf_deploy/tasks/trex/job.yml
@@ -1,0 +1,59 @@
+---
+- name: Fail if ecd_trex_app_version is not defined
+  ansible.builtin.fail:
+    msg: "ecd_trex_app_version is required"
+  when: ecd_trex_app_version is not defined
+
+- name: Get the list of incomplete jobs
+  community.kubernetes.k8s_info:
+    kind: Job
+    api_version: batch/v1
+    label_selectors:
+      - example-cnf-type=pkt-gen-app
+    field_selectors:
+      - status.successful!=1
+  register: _ecd_jobs_running
+
+- name: Set default active job fact
+  ansible.builtin.set_fact:
+    ecd_active_jobs: 0
+
+- name: Find active jobs
+  ansible.builtin.set_fact:
+    ecd_active_jobs: "{{ ecd_active_jobs + 1 }}"
+  loop: "{{ _ecd_jobs_running.resources }}"
+  when: "item.status.failed != 1"
+
+- name: Fail if any one of pkt gen job is running
+  ansible.builtin.fail:
+    msg: "All pkt gen job should be complete before starting next"
+  when: "ecd_active_jobs|int > 0"
+
+- name: Log the test config
+  ansible.builtin.debug:
+    var: ecd_test_config_item
+
+- name: Set the image name
+  ansible.builtin.set_fact:
+    ecd_image_app: "{{ ecd_registry_url }}/{{ ecd_repo_name }}/trex-container-app:{{ ecd_trex_app_version }}"
+  when: ecd_image_app is not defined
+
+- name: Create job for the provided test config
+  vars:
+    ecd_environments: "{{ ecd_test_config_item }}"
+    ecd_trex_app_job_name: "{{ ecd_test_config_item.name | default('test-' + 1000 | random | string) }}"
+  community.kubernetes.k8s:
+    definition: "{{ lookup('template', 'trex-app-job.yaml.j2') }}"
+
+- name: Wait for the job to complete
+  community.kubernetes.k8s_info:
+    kind: Job
+    api_version: batch/v1
+    label_selectors:
+      - example-cnf-type=pkt-gen-app
+    field_selectors:
+      - status.successful!=1
+  register: _ecd_jobs_running
+  retries: 120
+  delay: 5
+  until: _ecd_jobs_running.resources|length == 0

--- a/roles/example_cnf_deploy/tasks/trex/profile.yml
+++ b/roles/example_cnf_deploy/tasks/trex/profile.yml
@@ -1,0 +1,75 @@
+---
+- name: Set TRex profile variables
+  ansible.builtin.set_fact:
+    ecd_trex_profile_path: "{{ ecd_trex_test_config_item.trex_profile_path | default('') }}"
+    ecd_trex_profile_name: "{{ ecd_trex_test_config_item.trex_profile_name | default('') }}"
+    ecd_trex_profile_cm_name: "{{ ecd_trex_test_config_item.trex_profile_cm_name | default('') }}"
+    ecd_random_str: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=5') }}"
+    ecd_packet_rate: ''
+    ecd_packet_size: ''
+    ecd_duration: ''
+
+- name: Set packet rate if defined
+  ansible.builtin.set_fact:
+    ecd_packet_rate: "{{ ecd_trex_test_config_item.packet_rate }}"
+  when: "'packet_rate' in ecd_trex_test_config_item"
+
+- name: Set packet size if defined
+  ansible.builtin.set_fact:
+    ecd_packet_size: "{{ ecd_trex_test_config_item.packet_size }}"
+  when: "'packet_size' in ecd_trex_test_config_item"
+
+- name: Set duration if defined
+  ansible.builtin.set_fact:
+    ecd_duration: "{{ ecd_trex_test_config_item.duration }}"
+  when: "'duration' in ecd_trex_test_config_item"
+
+- name: Create configmap for trex profile if provided
+  when: ecd_trex_profile_path|default('')|length > 0
+  block:
+    - name: Check if trex_profile_path is valid
+      ansible.builtin.stat:
+        path: "{{ ecd_trex_profile_path }}"
+      register: _ecd_path_stat
+
+    - name: Fail if the path does not existt
+      ansible.builtin.fail:
+        msg: "Provide a valid file - {{ ecd_trex_profile_path }}"
+      when: not _ecd_path_stat.stat.exists
+
+    - name: Set cm name for trex profile
+      ansible.builtin.set_fact:
+        ecd_trex_profile_cm_name: "{{ 'trex-profile-' + ecd_random_str }}"
+        ecd_trex_profile_name: "{{ ecd_trex_profile_path | basename }}"
+
+    - name: Create config map
+      community.kubernetes.k8s:
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: "{{ ecd_cnf_namespace }}"
+            name: "{{ ecd_trex_profile_cm_name }}"
+          data:
+            name: "{{ ecd_trex_profile_name }}"
+            content: |
+              {{ lookup('file', ecd_trex_profile_path) }}
+
+- name: Create job for trex app
+  ansible.builtin.include_tasks: trex/job.yml
+  when: ecd_enable_trex_profile_direct|default(false)|bool
+
+- name: Set trex app cr name
+  ansible.builtin.set_fact:
+    ecd_trex_app_cr_name: "trex-app-{{ ecd_trex_test_config_item.name }}"
+  when: "'name' in ecd_trex_test_config_item"
+
+- name: Set trex app cr name - random
+  ansible.builtin.set_fact:
+    ecd_trex_app_cr_name: "trex-app-{{ ecd_random_str }}"
+  when: "'name' not in ecd_trex_test_config_item"
+
+- name: Create cr for trex app
+  community.kubernetes.k8s:
+    definition: "{{ lookup('template', 'trex-app-cr.yaml.j2') }}"
+  when: not ecd_enable_trex_profile_direct|default(false)|bool

--- a/roles/example_cnf_deploy/tasks/trex/retry-trex.yml
+++ b/roles/example_cnf_deploy/tasks/trex/retry-trex.yml
@@ -1,0 +1,42 @@
+---
+- name: "Set retry variables"
+  ansible.builtin.set_fact:
+    ecd_trex_app_cr_name: trex-app
+  when: ecd_trex_app_cr_name is not defined
+
+- name: "Update ecd_trex_continuous_mode if ecd_trex_duration is set to -1"
+  ansible.builtin.set_fact:
+    ecd_trex_continuous_mode: true
+  when: ecd_trex_duration == -1
+
+- name: "Deploy TRex app"
+  block:
+    - name: "Include TRex tasks to create app"
+      ansible.builtin.include_tasks: trex/app.yml
+
+    # Omit this check if we are running TRex job in continuous mode
+    - name: "Fail when run did not pass"
+      ansible.builtin.fail:
+        msg: "TRex App run has failed"
+      when:
+        - not ecd_trex_app_run_passed | bool
+        - not ecd_trex_tests_skip_failures|bool
+        - not ecd_trex_continuous_mode|bool
+  always:
+    - name: "Retrieve TRex app logs"
+      community.kubernetes.k8s_log:
+        namespace: "{{ ecd_cnf_namespace }}"
+        label_selectors:
+          - example-cnf-type=pkt-gen-app
+          - job-name=job-{{ ecd_trex_app_cr_name }}
+      register: _ecd_trex_app_logs
+      ignore_errors: true
+
+    - name: "Store logs"
+      ansible.builtin.copy:
+        content: "{{ _ecd_trex_app_logs.log }}"
+        dest: "{{ ecd_job_logs_path }}/{{ ecd_trex_app_cr_name }}.log"
+        mode: "0750"
+      when: not _ecd_trex_app_logs.failed
+      ignore_errors: true
+...

--- a/roles/example_cnf_deploy/tasks/trex/tests.yml
+++ b/roles/example_cnf_deploy/tasks/trex/tests.yml
@@ -1,0 +1,42 @@
+---
+- name: Deploy TRex profiles
+  ansible.builtin.include_tasks: trex/profile.yml
+  loop: "{{ ecd_trex_test_config }}"
+  loop_control:
+    loop_var: ecd_trex_test_config_item
+
+- name: Run additional tests
+  when:
+    - ecd_trex_tests_wait | bool
+  block:
+    - name: Get all trexapps
+      community.kubernetes.k8s_info:
+        namespace: "{{ ecd_cnf_namespace }}"
+        kind: TRexApp
+      register: _ecd_trex_apps
+
+    - name: Set trex app count to default 0
+      ansible.builtin.set_fact:
+        ecd_trex_apps_count: 0
+
+    - name: Increment trex_app_count for apps with valid duration
+      ansible.builtin.set_fact:
+        ecd_trex_apps_count: "{{ ecd_trex_apps_count | int + 1 }}"
+      loop: "{{ _ecd_trex_apps.resources }}"
+      when: "'duration' in item.spec and item.spec.duration != -1"
+
+    - name: Print ecd_trex_apps_count
+      ansible.builtin.debug:
+        var: ecd_trex_apps_count
+
+    - name: Wait trex app run complete event
+      community.kubernetes.k8s_info:
+        namespace: "{{ ecd_cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==TestCompleted"
+          - "involvedObject.kind=TRexApp"
+      register: _ecd_evts
+      retries: "{{ ecd_trex_tests_retry_mins_count | default(60) }}"
+      delay: 60
+      until: "_ecd_evts.resources | length >= ecd_trex_apps_count | int"

--- a/roles/example_cnf_deploy/tasks/validate.yml
+++ b/roles/example_cnf_deploy/tasks/validate.yml
@@ -1,0 +1,8 @@
+---
+
+- name: "Migrate tasks"
+  ansible.builtin.include_tasks: validate/migrate.yml
+
+- name: "Validate tasks"
+  ansible.builtin.include_tasks: validate/validate.yml
+  when: ecd_try_running_migration_tests|bool

--- a/roles/example_cnf_deploy/tasks/validate/migrate.yml
+++ b/roles/example_cnf_deploy/tasks/validate/migrate.yml
@@ -1,0 +1,49 @@
+---
+
+- name: "Get TestPMD CR info"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: TestPMD
+  register: _ecd_testpmd_list
+
+- name: "Validate number of TestPMD CRs"
+  ansible.builtin.fail:
+    msg: "TestPMD CRs count ({{ _ecd_testpmd_list.resources | length }}) is invalid"
+  when: "_ecd_testpmd_list.resources|length != 1"
+
+# This means that the TRex job may have failed, so we don't want to run the migration
+# tests in that case
+- name: "Check if previous TRex job worked when ecd_trex_tests_skip_failures is activated"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Event
+    field_selectors:
+      - reason==PacketMatched
+  register: _ecd_matched
+  when: ecd_trex_tests_skip_failures|bool
+
+- name: "Do not try migration tests if previous TRex job failed"
+  ansible.builtin.set_fact:
+    ecd_try_running_migration_tests: false
+  when:
+    - ecd_trex_tests_skip_failures|bool
+    - _ecd_matched.resources is defined
+    - _ecd_matched.resources|length == 0
+
+- name: "Try to run migration tests"
+  when: ecd_try_running_migration_tests|bool
+  block:
+    - name: "Wait for at least one PacketMatched event from TRex"
+      community.kubernetes.k8s_info:
+        namespace: "{{ ecd_cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - reason==PacketMatched
+      register: _ecd_matched
+      retries: 12
+      delay: 5
+      until: _ecd_matched.resources | length > 0
+
+    - name: "Run pod deletion test"
+      ansible.builtin.include_tasks: validate/pod-delete.yml
+      when: "ecd_validate_pod_delete | default(true) | bool"

--- a/roles/example_cnf_deploy/tasks/validate/pod-delete.yml
+++ b/roles/example_cnf_deploy/tasks/validate/pod-delete.yml
@@ -1,0 +1,73 @@
+---
+- name: "Get cnf app pod"
+  community.kubernetes.k8s_info:
+    kind: Pod
+    namespace: "{{ ecd_cnf_namespace }}"
+    label_selectors:
+      - example-cnf-type=cnf-app
+  register: _ecd_cnf_pod
+
+- name: "Fail if the cnf app pod is not found"
+  ansible.builtin.fail:
+    msg: "Unable to find cnf app pod"
+  when:
+    - "_ecd_cnf_pod.resources|length == 0"
+
+- name: "Set cnf app pod's node name"
+  ansible.builtin.set_fact:
+    ecd_cnf_existing_node: "{{ _ecd_cnf_pod.resources[0].spec.nodeName }}"
+    ecd_cnf_existing_pod_name: "{{ _ecd_cnf_pod.resources[0].metadata.name }}"
+    ecd_cnf_app_count: "{{ _ecd_cnf_pod.resources|length }}"
+    ecd_cnf_app_list: "{{ _ecd_cnf_pod | json_query('resources[*].metadata.name') }}"
+
+- name: "Show current node of testpmd"
+  ansible.builtin.debug:
+    msg: "CNF App is running on node {{ ecd_cnf_existing_node }}"
+
+- name: "Cordon the node"
+  ansible.builtin.shell: |
+    {{ ecd_oc_path }} adm cordon {{ ecd_cnf_existing_node }}
+
+- name: Delete the cnf app pod
+  community.kubernetes.k8s:
+    kind: Pod
+    namespace: "{{ ecd_cnf_namespace }}"
+    name: "{{ ecd_cnf_existing_pod_name }}"
+    state: absent
+    wait: true
+    wait_timeout: 300
+
+- name: "Check cnf app pod count to match and running"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Pod
+    label_selectors:
+      - example-cnf-type=cnf-app
+    field_selectors:
+      - status.phase=Running
+  register: _ecd_cnf_new_pods
+  retries: 60
+  delay: 5
+  until:
+    - "_ecd_cnf_new_pods.resources|length == ecd_cnf_app_count|int"
+
+- name: "Set new testpmd node name"
+  ansible.builtin.set_fact:
+    ecd_testpmd_new_node: "{{ pod.spec.nodeName }}"
+  loop: "{{ _ecd_cnf_new_pods.resources }}"
+  loop_control:
+    loop_var: pod
+  when: "pod.metadata.name not in ecd_cnf_app_list"
+
+- name: "Uncordon the node"
+  ansible.builtin.shell: |
+    {{ ecd_oc_path }} adm uncordon {{ ecd_cnf_existing_node }}
+
+- name: "Fail if TestPMD pod is not migrated"
+  ansible.builtin.fail:
+    msg: "TestPMD pod is not migrated"
+  when: ecd_testpmd_new_node == ecd_cnf_existing_node
+
+- name: "Debug new TestPMD pod"
+  ansible.builtin.debug:
+    msg: "TestPMD pod is migrated from {{ ecd_cnf_existing_node }} to {{ ecd_testpmd_new_node }}"

--- a/roles/example_cnf_deploy/tasks/validate/validate.yml
+++ b/roles/example_cnf_deploy/tasks/validate/validate.yml
@@ -1,0 +1,48 @@
+---
+
+- name: "Set event list variable"
+  ansible.builtin.set_fact:
+    ecd_event_list: []
+    ecd_dropped_new: []
+    ecd_matched_new: []
+
+- name: "Get trexconfig matched events"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Event
+    field_selectors:
+      - reason==PacketMatched
+  register: _ecd_matched
+  no_log: true
+
+- name: "Get trexconfig dropped events"
+  community.kubernetes.k8s_info:
+    namespace: "{{ ecd_cnf_namespace }}"
+    kind: Event
+    field_selectors:
+      - reason==PacketDropped
+  register: _ecd_dropped
+  no_log: true
+
+- name: "Merge dropped events to custom object list"
+  ansible.builtin.set_fact:
+    ecd_dropped_new: "{{ ecd_dropped_new + [{ 'eventTime': item.eventTime, 'reason': item.reason }] }}"
+  loop: "{{ _ecd_dropped.resources }}"
+  no_log: true
+
+- name: "Merge matched events to custom object list"
+  ansible.builtin.set_fact:
+    ecd_matched_new: "{{ ecd_matched_new + [{ 'eventTime': item.eventTime, 'reason': item.reason }] }}"
+  loop: "{{ _ecd_matched.resources }}"
+  no_log: true
+
+- name: "Find packet missing details"
+  packet_missing:
+    dropped: "{{ ecd_dropped_new }}"
+    matched: "{{ ecd_matched_new }}"
+  register: _ecd_packet_details
+
+- name: "Show Packet Missing"
+  ansible.builtin.debug:
+    var: _ecd_packet_details.missing
+    verbosity: 3

--- a/roles/example_cnf_deploy/templates/lb-cr.yaml.j2
+++ b/roles/example_cnf_deploy/templates/lb-cr.yaml.j2
@@ -1,0 +1,28 @@
+apiVersion: examplecnf.openshift.io/v1
+kind: LoadBalancer
+metadata:
+  name: lb
+  namespace: {{ ecd_cnf_namespace }}
+spec:
+  registry: "{{ ecd_registry_url }}"
+  org: "{{ ecd_repo_name }}"
+  version: "{{ ecd_testpmd_app_version }}"
+  imagePullPolicy: {{ ecd_image_pull_policy }}
+  cnf_app_networks: {{ ecd_cnf_nw }}
+  packet_generator_networks: {{ ecd_pack_nw }}
+  packet_generator_macs: {{ ecd_trex_mac_list }}
+  rx_queues: {{ ecd_queues|default(1) }}
+  tx_queues: {{ ecd_queues|default(1) }}
+  cpu: 10
+  memory: 20Gi
+  hugepage_1gb_count: 16Gi
+  forwarding_cores: 8
+  socket_memory: 4096
+  environments:
+    runApp: 1
+{% if ecd_numa_aware_topology is defined and ecd_numa_aware_topology | length %}
+  numa_aware_topology: "{{ ecd_numa_aware_topology }}"
+{% endif %}
+{% if ecd_high_perf_runtime is defined and ecd_high_perf_runtime|length %}
+  runtime_class_name: "{{ ecd_high_perf_runtime }}"
+{% endif %}

--- a/roles/example_cnf_deploy/templates/testpmd-cr.yaml.j2
+++ b/roles/example_cnf_deploy/templates/testpmd-cr.yaml.j2
@@ -1,0 +1,23 @@
+apiVersion: examplecnf.openshift.io/v1
+kind: TestPMD
+metadata:
+  name: testpmd
+  namespace: {{ ecd_cnf_namespace }}
+spec:
+  privileged: false
+  imagePullPolicy: {{ ecd_image_pull_policy }}
+{% if ecd_enable_lb|bool %}
+  ethpeerMaclist: {{ ecd_lb_cnf_port_mac_list }}
+  size: {{ ecd_testpmd_app_size|default(2) }}
+{% else %}
+  ethpeerMaclist: {{ ecd_trex_mac_list }}
+  size: 1  
+{% endif %}
+  networks: {{ ecd_networks_testpmd_app }}
+  terminationGracePeriodSeconds: {{ ecd_termination_grace_period_seconds }}
+{% if ecd_high_perf_runtime is defined and ecd_high_perf_runtime|length %}
+  runtime_class_name: "{{ ecd_high_perf_runtime }}"
+{% endif %}
+{% if ecd_numa_aware_topology is defined and ecd_numa_aware_topology | length %}
+  numa_aware_topology: "{{ ecd_numa_aware_topology }}"
+{% endif %}

--- a/roles/example_cnf_deploy/templates/trex-app-cr.yaml.j2
+++ b/roles/example_cnf_deploy/templates/trex-app-cr.yaml.j2
@@ -1,0 +1,32 @@
+apiVersion: examplecnf.openshift.io/v1
+kind: TRexApp
+metadata:
+  namespace: {{ ecd_cnf_namespace }}
+  name: {{ ecd_trex_app_cr_name }}
+  annotations:
+    "ansible.sdk.operatorframework.io/verbosity": "4"
+    "ansible.sdk.operatorframework.io/reconcile-period": "1m"
+spec:
+{% if ecd_packet_rate|default('') %}
+  packetRate: {{ ecd_packet_rate }}
+{% endif %}
+{% if ecd_duration|default(None) %}
+  duration: {{ ecd_duration }}
+{% endif %}
+{% if ecd_packet_size|default('') %}
+  packetSize: {{ ecd_packet_size }}
+{% endif %}
+  registry: {{ ecd_registry_url }}
+  org: {{ ecd_repo_name }}
+  version: {{ ecd_trex_app_version }}
+  imagePullPolicy: {{ ecd_image_pull_policy }}
+  enableLb: {{ ecd_enable_lb }}
+{% if ecd_high_perf_runtime is defined and ecd_high_perf_runtime|length %}
+  runtime_class_name: "{{ ecd_high_perf_runtime }}"
+{% endif %}
+{% if ecd_enable_lb|bool %}  
+  lbMacs: {{ ecd_lb_gen_port_mac_list }}
+{% endif %}  
+  trexProfileConfigMap: {{ ecd_trex_profile_cm_name|default('') }}
+  trexProfileName: {{ ecd_trex_profile_name|default('') }}
+  trexApp: false

--- a/roles/example_cnf_deploy/templates/trex-app-job.yaml.j2
+++ b/roles/example_cnf_deploy/templates/trex-app-job.yaml.j2
@@ -1,0 +1,92 @@
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: "job-{{ ecd_trex_app_job_name }}"
+  namespace: "{{ ecd_cnf_namespace }}"
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        example-cnf-type: pkt-gen-app
+    spec:
+      restartPolicy: Never
+      serviceAccountName: trex-app-account
+      containers:
+      - name: trex-app
+        image: "{{ ecd:image_app }}"
+        imagePullPolicy: "{{ ecd_image_pull_policy }}"
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+{% if ecd_trex_profile_cm_name|default('') %}
+        - name: profile
+          mountPath: /opt/trexprofile
+{% endif %}
+        env:
+        - name: MODE
+          value: "{{ 'lb' if ecd_enable_lb else 'direct' }}"
+        - name: LB_MACS
+          value: "{{ ecd_lb_gen_port_mac_list|join(',') }}"
+        - name: CR_NAME
+          value: "{{ ecd_trex_app_job_name }}"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+{% for key, value in ecd_environments.items() %}
+        - name: {{ key }}
+          value: "{{ value }}"
+{% endfor %}
+        - name: TREX_SERVER_URL
+          value: trex-server
+{% if ecd_trex_profile_name %}
+        - name: TREX_PROFILE_NAME
+          value: "{{ ecd_trex_profile_name }}"
+{% endif %}
+{% if ecd_duration %}
+        - name: DURATION
+          value: "{{ ecd_duration }}"
+{% endif %}
+{% if ecd_packet_size %}
+        - name: PACKET_SIZE
+          value: "{{ ecd_packet_size }}"
+{% endif %}
+{% if ecd_packet_rate %}
+        - name: PACKET_RATE
+          value: "{{ ecd_packet_rate }}"
+{% endif %}
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "echo Hello from the postStart handler"]
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "echo Hello from the preStop handler"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8095
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8095
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /startz
+            port: 8095
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        terminationMessagePolicy: FallbackToLogsOnError
+      volumes:
+      - name: varlog
+        emptyDir: {}
+{% if ecd_trex_profile_cm_name|default('') %}
+      - name: profile
+        configMap:
+          name: {{ ecd_trex_profile_cm_name }}
+{% endif %}

--- a/roles/example_cnf_deploy/templates/trex-server-cr.yaml.j2
+++ b/roles/example_cnf_deploy/templates/trex-server-cr.yaml.j2
@@ -1,0 +1,31 @@
+apiVersion: examplecnf.openshift.io/v1
+kind: TRexConfig
+metadata:
+  namespace: {{ ecd_cnf_namespace }}
+  name: {{ ecd_trex_cr_name }}
+  annotations:
+    "ansible.sdk.operatorframework.io/verbosity": "4"
+spec:
+{% if ecd_trex_core_count|int > 0 %}
+  environments:
+    trexCoreCount: {{ ecd_trex_core_count }}
+{% endif %}
+  registry: {{ ecd_registry_url }}
+  org: {{ ecd_repo_name }}
+  version: {{ ecd_trex_server_version }}
+  imagePullPolicy: {{ ecd_image_pull_policy }}
+  networks: {{ ecd_networks_trex }}
+  enableLb: {{ ecd_enable_lb }}
+{% if ecd_enable_lb|bool %}  
+  lbMacs: {{ ecd_lb_gen_port_mac_list }}
+{% endif %}  
+  cpu: 6
+{% if ecd_trex_config_skip|default(false)|bool %}
+  trex_config_skip: true
+{% endif %}
+{% if ecd_high_perf_runtime is defined and ecd_high_perf_runtime|length %}
+  runtime_class_name: "{{ ecd_high_perf_runtime }}"
+{% endif %}
+{% if ecd_numa_aware_topology is defined and ecd_numa_aware_topology | length %}
+  numa_aware_topology: "{{ ecd_numa_aware_topology }}"
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

- Migrating the roles from https://github.com/rh-nfv-int/nfv-example-cnf-deploy
- Updating catalog_source role to include a new field required by example-cnf catalog, setting default value as empty to not affect to current use cases

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

- [x] example-cnf deployment in direct mode - https://www.distributed-ci.io/jobs/1b0bc57c-2acc-413e-9a67-40818fd83617/jobStates?sort=date
- [x] example-cnf deployment in LB mode - https://www.distributed-ci.io/jobs/40aa9647-57d5-4d5c-8adf-a85d2483cfd3/jobStates/?sort=date
- [x] example-cnf deployment in LB mode with preflight and certsuite execution - https://www.distributed-ci.io/jobs/56d33661-20cd-47e3-8d1c-a6876f02f4b9/jobStates?sort=date
- [x] example-cnf extra trex job + draining scenario - https://www.distributed-ci.io/jobs?limit=20&offset=0&sort=-created_at&where=pipeline_id:af8c00f4-7683-41c3-aa32-8bc661931e35,state:active
- [x] example-cnf upgrade validation scenario - https://www.distributed-ci.io/jobs?limit=20&offset=0&sort=-created_at&where=pipeline_id:d2757257-08c8-4167-982d-77a4f36ea5e2,state:active

Test-Hints: no-check