### PR TITLE
Patch provisioning if available

### DIFF
--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -196,7 +196,7 @@
       spec:
         watchAllNamespaces: true
   when:
-    - _as_prov_conf.resources | default([0]) | length == 1
+    - _as_prov_conf.resources | default([]) | length == 1
 
 - name: "Get cluster version"
   community.kubernetes.k8s_info:

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -179,6 +179,13 @@
   retries: 20
   delay: 15
 
+- name: "Check if Metal3 provisioning is available"
+  community.kubernetes.k8s_info:
+    api_version: metal3.io/v1alpha1
+    kind: Provisioning
+    name: provisioning-configuration
+  register: _as_prov_conf
+
 - name: "Update the provisioning resource to watch all Namespaces"
   community.kubernetes.k8s:
     definition:
@@ -188,6 +195,8 @@
         name: provisioning-configuration
       spec:
         watchAllNamespaces: true
+  when:
+    - _as_prov_conf.resources | default([0]) | length == 1
 
 - name: "Get cluster version"
   community.kubernetes.k8s_info:


### PR DESCRIPTION
##### SUMMARY

- Allow ACM hubs setup on SNO instances
- Provisioning resource is not present in SNO deployments

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Fix

##### Tests
Test-Hint: no-check
