### PR TITLE
Do not fail if skippable is true

### DIFF
--- a/roles/olm_operator/README.md
+++ b/roles/olm_operator/README.md
@@ -16,6 +16,7 @@ operator_group_spec         | No        | {}                     | The operator 
 source                      | No        | redhat-operators       | CatalogSource where to pull operator from
 source_ns                   | No        | openshift-marketplace  | Namespace where the CatalogSource is (default: )
 starting_csv                | No        | \<latest\>             | Operator version to install different than the latest published in the catalog.
+olm_operator_skippable      | No        | false                  | When set to `true`, avoids failing if the `operator` is not present in the `source`.
 
 ## Examples of usage
 
@@ -54,4 +55,5 @@ Installing an operator's specific version:
       targetNamespaces:
         - openshift-storage
     starting_csv: 4.7.2
+    olm_operator_skippable: true
 ```

--- a/roles/olm_operator/defaults/main.yml
+++ b/roles/olm_operator/defaults/main.yml
@@ -3,4 +3,6 @@ channel: ""
 source: redhat-operators
 source_ns: openshift-marketplace
 operator_group_name: "{{ operator }}"
+olm_operator_skippable: false
+olm_operator_found: true
 ...

--- a/roles/olm_operator/defaults/main.yml
+++ b/roles/olm_operator/defaults/main.yml
@@ -4,5 +4,4 @@ source: redhat-operators
 source_ns: openshift-marketplace
 operator_group_name: "{{ operator }}"
 olm_operator_skippable: false
-olm_operator_found: true
 ...

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -55,9 +55,24 @@
     - operator_packagemanifest is defined
     - operator_packagemanifest.resources is defined
     - operator_packagemanifest.resources | length
-  failed_when: operator_packagemanifest is skipped
+  failed_when: false
+  ignore_errors: true
+
+- name: Set package as not found
+  ansible.builtin.set_fact:
+    olm_operator_found: false
+  when: operator_packagemanifest is skipped
     or operator_packagemanifest.resources is undefined
     or operator_packagemanifest.resources | length != 1
+
+- name: Fail if not found and nor skippable
+  ansible.builtin.fail:
+    msg: >
+      The operator {{ operator }} is not found in the catalog
+      and skippable is {{ olm_operator_skippable }}.
+  when:
+    - not olm_operator_skippable
+    - not olm_operator_found
 
 - name: "Installing Operator {{ operator }}"
   vars:
@@ -72,8 +87,9 @@
         | first
       }}
     operator_csv: "{{ starting_csv | default(default_csv, true) }}"
+  when:
+    - olm_operator_found | bool
   block:
-
     - name: Print install parameters
       ansible.builtin.debug:
         msg:

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: Initialize operator found fact
+  ansible.builtin.set_fact:
+    olm_operator_found: true
+
 - name: Assert all required fields are present
   ansible.builtin.assert:
     that:
@@ -57,16 +62,14 @@
     - operator_packagemanifest.resources | length
   ignore_errors: true
 
+- name: Set package as not found
+  ansible.builtin.set_fact:
+    olm_operator_found: false
+  when: operator_packagemanifest is skipped
+    or operator_packagemanifest.resources is undefined
+    or operator_packagemanifest.resources | length != 1
+
 - name: Fail if not found and nor skippable
-  vars:
-    olm_operator_found: |-
-      {%- if operator_packagemanifest is skipped
-          or operator_packagemanifest.resources is undefined
-          or operator_packagemanifest.resources | length != 1 -%}
-      false
-      {%- else -%}
-      true
-      {%- endif -%}
   ansible.builtin.fail:
     msg: >
       The operator {{ operator }} is not found in the catalog

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -55,7 +55,6 @@
     - operator_packagemanifest is defined
     - operator_packagemanifest.resources is defined
     - operator_packagemanifest.resources | length
-  failed_when: false
   ignore_errors: true
 
 - name: Set package as not found

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -57,14 +57,16 @@
     - operator_packagemanifest.resources | length
   ignore_errors: true
 
-- name: Set package as not found
-  ansible.builtin.set_fact:
-    olm_operator_found: false
-  when: operator_packagemanifest is skipped
-    or operator_packagemanifest.resources is undefined
-    or operator_packagemanifest.resources | length != 1
-
 - name: Fail if not found and nor skippable
+  vars:
+    olm_operator_found: |-
+      {%- if operator_packagemanifest is skipped
+          or operator_packagemanifest.resources is undefined
+          or operator_packagemanifest.resources | length != 1 -%}
+      false
+      {%- else -%}
+      true
+      {%- endif -%}
   ansible.builtin.fail:
     msg: >
       The operator {{ operator }} is not found in the catalog


### PR DESCRIPTION
##### SUMMARY
It allows to skip operators that may not be present in the catalog, but it is acceptable not to try installing them.

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

- [x] TestBos2 - https://www.distributed-ci.io/jobs/6552213a-2739-4440-bd92-4a84184f7dce/jobStates

---

Test-Hint: no-check

