### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+---
+
+name: Stale issues/PRs
+on:
+  schedule:
+    - cron: "0 9 * * 1-5"  # Weekdays at 09:00 UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+          days-before-stale: 30
+          days-before-close: 7
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days'


### PR DESCRIPTION
##### SUMMARY

Workflow to label stale issues/PRs for 30d and closing them after 7d of inactivity.

Stale: 30d (default: 60s)
Close: 7d

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

None

---

Test-Hint: no-check
