### PR TITLE
[ocp_on_libvirt] reduce retries to power off VMs

### DIFF
--- a/roles/ocp_on_libvirt/tasks/libvirt_host_up2.yml
+++ b/roles/ocp_on_libvirt/tasks/libvirt_host_up2.yml
@@ -5,7 +5,7 @@
     command: status
   register: vmstatus
   until: vmstatus.status == 'shutdown'
-  retries: 1500
+  retries: 150
   delay: 10
   when: ool_node_not_exists
 


### PR DESCRIPTION
##### SUMMARY

1500 retries with a delay of 10 is too much, 150 retries with a delay of 10 should be enough.
The current config takes up to 4 hours to fail because of the retries.

##### ISSUE TYPE

- Bug

##### Tests

TestBos2: virt
