### PR TITLE
Remove checking client

### DIFF
--- a/roles/node_prep/tasks/10_validation.yml
+++ b/roles/node_prep/tasks/10_validation.yml
@@ -387,16 +387,6 @@
     - always
     - validation
 
-- name: Check if openshift-client-linux-{{ version }}.tar.gz exists
-  ansible.builtin.uri:
-    url: "{{ release_url }}/{{ version }}/openshift-client-linux-{{ release_version }}.tar.gz"
-  until: ocp_client_chk.status == 200
-  retries: 6
-  delay: 10
-  register: ocp_client_chk
-  delegate_to: "{{ (not dra_set and not drm_set and registry_host_exists) | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
-  tags: validation
-
 - name: Fail if hostgroups not defined in inventory/hosts file
   fail:
     msg: "The masters group is not defined. Please add masters to the inventory/hosts file"

--- a/roles/node_prep/tasks/10_validation.yml
+++ b/roles/node_prep/tasks/10_validation.yml
@@ -388,12 +388,11 @@
     - validation
 
 - name: Check if openshift-client-linux-{{ version }}.tar.gz exists
-  uri:
+  ansible.builtin.uri:
     url: "{{ release_url }}/{{ version }}/openshift-client-linux-{{ release_version }}.tar.gz"
-    method: HEAD
   until: ocp_client_chk.status == 200
-  retries: 6 # 1 minute (10 * 6)
-  delay: 10 # Every 10 seconds
+  retries: 6
+  delay: 10
   register: ocp_client_chk
   delegate_to: "{{ (not dra_set and not drm_set and registry_host_exists) | ternary(groups['registry_host'][0], groups['provisioner'][0]) }}"
   tags: validation


### PR DESCRIPTION
HEAD requests through the CDN are now returning a 403, switching to GET to validate the OCP client URL

With HEAD:
```ShellSession
❯ curl -ILs https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.16.3/openshift-client-linux-4.16.3.tar.gz
HTTP/2 307 
content-length: 0
location: https://2209d6dda25891dee55b086a469130de.r2.cloudflarestorage.com/art-srv-enterprise/pub/openshift-v4/x86_64/clients/ocp/4.16.3/openshift-client-linux-4.16.3.tar.gz?response-content-disposition=attachment%3B%20filename%3D%22openshift-client-linux-4.16.3.tar.gz%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=36cc88a3d563d343cfdd69cbe5af624a%2F20240718%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240718T222128Z&X-Amz-Expires=1200&X-Amz-SignedHeaders=host&X-Amz-Signature=58922cca6926b2927169d0bcd40de19aae4105b10de8cc74e2b15b6f82779f1c
server: CloudFront
date: Thu, 18 Jul 2024 22:21:28 GMT
x-cache: LambdaGeneratedResponse from cloudfront
via: 1.1 d350ada4cd02b5e4f46c6fd256973084.cloudfront.net (CloudFront)
x-amz-cf-pop: QRO51-P3
x-amz-cf-id: N_om92H2mWVw0kB4_RR--uO6apV8RCynoPUGKJjVL-fj2oCb-Rqi-g==

HTTP/1.1 403 Forbidden
Date: Thu, 18 Jul 2024 22:21:28 GMT
Content-Type: text/plain;charset=UTF-8
Connection: keep-alive
Server: cloudflare
CF-RAY: 8a55dd6ca9e61b23-PHX
```

With GET:
```ShellSession
❯ curl -iLs https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.16.3/openshift-client-linux-4.16.3.tar.gz
HTTP/2 307 
content-length: 0
location: https://2209d6dda25891dee55b086a469130de.r2.cloudflarestorage.com/art-srv-enterprise/pub/openshift-v4/x86_64/clients/ocp/4.16.3/openshift-client-linux-4.16.3.tar.gz?response-content-disposition=attachment%3B%20filename%3D%22openshift-client-linux-4.16.3.tar.gz%22&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=36cc88a3d563d343cfdd69cbe5af624a%2F20240718%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240718T222102Z&X-Amz-Expires=1200&X-Amz-SignedHeaders=host&X-Amz-Signature=fb663d9c82edfe3686f9d016fa2ddf2583e39a1c0139598ca04af8532e726278
server: CloudFront
date: Thu, 18 Jul 2024 22:21:02 GMT
x-cache: LambdaGeneratedResponse from cloudfront
via: 1.1 218d65ed3ca147040416a2bdc7fc1a88.cloudfront.net (CloudFront)
x-amz-cf-pop: QRO51-P3
x-amz-cf-id: gxjS5T5W1ywb8bxmbEpFcJUnE45jcR7-QJIyVTPyjiLfGb5_BYxz7w==

HTTP/1.1 200 OK
Date: Thu, 18 Jul 2024 22:21:03 GMT
Content-Type: application/x-tar
Content-Length: 66929757
Connection: keep-alive
Accept-Ranges: bytes
Content-Disposition: attachment; filename="openshift-client-linux-4.16.3.tar.gz"
ETag: "19453476b731924ef38a2188b939a901"
Last-Modified: Thu, 18 Jul 2024 15:38:31 GMT
Server: cloudflare
CF-RAY: 8a55dccf9ba72cce-DFW
```

Example of jobs failing:
- https://www.distributed-ci.io/jobs/d8a75933-4c68-4f71-907c-8da5c6a804fe/jobStates?sort=date&task=8947ec77-bdbc-4987-948a-2af882aa52a2

TestBos2: virt