### PR TITLE
[installer] add support to define bootstrap fixed ext net vars

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.19.EPOCH
+Version:        0.20.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -51,6 +51,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Thu Sep 12 2024 Manuel Rodriguez <manrodri@redhat.com> - 0.20.EPOCH-VERS
+- Version bump for installer and node_prep roles updates
+
 * Mon Sep  9 2024 Ramon Perez <raperez@redhat.com> - 0.19.EPOCH-VERS
 - Removed cnf_cert deprecated role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.19.0
+version: 0.20.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/installer/templates/install-config-virtualmedia.j2
+++ b/roles/installer/templates/install-config-virtualmedia.j2
@@ -74,8 +74,21 @@ platform:
     provisioningNetwork: "Disabled"
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int == 6)) %}
     provisioningHostIP: {{ provisioningHostIP }}
-{% endif %}
     bootstrapProvisioningIP: {{ bootstrapProvisioningIP }}
+{% endif %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) and (static_bootstrap_extnet | default(false) | bool)) %}
+{% if bootstrapExternalStaticIP is defined %}
+    bootstrapExternalStaticIP: {{ bootstrapExternalStaticIP }}
+{% endif %}
+{% if bootstrapExternalStaticGateway is defined %}
+    bootstrapExternalStaticGateway: {{ bootstrapExternalStaticGateway }}
+{% endif %}
+{% endif %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 14)) and (static_bootstrap_extnet | default(false) | bool)) %}
+{% if bootstrapExternalStaticDNS is defined %}
+    bootstrapExternalStaticDNS: {{ bootstrapExternalStaticDNS }}
+{% endif %}
+{% endif %}
 {% if externalMACAddress is defined %}
     externalMACAddress: {{ externalMACAddress }}
 {% endif %}

--- a/roles/installer/templates/install-config.j2
+++ b/roles/installer/templates/install-config.j2
@@ -78,6 +78,9 @@ platform:
 {% if prov_dhcp_range is defined and prov_dhcp_range|length %}
     provisioningDHCPRange: {{ prov_dhcp_range }}
 {% endif %}    
+{% if bootstrapProvisioningIP is defined and bootstrapProvisioningIP|length %}
+    bootstrapProvisioningIP: {{ bootstrapProvisioningIP }}
+{% endif %}
 {% if externalMACAddress is defined and externalMACAddress|length %}
     externalMACAddress: '{{ externalMACAddress }}'
 {% endif %}

--- a/roles/node_prep/defaults/main.yml
+++ b/roles/node_prep/defaults/main.yml
@@ -18,3 +18,4 @@ baremetal_bridge: "baremetal"
 disable_bmc_certificate_verification: false
 redfish_inspection: true
 enable_virtualmedia: false
+static_bootstrap_extnet: false

--- a/roles/node_prep/tasks/10_validation.yml
+++ b/roles/node_prep/tasks/10_validation.yml
@@ -536,12 +536,26 @@
     - always
     - validation
 
-- name: Fail when bootstrapProvisioningIP are not set when virtualmedia option is enabled
-  fail:
-    msg: "bootstrapProvisioningIP must be set when enable_virtualmedia is set"
+- name: Fail when bootstrapExternalStatic* variables are not set when virtualmedia option and static bootstrap booleans are enabled
+  ansible.builtin.fail:
+    msg: "bootstrapExternalStaticIP and bootstrapExternalStaticGateway variables must be set when enable_virtualmedia and static_bootstrap_extnet are set"
   when:
+    - release_version is ansible.builtin.version('4.12', '>=')
     - enable_virtualmedia|bool
-    - bootstrapProvisioningIP is undefined
+    - static_bootstrap_extnet|bool
+    - bootstrapExternalStaticIP is undefined or bootstrapExternalStaticGateway is undefined
+  tags:
+    - always
+    - validation
+
+- name: Fail when bootstrapExternalStaticDNS variable is not set when virtualmedia option and static bootstrap booleans are enabled in OCP 4.14 and above
+  fail:
+    msg: "bootstrapExternalStaticDNS variable must be set when enable_virtualmedia and static_bootstrap_extnet are set in OCP >= 4.14"
+  when:
+    - release_version is ansible.builtin.version('4.14', '>=')
+    - enable_virtualmedia|bool
+    - static_bootstrap_extnet|bool
+    - bootstrapExternalStaticDNS is undefined
   tags:
     - always
     - validation


### PR DESCRIPTION
##### SUMMARY

bootstrapProvisioningIP is intended to be an IP
on the provisioning network when prov network is
defined. If disabled then allow to define the
bootstrap VM to have a Fixed IP/GW/DNS on the
external network.


##### ISSUE TYPE

Enhanced Feature
More details in https://issues.redhat.com/browse/OCPBUGS-36869

##### Tests

- [x] 4.12 IPI Baremetal without  bootstrapProvisioningIP and with bootstrapExternalStaticIP/GW settings - https://www.distributed-ci.io/jobs/6620f5b0-3906-441d-b2f7-6ba0a68143f5/jobStates?sort=date&task=867e63a8-6f9b-44c0-9540-776cbb1ac2d4 - failed because DNS is different than the GW in Telco Partner CI labs, but it should work in an env where the GW is the same IP address as the DNS.
- [x] 4.14 IPI Baremetal without  bootstrapProvisioningIP and with bootstrapExternalStaticIP/GW/DNS settings - https://www.distributed-ci.io/jobs/7538cc68-0e57-4cdb-8950-d8414bf70a8c/jobStates?sort=date
- [x] 4.16 IPI Baremetal without  bootstrapProvisioningIP and with DHCP settings for external network - https://www.distributed-ci.io/jobs/587d92d5-d4c2-4c23-851d-b4b060439994/jobStates?sort=date

---

Test-Hints: no-check