### PR TITLE
Supporting concurrent jobs in the SNO provision host

### DIFF
--- a/roles/sno_installer/tasks/10_get_oc.yml
+++ b/roles/sno_installer/tasks/10_get_oc.yml
@@ -188,7 +188,7 @@
   block:
     - name: "Get the openshift client tools from registry host into temp file on control machine"
       ansible.builtin.fetch:
-        dest: /tmp/
+        dest: "{{ _si_tmp_dir.path }}/"
         flat: true
         src: "{{ cache_dir }}/{{ version }}/{{ item }}"
       loop:
@@ -198,7 +198,7 @@
 
     - name: "Copy the openshift client tools from control machine to the provisioner host"
       ansible.builtin.copy:
-        src: "/tmp/{{ item }}"
+        src: "{{ _si_tmp_dir.path }}/{{ item }}"
         dest: "{{ dir }}/{{ item }}"
         owner: "{{ ansible_user_id }}"
         group: "{{ ansible_user_gid }}"
@@ -207,15 +207,6 @@
         - kubectl
         - oc
       become: true
-
-    - name: "Remove the temporary copy of the openshift clients on control machine"
-      ansible.builtin.file:
-        path: "/tmp/{{ item }}"
-        state: absent
-      loop:
-        - kubectl
-        - oc
-      delegate_to: localhost
 
     - name: "Copy oc and kubectl binaries to binary path on provisioner"
       ansible.builtin.copy:

--- a/roles/sno_installer/tasks/20_extract_installer.yml
+++ b/roles/sno_installer/tasks/20_extract_installer.yml
@@ -56,25 +56,19 @@
   block:
     - name: "Get the openshift install from registry host into temp file on control machine"
       ansible.builtin.fetch:
-        dest: /tmp/
+        dest: "{{ _si_tmp_dir.path }}/"
         flat: true
         src: "{{ cache_dir }}/{{ version }}/openshift-install"
       delegate_to: "{{ groups['registry_host'][0] }}"
 
     - name: "Copy the openshift installer from control machine to the provisioner host"
       ansible.builtin.copy:
-        src: "/tmp/openshift-install"
+        src: "{{ _si_tmp_dir.path }}/openshift-install"
         dest: "{{ dir }}/openshift-install"
         owner: "{{ ansible_user_id }}"
         group: "{{ ansible_user_gid }}"
         mode: "0755"
       become: true
-
-    - name: "Remove the temporary copy of the openshift installer on control machine"
-      ansible.builtin.file:
-        path: "/tmp/openshift-install"
-        state: absent
-      delegate_to: localhost
 
     - name: "Copy openshift installer binary to binary path on provisioner"
       ansible.builtin.copy:

--- a/roles/sno_installer/tasks/21_rhcos_image_paths.yml
+++ b/roles/sno_installer/tasks/21_rhcos_image_paths.yml
@@ -25,20 +25,14 @@
 
 - name: "Get the rhcos.json from cache server into temp file on control machine"
   ansible.builtin.fetch:
-    dest: /tmp/
+    dest: "{{ _si_tmp_dir.path }}/"
     flat: true
     src: "{{ cache_dir }}/{{ version }}/rhcos.json"
   delegate_to: "{{ cache_server }}"
 
 - name: "Load variables from rhcos.json"
   ansible.builtin.include_vars:
-    file: "/tmp/rhcos.json"
+    file: "{{ _si_tmp_dir.path }}/rhcos.json"
     name: rhcos_json_vars
   tags: rhcospath
-
-- name: "Remove the temporary copy of rhcos.json on control machine"
-  ansible.builtin.file:
-    path: "/tmp/rhcos.json"
-    state: absent
-  delegate_to: localhost
 ...

--- a/roles/sno_installer/tasks/55_create_ignition.yml
+++ b/roles/sno_installer/tasks/55_create_ignition.yml
@@ -21,24 +21,18 @@
   block:
     - name: "Get the ignition file from the provisione host into temp file on control machine"
       ansible.builtin.fetch:
-        dest: /tmp/
+        dest: "{{ _si_tmp_dir.path }}/"
         flat: true
         src: "{{ dir }}/bootstrap-in-place-for-live-iso.ign"
 
     - name: "Copy the ignition file from control machine to the registry host"
       ansible.builtin.copy:
-        src: "/tmp/bootstrap-in-place-for-live-iso.ign"
+        src: "{{ _si_tmp_dir.path }}/bootstrap-in-place-for-live-iso.ign"
         dest: "{{ coreos_sno_ignition }}"
         mode: "0644"
         setype: httpd_sys_content_t
       become: true
       delegate_to: "{{ groups['registry_host'][0] }}"
-
-    - name: "Remove the temporary copy of ignition file on control machine"
-      ansible.builtin.file:
-        path: "/tmp/bootstrap-in-place-for-live-iso.ign"
-        state: absent
-      delegate_to: localhost
 
 - name: "Extra tasks to get ignition file for baremetal SNO"
   when:

--- a/roles/sno_installer/tasks/main.yml
+++ b/roles/sno_installer/tasks/main.yml
@@ -1,5 +1,16 @@
 ---
 # tasks file for sno_installer
+
+- name: Create temp dir for artifact manipulation
+  ansible.builtin.tempfile:
+    state: directory
+    prefix: sno_installer.
+  register: _si_tmp_dir
+  tags:
+    - extract
+    - rhcospath
+    - ignition
+
 - name: Get OCP client
   ansible.builtin.include_tasks: 10_get_oc.yml
   tags:
@@ -106,3 +117,12 @@
 - name: Wait for deployment to complete
   ansible.builtin.include_tasks: 70_wait_deployment.yml
   tags: waitdeploy
+
+- name: Delete temp dir for artifact manipulation
+  ansible.builtin.file:
+    state: absent
+    path: "{{ _si_tmp_dir.path }}"
+  tags:
+    - extract
+    - rhcospath
+    - ignition


### PR DESCRIPTION
##### SUMMARY
Fixes CILAB-1776: Failed at redhatci.ocp.sno_installer : Load variables from rhcos.jso

> The rhcos.json file is first downloaded and placed in the /tmp directory, then processed, and finally removed.
> 
> When running two simultaneous jobs, it may happen that the first job removes the file just after the second one pulls it but before it processes it's contents, thus the error.

##### ISSUE TYPE

- Bug

##### Tests

TestBos2Sno: sno
