### PR TITLE
Fix for the renaming of certsuite config file and some flags

### DIFF
--- a/roles/k8s_best_practices_certsuite/tasks/teardown.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/teardown.yml
@@ -1,6 +1,6 @@
 ---
 # Always submit these files to DCI:
-# - Configuration files - tnf_config.yml
+# - Configuration files - tnf_config.yml (or certsuite_config.yml)
 # - Execution logs - certsuite-stdout.log and certsuite.log, if they exist
 - name: Copy config and log files related to certsuite execution
   ansible.builtin.copy:
@@ -8,7 +8,7 @@
     dest: "{{ kbpc_log_path }}"
     mode: "0750"
   with_fileglob:
-    - "{{ kbpc_certsuite_dir }}/config_files/tnf_config.yml"
+    - "{{ kbpc_certsuite_dir }}/config_files/*_config.yml"
     - "{{ kbpc_certsuite_dir }}/result_files/*.log"
   when:
     - kbpc_log_path is defined
@@ -25,16 +25,18 @@
 - name: Clean certsuite resources
   when: kbpc_postrun_delete_resources|bool
   block:
-    - name: Define tnf-debug daemonset namespace
+    - name: Define probe daemonset namespace
       ansible.builtin.set_fact:
-        kbpc_debug_ds_ns: "cnf-suite"
+        kbpc_probe_ds_ns: "{{ (kbpc_version == 'HEAD') | ternary('certsuite', 'cnf-suite') }}"
 
-    - name: Ensure tnf-debug DaemonSet is absent
+    - name: Ensure probe DaemonSet is absent
+      vars:
+        kbpc_probe_ds_name: "{{ (kbpc_version == 'HEAD') | ternary('certsuite-debug', 'tnf-debug') }}"
       community.kubernetes.k8s:
         api_version: v1
         kind: DaemonSet
-        name: tnf-debug
-        namespace: "{{ kbpc_debug_ds_ns }}"
+        name: "{{ kbpc_probe_ds_name }}"
+        namespace: "{{ kbpc_probe_ds_ns }}"
         state: absent
 
     - name: Ensure tnf namespace is absent
@@ -44,11 +46,11 @@
         name: tnf
         state: absent
 
-    - name: Ensure tnf-debug namespace is absent
+    - name: Ensure probe daemonset namespace is absent
       community.kubernetes.k8s:
         api_version: v1
         kind: Namespace
-        name: "{{ kbpc_debug_ds_ns }}"
+        name: "{{ kbpc_probe_ds_ns }}"
         state: absent
 
 # This is just done when testing a certsuite stable version

--- a/roles/k8s_best_practices_certsuite/tasks/tests.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/tests.yml
@@ -11,10 +11,12 @@
     state: directory
     mode: '0755'
 
-- name: Template tnf_config.yml
+- name: Template config file
+  vars:
+    kbpc_config_file_name: "{{ (kbpc_version == 'HEAD') | ternary('certsuite_config', 'tnf_config') }}"
   ansible.builtin.template:
-    src: templates/tnf_config.yml.j2
-    dest: "{{ kbpc_certsuite_dir }}/config_files/tnf_config.yml"
+    src: "templates/{{ kbpc_config_file_name }}.yml.j2"
+    dest: "{{ kbpc_certsuite_dir }}/config_files/{{ kbpc_config_file_name }}.yml"
     mode: '0755'
 
 # Just do this in case preflight test suite is used.
@@ -36,6 +38,7 @@
         _kbpc_repo_org_name: "{{ (kbpc_version is version('v5.2.3', '>=') or kbpc_version == 'HEAD') | ternary('redhat-best-practices-for-k8s', 'testnetworkfunction') }}"
         kbpc_partner_repo: "{{ (kbpc_registry | length) | ternary(kbpc_registry, 'quay.io') }}/{{ _kbpc_repo_org_name }}"
         kbpc_support_image: "{{ kbpc_support_image_name }}:{{ kbpc_support_image_version }}"
+        kbpc_config_file_name: "{{ (kbpc_version == 'HEAD') | ternary('certsuite_config', 'tnf_config') }}"
         kbpc_container_command: |
           ./certsuite run \
           {% if kbpc_test_labels | length > 0 %}
@@ -47,10 +50,14 @@
           {% endif %}
           --output-dir=/usr/certsuite/results \
           --offline-db=/usr/offline-db \
-          --config-file=/usr/certsuite/config/tnf_config.yml \
+          --config-file=/usr/certsuite/config/{{ kbpc_config_file_name }}.yml \
           --kubeconfig=/usr/certsuite/config/kubeconfig \
+          {% if kbpc_version == 'HEAD' %}
+          --certsuite-probe-image={{ kbpc_partner_repo }}/{{ kbpc_support_image }} \
+          {% else %}
           --tnf-image-repository={{ kbpc_partner_repo }} \
           --tnf-debug-image={{ kbpc_support_image }} \
+          {% endif %}
           --create-xml-junit-file={{ kbpc_enable_xml_creation }} \
           --non-intrusive={{ kbpc_non_intrusive_only }} \
           --log-level={{ kbpc_log_level }} \

--- a/roles/k8s_best_practices_certsuite/templates/certsuite_config.yml.j2
+++ b/roles/k8s_best_practices_certsuite/templates/certsuite_config.yml.j2
@@ -1,0 +1,73 @@
+---
+targetNameSpaces:
+{% for item in kbpc_test_config %}
+{% if item.namespace is defined and item.namespace|length %}
+  - name: {{ item.namespace }}
+{% endif %}
+{% endfor %}
+
+podsUnderTestLabels:
+{% for item in kbpc_test_config %}
+{% if item.targetpodlabels is defined and item.targetpodlabels is iterable %}
+{% for label in item.targetpodlabels %}
+{% if label|length %}
+  - "{{ label|regex_search('.+?=')|regex_replace('=', '') }}: {{ label|regex_search('=.*')|regex_replace('=', '') }}"
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+operatorsUnderTestLabels:
+{% for item in kbpc_test_config %}
+{% if item.targetoperatorlabels is defined and item.targetoperatorlabels is iterable %}
+{% for label in item.targetoperatorlabels %}
+{% if label|length %}
+  - "{{ label|regex_search('.+?=')|regex_replace('=', '') }}: {{ label|regex_search('=.*')|regex_replace('=', '') }}"
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+targetCrdFilters:
+{% for item in kbpc_test_config %}
+{% if item.target_crds is defined and item.target_crds is iterable %}
+{% for crd in item.target_crds %}
+  - nameSuffix: {{ crd.nameSuffix }}
+    scalable: {{ crd.scalable }}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+acceptedKernelTaints:
+{% for item in kbpc_accepted_kernel_taints %}
+{% if item.module is defined and item.module|length %}
+  - module: {{ item.module }}
+{% endif %}
+{% endfor %}
+
+servicesignorelist:
+{% for item in kbpc_services_ignore_list %}
+  - {{ item }}
+{% endfor %}
+
+## fields below are not currently used, leaving placeholder in case they were needed in the future
+#managedDeployments:
+
+#managedStatefulsets:
+
+#skipScalingTestDeployments:
+
+#skipScalingTestStatefulSetNames:
+
+#skipHelmChartList:
+
+#validProtocolNames:
+
+#collectorAppEndPoint: ""
+
+#executedBy: ""
+
+#partnerName: ""
+
+#collectorAppPassword: ""
+...


### PR DESCRIPTION
##### SUMMARY

[ This change in certsuite](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2379) introduced a couple of new features that needs to be included also in k8s_best_practices_certsuite role:

- Renaming of config file
- Renaming of some flags

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

- [x] certsuite HEAD version - https://www.distributed-ci.io/jobs/b105866c-a37c-4116-93ee-df1ef21c3806/jobStates
- [x] certsuite v5.3.2 (to confirm backwards compatibility) - https://www.distributed-ci.io/jobs/d6a298cf-6893-490c-a857-8023b7432e25/jobStates

Test-Hints: no-check