### PR TITLE
Increase certsuite to v5.3.2

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 kbpc_check_commit_sha: false
 kbpc_repository: "https://github.com/redhat-best-practices-for-k8s/certsuite"
-kbpc_version: v5.3.1
+kbpc_version: v5.3.2
 kbpc_project_name: certsuite
 kbpc_test_labels: "all"
 kbpc_test_config:


### PR DESCRIPTION
##### SUMMARY

Increase default version of certsuite in k8s_best_practices_certsuite role

##### ISSUE TYPE

- New

##### Tests

- [ ] TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[] - 

---

TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[]