### PR TITLE
Add role to clean up UEFI boot entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Name | Description
 [redhatci.ocp.deprecated_api](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/deprecated_api/README.md) | Extracts deprecated API calls in a cluster
 [redhatci.ocp.destroy_vms](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/destroy_vms/README.md) | Destroys libvirt network, storage pools and the KVM Nodes and the network bridge connection.
 [redhatci.ocp.display_deployment_plan](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/display_deployment_plan/README.md) | Displays the crucible deployment plan and waits for user confirmation.
+[redhatci.ocp.efi_boot_mgr](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/efi_boot_mgr/README.md) | Remove the non-active UEFI boot entries from OCP nodes.
 [redhatci.ocp.extract_openshift_installer](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/extract_openshift_installer/README.md) | Extracts openshift_installer binary from the release image.
 [redhatci.ocp.generate_agent_iso](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/generate_agent_iso/README.md) | Creates the boot ISO using OpenShift_installer's agent sub-command
 [redhatci.ocp.generate_discovery_iso](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/generate_discovery_iso/README.md) | Creates the discovery ISO for a pre-existing cluster definition using a pre-existing on-prem assisted installer

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.13.EPOCH
+Version:        0.14.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -51,6 +51,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Fri Jul 26 2024 Tony Garcia <tonyg@redhat.com> - 0.14.EPOCH-VERS
+- Version bump due to efi_boot_mgr role
+
 * Fri Jul 26 2024 Ramon Perez <raperez@redhat.com> - 0.13.EPOCH-VERS
 - Version bump due to deprecation of cnf_cert role, moving in favour of
   k8s_best_practices_certsuite role

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.13.0
+version: 0.14.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/efi_boot_mgr/README.md
+++ b/roles/efi_boot_mgr/README.md
@@ -2,6 +2,8 @@
 
 Remove the non-active UEFI boot entries from OCP nodes.
 
+> IMPORTANT: This role removes permantently UEFI boot entries, use it with care.
+
 ## Requirements
 
 A valid *KUBECONFIG* env variable pointing to a kubeconfig file.

--- a/roles/efi_boot_mgr/README.md
+++ b/roles/efi_boot_mgr/README.md
@@ -1,0 +1,30 @@
+# EFI Boot Manager
+
+Remove the non-active UEFI boot entries from OCP nodes.
+
+## Requirements
+
+A valid *KUBECONFIG* env variable pointing to a kubeconfig file.
+
+## Variables
+
+| Variable      | Default             | Required  | Description                                           |
+| ------------- | ------------------- | --------- | ----------------------------------------------------- |
+| ebm_nodes     | \<undefined\>       | Yes       | A list of OCP node names to manage their Boot order.  |
+| ebm_oc_path   | /usr/local/bin/oc   | No        | Path to oc client.                                    |
+
+## Example Playbook
+
+- Remove the non-active UEFI Boot entries in the nodes
+
+```YAML
+- name: Clean up non-active UEFI boot entries
+  ansible.builtin.include_role:
+    name: redhatci.ocp.efi_boot_mgr
+  vars:
+    ebm_nodes:
+      - worker-0
+      - worker-1
+      - worker-2
+    ebm_oc_path: /path/to/my/oc
+```

--- a/roles/efi_boot_mgr/defaults/main.yml
+++ b/roles/efi_boot_mgr/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+ebm_oc_path: "/usr/local/bin/oc"

--- a/roles/efi_boot_mgr/files/rm-efiboot
+++ b/roles/efi_boot_mgr/files/rm-efiboot
@@ -3,6 +3,11 @@
 echo "=== Current Boot order ==="
 efibootmgr --verbose
 
+if [[ $? -ne 0 ]]; then
+    echo "Warning: efibootmgr can't remove boot entries"
+    exit
+fi
+
 boot_current=$(efibootmgr --verbose | sed -n -e 's,BootCurrent: \(.*\),\1,p')
 boot_list=($(efibootmgr --verbose | sed -n -e 's/,/ /g' -e 's,BootOrder: \(.*\),\1,p'))
 

--- a/roles/efi_boot_mgr/files/rm-efiboot
+++ b/roles/efi_boot_mgr/files/rm-efiboot
@@ -15,7 +15,7 @@ for bootnum in ${boot_list[*]}; do
     if [[ "${boot_id}" == "${boot_current}" ]]; then
         continue
     fi
-    echo efibootmgr --bootnum ${bootnum} --delete-bootnum
+    efibootmgr --bootnum ${bootnum} --delete-bootnum
 done
 
 echo "=== New Boot order ==="

--- a/roles/efi_boot_mgr/files/rm-efiboot
+++ b/roles/efi_boot_mgr/files/rm-efiboot
@@ -1,0 +1,17 @@
+# Remove non-active UEFI boot entries
+
+echo "=== Current Boot order ==="
+efibootmgr --verbose
+
+boot_current=$(efibootmgr --verbose | sed -n -e 's,BootCurrent: \(.*\),\1,p')
+boot_list=($(efibootmgr --verbose | sed -n -e 's/,/ /g' -e 's,BootOrder: \(.*\),\1,p'))
+
+for bootnum in ${boot_list[*]}; do
+    if [[ "${boot_id}" == "${boot_current}" ]]; then
+        continue
+    fi
+    echo efibootmgr --bootnum ${bootnum} --delete-bootnum
+done
+
+echo "=== New Boot order ==="
+efibootmgr --verbose

--- a/roles/efi_boot_mgr/tasks/main.yml
+++ b/roles/efi_boot_mgr/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Validation for UEFI Boot Manager
+  ansible.builtin.assert:
+    that:
+      - ebm_nodes is defined
+      - ebm_nodes | length
+
+- name: Delete UEFI boot entries in nodes
+  vars:
+    _ebm_script: "{{ lookup('file', 'rm-efiboot') | ansible.builtin.b64encode }}"
+  ansible.builtin.shell: >
+    set -eo pipefail;
+    {{ ebm_oc_path }} debug node/{{ node_name }} --
+    bash -c "echo {{ _ebm_script }} | base64 -d > /host/tmp/rm-efiboot";
+    {{ ebm_oc_path }} debug node/{{ node_name }} -- chroot /host bash -x /tmp/rm-efiboot;
+    {{ ebm_oc_path }} debug node/{{ node_name }} -- rm -f /host/tmp/rm-efiboot;
+  async: 120
+  poll: 0
+  register: _ebm_rm
+  loop: "{{ ebm_nodes }}"
+  loop_control:
+    loop_var: node_name
+  changed_when: true
+
+- name: Check boot cleanup status
+  ansible.builtin.async_status:
+    jid: "{{ result.ansible_job_id }}"
+  loop: "{{ _ebm_rm.results }}"
+  loop_control:
+    loop_var: "result"
+  register: _ebm_async_results
+  until: _ebm_async_results.finished
+  retries: 10
+  delay: 12


### PR DESCRIPTION
In a CI environment is quite common to reinstall OCP, after several times the UEFI boot order stops updating due to high amount of non-active entries. This role helps to clean them up, leaving only the active boot entry.


---

- [x] TestDallas: https://www.distributed-ci.io/jobs/835c7cf6-7693-413b-9927-4536f6313418/jobStates
- [x] TestBos2: https://www.distributed-ci.io/jobs/1b43ed01-f3d2-42c8-85c4-5fff52db2980/jobStates?sort=date

---

Test-Hints: no-check

