### PR TITLE
Fix for catalog_source role

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -51,7 +51,7 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
-* Sat Sep  7 2024 Tony Garcia <tonyg@rehat.com> - 0.18.EPOCH-VERS
+* Sat Sep  7 2024 Tony Garcia <tonyg@redhat.com> - 0.18.EPOCH-VERS
 - New version with fix to catalog_source role
 
 * Fri Sep  6 2024 Ramon Perez <raperez@redhat.com> - 0.17.EPOCH-VERS

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.17.EPOCH
+Version:        0.18.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -51,6 +51,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Sat Sep  7 2024 Tony Garcia <tonyg@rehat.com> - 0.18.EPOCH-VERS
+- New version with fix to catalog_source role
+
 * Fri Sep  6 2024 Ramon Perez <raperez@redhat.com> - 0.17.EPOCH-VERS
 - Version bump for example_cnf_deploy role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.17.0
+version: 0.18.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/catalog_source/README.md
+++ b/roles/catalog_source/README.md
@@ -10,7 +10,7 @@ cs_image           | Yes      |                | Catalog Image URL
 cs_namespace       | No       | openshift-marketplace  | Namespace where the CatalogSource will be defined
 cs_publisher       | No       | Third Party    | CatalogSource publisher
 cs_type            | No       | grpc           | CatalogSource type
-cs_update_strategy | No       | {}             | CatalogSource update strategy
+cs_update_strategy | No       | undefined      | CatalogSource update strategy
 
 ## Example of usage
 

--- a/roles/catalog_source/defaults/main.yml
+++ b/roles/catalog_source/defaults/main.yml
@@ -2,6 +2,5 @@
 cs_namespace: openshift-marketplace
 cs_publisher: "Third party"
 cs_type: grpc
-cs_update_strategy: {}
 
 ...

--- a/roles/catalog_source/tasks/main.yml
+++ b/roles/catalog_source/tasks/main.yml
@@ -12,8 +12,8 @@
     msg: CatalogSource {{ cs_name }}
 
 - name: Create CatalogSource
-  community.kubernetes.k8s:
-    definition:
+  vars:
+    _cs_definition: |-
       apiVersion: operators.coreos.com/v1alpha1
       kind: CatalogSource
       metadata:
@@ -24,7 +24,12 @@
         image: "{{ cs_image }}"
         publisher: "{{ cs_publisher }}"
         sourceType: "{{ cs_type }}"
-        updateStrategy: "{{ cs_update_strategy }}"
+      {% if cs_update_strategy is defined %}
+        updateStrategy:
+          {{ cs_update_strategy }}
+      {% endif %}
+  community.kubernetes.k8s:
+    definition: "{{ _cs_definition }}"
 
 - name: Wait for CatalogSource to be Ready
   community.kubernetes.k8s_info:


### PR DESCRIPTION
##### SUMMARY

The catalog_source role introduced a new setting "cs_update_strategy" that injected an empty object by default to the catalog causing it to fail. This fix only adds an object when a strategy is provided.

##### ISSUE TYPE

- Bug Fix
- 
##### Tests

- [x] TestDallas: ocp-4.14-vanilla example-cnf
  - [x]  https://www.distributed-ci.io/jobs/8a379692-d57e-4bee-ad26-ce1faf94c878
  - [x] https://www.distributed-ci.io/jobs/ac3bc698-4709-4f88-9002-925b83b50c5a - The failure is unrelated to this change

---

Test-Hints: no-check