### PR TITLE
Patch or create provision resource

### DIFF
--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -179,13 +179,6 @@
   retries: 20
   delay: 15
 
-- name: "Check if Metal3 provisioning is available"
-  community.kubernetes.k8s_info:
-    api_version: metal3.io/v1alpha1
-    kind: Provisioning
-    name: provisioning-configuration
-  register: _as_prov_conf
-
 - name: "Update the provisioning resource to watch all Namespaces"
   community.kubernetes.k8s:
     definition:
@@ -194,9 +187,8 @@
       metadata:
         name: provisioning-configuration
       spec:
+        provisioningNetwork: "Disabled"
         watchAllNamespaces: true
-  when:
-    - _as_prov_conf.resources | default([]) | length == 1
 
 - name: "Get cluster version"
   community.kubernetes.k8s_info:


### PR DESCRIPTION
https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html-single/clusters/index#enable-cim-create-provision

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Provision resource must be present in SNO and MNO deployments, disabling the provisioningNetwork is missing here.

[Create provision resource](https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html-single/clusters/index#enable-cim-create-provision)

##### ISSUE TYPE

- Fix

##### Tests

- [x] TestBos2: acm-hub - https://www.distributed-ci.io/jobs/16e265ae-7f2f-4460-8859-9ee2ff310d6e/
- [x] TestBos2Sno: sno-ai ztp-spoke-4.15 - https://www.distributed-ci.io/jobs/116f6ceb-f89c-48d8-b4aa-e9f51ad69273/jobStates, https://www.distributed-ci.io/jobs/808852c2-c292-492a-a2d8-08fc009ac9c3/jobStates

---

Test-Hints: no-check

