### PR TITLE
Cleanup previous assisted installation

### DIFF
--- a/roles/acm_hypershift/tasks/download-cli.yml
+++ b/roles/acm_hypershift/tasks/download-cli.yml
@@ -1,13 +1,9 @@
 ---
 - name: Download stable openshift client
   vars:
-    ocp_client_url: >
-      https://mirror.openshift.com/pub/openshift-v4/
-      x86_64/clients/ocp
+    ocp_client_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.14/openshift-client-linux.tar.gz"
   ansible.builtin.unarchive:
-    src: >
-      {{ ocp_client_url }}/stable/openshift-client-linux-amd64-rhel
-      {{ ansible_distribution_major_version }}.tar.gz
+    src: "{{ ocp_client_url }}"
     dest: "{{ ah_tmp_dir }}"
     remote_src: true
     mode: "0755"

--- a/roles/acm_hypershift/tasks/download-cli.yml
+++ b/roles/acm_hypershift/tasks/download-cli.yml
@@ -1,9 +1,13 @@
 ---
 - name: Download stable openshift client
   vars:
-    ocp_client_url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.14/openshift-client-linux.tar.gz"
+    ocp_client_url: >
+      https://mirror.openshift.com/pub/openshift-v4/
+      x86_64/clients/ocp
   ansible.builtin.unarchive:
-    src: "{{ ocp_client_url }}"
+    src: >
+      {{ ocp_client_url }}/stable/openshift-client-linux-amd64-rhel
+      {{ ansible_distribution_major_version }}.tar.gz
     dest: "{{ ah_tmp_dir }}"
     remote_src: true
     mode: "0755"

--- a/roles/setup_assisted_installer/defaults/main.yml
+++ b/roles/setup_assisted_installer/defaults/main.yml
@@ -11,6 +11,7 @@ assisted_service_installer_image: "{{ assisted_service_image_repo_url }}/assiste
 assisted_postgres_image: quay.io/centos7/postgresql-12-centos7:centos7
 assisted_installer_dir: /opt/assisted-installer
 assisted_installer_data_dir: "{{ assisted_installer_dir }}/data"
+setup_assisted_installer_keep_data: true
 assisted_installer_pod_volumes: {}
 # Useful if you want to e.g. install extra certificate chains in the pods prior
 # to setting up the AI service, e.g. you built your own AI images and pushed
@@ -58,3 +59,4 @@ podman_ipv6_network_subnet: 'fd00::1:8:0/112'
 podman_ipv6_network_gateway: 'fd00::1:8:1'
 assisted_service_extra_config: {}
 insecure_skip_verify: false
+...

--- a/roles/setup_assisted_installer/tasks/main.yml
+++ b/roles/setup_assisted_installer/tasks/main.yml
@@ -40,14 +40,23 @@
     - name: Open ports zone internal and public, for firewalld
       firewalld:
         port: "{{ item.1 }}/tcp"
-        permanent: yes
-        immediate: yes
+        permanent: true
+        immediate: true
         state: enabled
         zone: "{{ item.0 }}"
       loop: "{{ ['internal', 'public'] | product(['8000', port, assisted_service_gui_port, assisted_service_image_service_port]) | list }}"
 
-    - name: Create directories for assisted-installer
+    - name: Delete previous assisted-installer directories
       file:
+        path: "{{ item }}"
+        state: absent
+        force: true
+      with_items:
+        - "{{ assisted_installer_dir }}"
+      failed_when: false
+
+    - name: Create directories for assisted-installer
+      ansible.builtin.file:
         path: "{{ item }}"
         mode: 0775
         state: directory

--- a/roles/setup_assisted_installer/tasks/main.yml
+++ b/roles/setup_assisted_installer/tasks/main.yml
@@ -55,6 +55,8 @@
         - "{{ assisted_installer_data_dir }}"
         - "{{ assisted_installer_dir }}"
       failed_when: false
+      when:
+        - setup_assisted_installer_keep_data | bool
 
     - name: Create directories for assisted-installer
       ansible.builtin.file:

--- a/roles/setup_assisted_installer/tasks/main.yml
+++ b/roles/setup_assisted_installer/tasks/main.yml
@@ -52,6 +52,7 @@
         state: absent
         force: true
       with_items:
+        - "{{ assisted_installer_data_dir }}"
         - "{{ assisted_installer_dir }}"
       failed_when: false
 


### PR DESCRIPTION
Not cleaning up the postgress DB makes that previous deployments have access to other deployments data.

build_depends: https://github.com/dci-labs/bos2-ci-config/pull/170

TestBos2: assisted
