### PR TITLE
acm_setup | Wait up to 30 mins for MCH to be ready

### DIFF
--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -90,7 +90,7 @@
   retries: 20
   delay: 15
 
-- name: "Wait up to 20 mins for MCH to be ready"
+- name: "Wait up to 30 mins for MCH to be ready"
   community.kubernetes.k8s_info:
     api: operator.open-cluster-management.io/v1
     kind: MultiClusterHub
@@ -98,7 +98,7 @@
     namespace: "{{ hub_namespace }}"
   register: mch
   retries: 60
-  delay: 20
+  delay: 30
   until:
     - mch.resources is defined
     - mch.resources | length == 1


### PR DESCRIPTION
##### SUMMARY

Currently, we're waiting 20 minutes for MCH to be ready in acm_setup role, but sometimes, this task fails in OCP 4.17 deployments, and it looks like we're not waiting enough time. Example [here](https://www.distributed-ci.io/jobs/233e47b3-2e23-4662-8a53-53757eb7a163/jobStates?sort=date&task=73e1ac50-245c-4c8b-adca-4b6ec8c891bd).

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### Tests

- [] TestDallas - <JobID>

---

TestDallas: ocp-4.17-vanilla openshift-vanilla:ansible_extravars=dci_pre_ga_catalog:quay.io/prega/prega-operator-index:v4.17-20240812T200310