### PR TITLE
Prevent from creating client tarball if already exists

### DIFF
--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -7,8 +7,9 @@
   when:
     - mor_version is version("4.8", ">=")
   ansible.builtin.shell: >
-    {{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }} coreos print-stream-json >
-    {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json
+    flock -x -w 30 "{{ mor_cache_dir }}/{{ mor_version }}/.installer.lock" -c
+    '{{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }} coreos print-stream-json >
+    {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json'
   changed_when: true
 
 # TODO: Remove this block when 4.7 is no longer supported

--- a/roles/mirror_ocp_release/tasks/installer.yml
+++ b/roles/mirror_ocp_release/tasks/installer.yml
@@ -10,12 +10,23 @@
 - name: "Extract installer command from release image"
   when:
     - mor_force | bool or not target.stat.exists
-  ansible.builtin.command: >
-    {{ mor_oc }} adm release extract
-    --registry-config={{ mor_auths_file }}
-    --command={{ mor_installer }}
-    --from {{ mor_pull_url }}
-    --to "{{ mor_cache_dir }}/{{ mor_version }}"
+  ansible.builtin.shell: |
+    flock -x -n -E 200 "{{ mor_cache_dir }}/{{ mor_version }}/.installer.lock" -c '
+    {{ mor_oc }} adm release extract \
+    --registry-config="{{ mor_auths_file }}" \
+    --command="{{ mor_installer }}" \
+    --from "{{ mor_pull_url }}" \
+    --to "{{ mor_cache_dir }}/{{ mor_version }}"'
+
+    RESULT="$?"
+
+    if [ "$RESULT" -eq 200 ]
+    then
+      echo "Waiting for lock release"
+      flock -x -w 30 "{{ mor_cache_dir }}/{{ mor_version }}/.installer.lock" -c 'echo "Lock release"'
+    else
+      exit $RESULT
+    fi
   register: extract_cmd
   until: extract_cmd is succeeded
   retries: 9

--- a/roles/mirror_ocp_release/tasks/unpack.yml
+++ b/roles/mirror_ocp_release/tasks/unpack.yml
@@ -50,31 +50,44 @@
       delay: 10
       until: _mor_result is not failed
 
-    - name: Extract el8 client for 4.16+
-      ansible.builtin.command: >
-        {{ _mor_tmp_dir.path }}/oc adm release extract
-        --registry-config={{ mor_auths_file }}
-        --command=oc.rhel8
-        --from {{ mor_pull_url }}
-        --to "{{ mor_cache_dir }}/{{ mor_version }}"
-      register: _mor_extract_cmd
-      until: _mor_extract_cmd is succeeded
-      retries: 9
-      delay: 10
-      changed_when: false
-
     # redhatci.ocp.installer 4.16+ for el8 expects a rhel8 tarball
     # required only for nightly builds
     # using community.general.archive generates the tarball but
     # throws an exception: load_file_common_arguments() unexpected keyword argument 'path'
     - name: Create a client tarball for el8 on 4.16+ # noqa command-instead-of-module
-      ansible.builtin.shell: >
-        tar czf
-        "{{ mor_cache_dir }}/{{ mor_version }}/openshift-client-linux-amd64-rhel8-{{ mor_version }}.tar.gz"
-        -C "{{ mor_cache_dir }}/{{ mor_version }}"
-        oc
-        kubectl
+      ansible.builtin.shell:
+        cmd: |
+          if [ ! -f "{{ mor_cache_dir }}/{{ mor_version }}/openshift-client-linux-amd64-rhel8-{{ mor_version }}.tar.gz" ]
+          then
+            flock -x -n -E 200 {{ mor_cache_dir }}/{{ mor_version }}/.tar.lock -c '
+            {{ _mor_tmp_dir.path }}/oc adm release extract \
+            --registry-config={{ mor_auths_file }} \
+            --command=oc.rhel8 \
+            --from {{ mor_pull_url }} \
+            --to "{{ mor_cache_dir }}/{{ mor_version }}" \
+            && \
+            tar czf \
+            "{{ mor_cache_dir }}/{{ mor_version }}/openshift-client-linux-amd64-rhel8-{{ mor_version }}.tar.gz" \
+            -C "{{ mor_cache_dir }}/{{ mor_version }}" \
+            oc \
+            kubectl
+            '
+
+            RESULT="$?"
+
+            if [ "$RESULT" -eq 200 ]
+            then
+              echo "Waiting for lock release"
+              flock -x -w 30 {{ mor_cache_dir }}/{{ mor_version }}/.tar.lock -c 'echo "Lock released"'
+            else
+              exit $RESULT
+            fi
+          fi
       changed_when: true
+      register: _mor_create_tarball
+      until: _mor_create_tarball is succeeded
+      retries: 9
+      delay: 10
 
     - name: Delete temporary directory for oc client
       ansible.builtin.file:


### PR DESCRIPTION
##### SUMMARY
Fixes: CILAB-1745: Failed at redhatci.ocp.mirror_ocp_release : Create a client tarball for el8 on 4.16

If two Ansible jobs attempt at running the task from redhatci/ocp/roles/mirror_ocp_release/tasks/unpack.yml from the same runner host a conflict will happen since the tar command monitors the target tarball file for external changes. In other words, the first job running the task will eventually detect that the second job overrode the file and fail.

Likewise, there's a conflict between the tasks "Extract installer command from release image" and "Write rhcos.json from command 4.8+" where the first one exports the openshift-install script and the second one executes it so, if one job tries to execute the script while a different one is exporting (and overwriting) it a failure is thrown with the script execution reporting the script is being altered.

With this change, Ansible uses filesystem locks to ensure only one job at a time can create the client tools tarball and extract the openshift installer, while any other job detecting the tasks above are already undergoing, will put on hold and rely on the artifacts generated by the first job.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### Tests
To be tested with two parallel SNO deployments in a partner lab:

```
$ dci-pipeline-check https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/395 -p sno intel-nm-ocp sno-config &
$ dci-pipeline-check https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/395 -p sno-2 intel-nm-ocp sno-config
```

Following jobs illustrate the fixed used case:
- https://www.distributed-ci.io/jobs/28328ec2-9774-4f34-a22f-67e3bac1b2ae/jobStates?sort=date&task=0bc66810-6ac3-4228-a18b-f2433d21fcec
- https://www.distributed-ci.io/jobs/711ed29c-39c8-41de-9cb5-46543fa41ab8/jobStates?sort=date&task=7ec68d27-7dba-4b60-85d8-89afcfc9205c

TestBos2Sno: sno
