### PR TITLE
increase retries of pods operator in running status

### DIFF
--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -186,7 +186,7 @@
         kind: Pod
         namespace: "{{ namespace }}"
       register: olm_pod
-      retries: 12
+      retries: 45
       delay: 10
       until:
         olm_pod.resources | map(attribute='status.phase') | difference(['Succeeded', 'Running']) | length == 0


### PR DESCRIPTION
##### SUMMARY

increase retries of pods operator in running status

some operators like odf are taking longer to settle.

##### ISSUE TYPE

- Enhanced

##### DEPENDENCIES

build-depends: https://github.com/dci-labs/bos2-ci-config/pull/180

##### Tests

 - [x] TestBos2: virt-prega libvirt:ansible_extravars=dci_pre_ga_catalog:quay.io/prega/prega-operator-index:v4.17-20240808T200304 libvirt:topic=OCP-4.17

---

Test-hints: no-check

