### PR TITLE
Added support for Git HTTP transport

### DIFF
--- a/roles/configure_ztp_gitops_apps/README.md
+++ b/roles/configure_ztp_gitops_apps/README.md
@@ -20,8 +20,10 @@ czga_sites_path             | string | yes      | -                             
 czga_policies_gitops_repo   | string | yes      | -                                                  | Repository where Policies can be found.
 czga_policies_branch        | string | yes      | -                                                  | Policies repo's branch.
 czga_policies_path          | string | yes      | -                                                  | Path to find Policies' kustomize file in the repo.
-czga_site_generator_image   | string | yes      | -                                                  | ZTP site generator container image
 czga_site_generator_version | string | yes      | -                                                  | ZTP site generator container version
+czga_multicluster_version   | string | yes      | -                                                  | Multicluster operators subscription container version
+czga_site_generator_image   | string | no       | `registry.redhat.io/openshif4/ztp-site-generate-rhel8` | ZTP site generator container image
+czga_multicluster_image     | string | no       | `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9` | Multicluster operators subscription container image
 czga_podman_runner_host     | string | no       | podman-runner                                      |  Identity of the inventory host pulling the sites template generator image.
 czga_clusters_namespace     | string | no       | cluster-sub                                        | Namespace for the site config resources.
 czga_kubeconfig_path        | string | no       | `{{ omit }}`                                       | Path to the ACM hub kubeconfig file.

--- a/roles/configure_ztp_gitops_apps/defaults/main.yaml
+++ b/roles/configure_ztp_gitops_apps/defaults/main.yaml
@@ -5,3 +5,5 @@ czga_clusters_namespace: clusters-sub
 czga_kubeconfig_path: "{{ omit }}"
 czga_policies_namespace: policies-sub
 czga_oc_tool_path: "{{ oc_tool_path | default('/usr/loca/bin/oc') }}"
+czga_site_generator_image: registry.redhat.io/openshift4/ztp-site-generate-rhel8
+czga_multicluster_image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9

--- a/roles/configure_ztp_gitops_apps/tasks/main.yaml
+++ b/roles/configure_ztp_gitops_apps/tasks/main.yaml
@@ -17,10 +17,10 @@
       - czga_policies_branch | length > 0
       - czga_policies_path is defined
       - czga_policies_path | length > 0
-      - czga_site_generator_image is defined
-      - czga_site_generator_image | length > 0
       - czga_site_generator_version is defined
       - czga_site_generator_version | length > 0
+      - czga_multicluster_version is defined
+      - czga_multicluster_version | length > 0
       - czga_ocp_pull_secret is defined
       - czga_ocp_pull_secret | length > 0
 
@@ -159,11 +159,17 @@
             - "    kind: ClusterImageSet"
             - "  - group: hive.openshift.io"
 
-    - name: Replace image container URL in argocd-openshift-gitops-patch.json
+    - name: Replace ztp-site-generate image container URL in argocd-openshift-gitops-patch.json
       ansible.builtin.replace:
         path: "{{ temp_dir.path }}/ztp/argocd/deployment/argocd-openshift-gitops-patch.json"
-        regexp: "{{ czga_site_generator_image }}.*/"
+        regexp: '[^"]*ztp-site-generate[^"]*'
         replace: "{{ czga_site_generator_image }}:{{ czga_site_generator_version }}"
+
+    - name: Replace multicluster-operators-subscription image container URL in argocd-openshift-gitops-patch.json
+      ansible.builtin.replace:
+        path: "{{ temp_dir.path }}/ztp/argocd/deployment/argocd-openshift-gitops-patch.json"
+        regexp: '[^"]*multicluster-operators-subscription[^"]*'
+        replace: "{{ czga_multicluster_image }}:{{ czga_multicluster_version }}"
 
     - name: Patch the ArgoCD instance to install the GitOps ZTP plugin
       ansible.builtin.shell: |

--- a/roles/gitops_configure_repo/README.md
+++ b/roles/gitops_configure_repo/README.md
@@ -13,13 +13,15 @@ Requirements
 Role Variables
 --------------
 
-Name                        | Type   | Required | Default                                            | Description
---------------------------- | ------ | -------- | -------------------------------------------------- | -------------------------------------------------------------
-gcr_ssh_key_path            | string | yes      | `{{ lookup('env', 'HOME') }}/.ssh/id_rsa`          | Path to the SSH private key file used to log into the GitOps manifest repository.
-gcr_ssh_known_hosts         | string | no       | -                                                  | Should be the SSH known hosts. It is required by ArgoCD when working with a SSH key.
-gcr_ztp_gitops_repo         | string | yes      | -                                                  | URL to the ZTP GitOps Git repository.
-gcr_argo_cd_known_host_cm   | string | no       | argocd-ssh-known-hosts-cm                          | ConfigMap that will save the ArgoCD SSH known hosts.
-gcr_private_repo_secret     | string | no       | private-repo                                       | Secret that will hold the private repo credentials.
+Name                        | Type   | Required | Default                                   | Description
+--------------------------- | ------ | -------- | ----------------------------------------- | ------------
+gcr_ssh_key_path            | string | yes      | `{{ lookup('env', 'HOME') }}/.ssh/id_rsa` | Path to the SSH private key file used to log into the GitOps manifest repository. Only mandatory if repository transport is SSH.
+gcr_ssh_known_hosts         | string | no       | -                                         | Should be the SSH known hosts. It is required by ArgoCD when working with a SSH key.
+gcr_ztp_gitops_repo         | string | yes      | -                                         | URL to the ZTP GitOps Git repository.
+gcr_argo_cd_known_host_cm   | string | no       | argocd-ssh-known-hosts-cm                 | ConfigMap that will save the ArgoCD SSH known hosts.
+gcr_private_repo_secret     | string | no       | private-repo                              | Secret that will hold the private repo credentials.
+gcr_repo_username           | string | yes      |                                           | Username to connect to the repository. Only mandatory if repository transport is HTTP.
+gcr_repo_password           | string | yes      |                                           | Password to connect to the repository. Only mandatory if repository transport is HTTP.
 
 Dependencies
 ------------

--- a/roles/gitops_configure_repo/tasks/main.yaml
+++ b/roles/gitops_configure_repo/tasks/main.yaml
@@ -1,12 +1,19 @@
 ---
 
+- name: Identify the Git repo transport protocol
+  ansible.builtin.set_fact:
+    gcr_repo_protocol_http: "{{ gcr_ztp_gitops_repo | regex_search('https?://') | type_debug == 'str' }}"
+
 - name: Assert the required variables are defined
   ansible.builtin.assert:
     that:
-      - gcr_ssh_key_path is defined
-      - gcr_ssh_key_path | length > 0
       - gcr_ztp_gitops_repo is defined
       - gcr_ztp_gitops_repo | length > 0
+      - >
+          (gcr_repo_protocol_http and
+          gcr_repo_username is defined and gcr_repo_username | length > 0 and
+          gcr_repo_password is defined and gcr_repo_password | length > 0) or
+          (gcr_ssh_key_path is defined and gcr_ssh_key_path | length > 0)
 
 - name: Add ssh_known_hosts to ArgoCD
   community.kubernetes.k8s:
@@ -26,29 +33,14 @@
     - gcr_ssh_known_hosts | length > 0
   no_log: true
 
-- name: Register key
-  ansible.builtin.set_fact:
-    gcr_ssh_key: "{{ lookup('file', gcr_ssh_key_path) }}"
-  no_log: true
-
-- name: Create temporary template directory
-  ansible.builtin.tempfile:
-    state: directory
-    suffix: build
-  register: temp_dir
-
-- name: Template the private repo resource for Argo
-  ansible.builtin.template:
-    src: ssh_private_repo.yaml.j2
-    dest: "{{ temp_dir.path }}/ssh_private_repo.yaml"
-    mode: '0644'
-
-- name: Apply ssh private repo
+- name: Set up a SSH private repository
   community.kubernetes.k8s:
-    src: "{{ temp_dir.path }}/ssh_private_repo.yaml"
+    definition: "{{ lookup('template', 'ssh_private_repo.yaml.j2') | from_yaml }}"
+  when: not gcr_repo_protocol_http
   no_log: true
 
-- name: Remove temporary directory
-  ansible.builtin.file:
-    path: "{{ temp_dir.path }}"
-    state: absent
+- name: Set up a HTTP private repository
+  community.kubernetes.k8s:
+    definition: "{{ lookup('template', 'http_private_repo.yaml.j2') | from_yaml }}"
+  when: gcr_repo_protocol_http
+  no_log: true

--- a/roles/gitops_configure_repo/templates/http_private_repo.yaml.j2
+++ b/roles/gitops_configure_repo/templates/http_private_repo.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: repository
+  name: {{ gcr_private_repo_secret }}
+  namespace: openshift-gitops
+stringData:
+# Set project to restrict the access to these credentials
+#  project: default
+  type: git
+  url: {{ gcr_ztp_gitops_repo }}
+  username: {{ gcr_repo_username }}
+  password: {{ gcr_repo_password }}

--- a/roles/gitops_configure_repo/templates/ssh_private_repo.yaml.j2
+++ b/roles/gitops_configure_repo/templates/ssh_private_repo.yaml.j2
@@ -9,4 +9,4 @@ stringData:
   type: git
   url: {{ gcr_ztp_gitops_repo }}
   sshPrivateKey: |
-    {{ gcr_ssh_key | indent(4)}}
+    {{ lookup('file', gcr_ssh_key_path) | indent(4)}}


### PR DESCRIPTION
##### SUMMARY
This change updates the gitops_configure_repo role to add support for Git HTTP transport.
This is needed because the role currently only supports SSH transport, but HTTP is easier to set up in repositories hosted in an OpenShift cluster, for instance, in disconnected networks

##### ISSUE TYPE

- Enhanced Feature

##### Tests

Test-Hints: no-check