### PR TITLE
Increase waiting time for pods in operator install

### DIFF
--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -186,7 +186,7 @@
         kind: Pod
         namespace: "{{ namespace }}"
       register: olm_pod
-      retries: 12
+      retries: 30
       delay: 10
       until:
         olm_pod.resources | map(attribute='status.phase') | difference(['Succeeded', 'Running']) | length == 0


### PR DESCRIPTION
##### SUMMARY

We've observed some operators' pod take a bit longer to settle, increasing the wait from 2min to 5min.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### Tests

- [ ] TestBos2 -

---

TestBos2: virt-prega libvirt:ansible_extravars=dci_pre_ga_catalog:quay.io/prega/prega-operator-index:v4.17-20240802T200308 libvirt:topic=OCP-4.17
