### PR TITLE
acm-setup - Add initial clusterimageset

### DIFF
--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -342,4 +342,20 @@
   retries: 20
   delay: 15
   no_log: true
+
+- name: "Create an initial ClusterImageSet based on Hub release info"
+  community.kubernetes.k8s:
+    definition:
+      apiVersion: hive.openshift.io/v1
+      kind: ClusterImageSet
+      metadata:
+        labels:
+          channel: "{{ cluster_version.resources[0].spec.channel }}"
+          visible: 'true'
+        name: "img-{{ cluster_version.resources[0].status.desired.version }}"
+        namespace: open-cluster-management
+      spec:
+        releaseImage: "{{ cluster_version.resources[0].status.desired.image }}"
+  when:
+    - hub_disconnected | bool
 ...


### PR DESCRIPTION
##### SUMMARY

- Add an initial clusterimageset for disconnected environments using the information from the Hub cluster

This allows the deployment of other clusters using the same release as the cluster.

* The OS images for the release must be present in the AgentServiceConfig

##### ISSUE TYPE

- Enhanced Feature

##### Tests
- [] TestDallas - <JobID>

---

TestDallas: ocp-4.16-acm-hub