### PR TITLE
Double the time we wait for OCS health status

### DIFF
--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -40,7 +40,7 @@
     namespace: "{{ ocs_storage_namespace }}"
     name: "{{ ocs_storagecluster_name }}-cephcluster"
   register: ocs_health_status
-  retries: 30
+  retries: 60
   delay: 20
   until:
     - ocs_health_status.resources is defined


### PR DESCRIPTION
##### SUMMARY

We're having [troubles](https://www.distributed-ci.io/jobs/9ff55d83-8417-4396-ab07-69cdac1b5301/jobStates?sort=date&task=a13bcbb5-80ef-4802-9774-13e7aed670ac) with Get OCS health status task. It looks like it's required more time to achieve the desired status.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/08650ac9-72cd-45fe-8f4d-088c50a322a9/jobStates

---

TestBos2: virt