### PR TITLE
Updating odf_setup role

### DIFF
--- a/roles/odf_setup/README.md
+++ b/roles/odf_setup/README.md
@@ -27,9 +27,11 @@ Role Variables
 | default_storageclass_annotation  | '{"storageclass.kubernetes.io/is-default-class": "true"}'  | String       | No          | Default storageclass annotation             |
 | external_ceph_data               |                               | JSON         | No          | A JSON payload generated from RHCS                                       |
 | ocs_install_type                 |                               | String       | Yes         | `internal` for LSO, `external` for Ceph/RHCS                             |
-| local_storage_devices            |                               | List         | No          | For LSO, a list of local devices that will be use as backend             |
+| local_storage_devices            |                               | List         | Yes          | For LSO, a list of local devices that will be use as backend             |
 | ocs_default_storage_class        | storagecluster-cephfs         | String       | No          | Default storage class name                                               |
 | gatherer_image                   | registry.access.redhat.com/ubi8/ubi | String | No          | Image for disk-gatherer deployment                                       |
+| odf_setup_oc_tool_path                   | '/usr/local/bin/oc` | String | No          | Path to the OpenShift Command Line Interface binary.
+
 
 Inventory Groups and Variables
 --------------
@@ -43,9 +45,8 @@ ocs_install_type=
 # with ceph-external-cluster-details-exporter.py script
 external_ceph_data='JSON_PAYLOAD'
 
-# (Optional) when enable_lso=true List of disk devices per node to use for LSO
-# If not specified, it will use all the local disks available
-# comma separated, all servers must have the same
+# When enable_lso=true, list of disk devices per node to use for LSO
+# Comma separated, all servers must have the same
 local_storage_devices=["/dev/sdX", "/dev/sdY", "/dev/sdZ"]
 
 # (Optional) Default storage class name

--- a/roles/odf_setup/defaults/main.yml
+++ b/roles/odf_setup/defaults/main.yml
@@ -30,3 +30,6 @@ default_storageclass_annotation: '{"storageclass.kubernetes.io/is-default-class"
 
 # OCS gatherer_image
 gatherer_image: registry.access.redhat.com/ubi8/ubi
+
+# OpenShift Command Line Interface path
+odf_setup_oc_tool_path: /usr/local/bin/oc

--- a/roles/odf_setup/tasks/local-storage-operator.yml
+++ b/roles/odf_setup/tasks/local-storage-operator.yml
@@ -27,7 +27,7 @@
   ansible.builtin.shell:
     cmd: >
       sleep 90;
-      {{ oc_tool_path }} logs
+      {{ odf_setup_oc_tool_path }} logs
       --selector name=ocs-disk-gatherer
       --tail=-1
       --since=10m

--- a/roles/odf_setup/tasks/validation.yml
+++ b/roles/odf_setup/tasks/validation.yml
@@ -52,4 +52,11 @@
           There are less than 3 nodes with the label
           cluster.ocs.openshift.io/openshift-storage
       when: nodes_info.resources | length < 3
+
+- name: Assert that local_storage_devices is defined and is a list with at least one item
+  ansible.builtin.assert:
+    that:
+      - local_storage_devices is defined
+      - local_storage_devices | length > 0
+    fail_msg: "local_storage_devices must be a list with at least one item"
 ...


### PR DESCRIPTION
Updating odf_setup oc path and adding default value for local_storage_devices.

---

- [x] TestBos2: virt libvirt:ansible_extravars=enable_lso:true libvirt:ansible_extravars=enable_odf:true libvirt:ansible_extravars='{"dci_operators":[{"name":"odf-operator","catalog_source":"redhat-operators","namespace":"openshift-storage","operator_group_name":"sg","operator_group_spec":{"targetNamespaces":["openshift-storage"]}},{"name":"local-storage-operator","catalog_source":"redhat-operators","namespace":"openshift-local-storage","operator_group_name":"ols","operator_group_spec":{"targetNamespaces":["openshift-local-storage"]}}]}' -  https://www.distributed-ci.io/jobs/d5fa5521-4394-4f71-b94c-179885536326

---
Test-hints: no-check