### PR TITLE
No log for extra verbose tasks

### DIFF
--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -89,6 +89,7 @@
   until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
   retries: 20
   delay: 15
+  no_log: true
 
 - name: "Wait up to 30 mins for MCH to be ready"
   community.kubernetes.k8s_info:
@@ -178,7 +179,7 @@
   until: pod_list|json_query('resources[*].status.phase')|unique == ["Running"]
   retries: 20
   delay: 15
-
+  no_log: true
 
 - name: "Disable provisioning network and update to watch all Namespaces"
   community.kubernetes.k8s:

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -61,6 +61,7 @@
     - operator_packagemanifest.resources is defined
     - operator_packagemanifest.resources | length
   ignore_errors: true
+  no_log: true
 
 - name: Set package as not found
   ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY

Logging produced by these tasks may break the DCI GUI.

##### ISSUE TYPE

- Bug, Docs Fix, or other nominal change

##### Tests

- [x] TestBos2: acm-hub -  https://www.distributed-ci.io/jobs/a527c9fb-452e-49aa-a67b-d437a7652c56/jobStates

---

Test-Hints: no-check

