### PR TITLE
Destroy disks of current inventory in destroy_vms

### DIFF
--- a/roles/destroy_vms/defaults/main.yml
+++ b/roles/destroy_vms/defaults/main.yml
@@ -1,7 +1,7 @@
 virt_packages:
   - python3
   - libvirt
-  -  virt-install
+  - virt-install
   - qemu-kvm
   - virt-manager
   - python3-pip

--- a/roles/destroy_vms/tasks/destroy_vms.yml
+++ b/roles/destroy_vms/tasks/destroy_vms.yml
@@ -1,10 +1,10 @@
 - name: Find vm creation scripts
-  find:
+  ansible.builtin.find:
     path: "{{ vm_create_scripts_dir }}"
   register: creation_to_remove
 
-- name: Remove file in {{ vm_create_scripts_dir }} dir
-  file:
+- name: Remove file in dir {{ vm_create_scripts_dir }}
+  ansible.builtin.file:
     path: "{{ item }}"
     state: absent
   loop: "{{ creation_to_remove.files | map(attribute='path') | select('match', prefix_regex) | list }}"
@@ -17,7 +17,22 @@
     state: destroyed
   loop: "{{ vms_to_remove | default([]) }}"
 
-- name: Undefine VM # The 'loop' default will prevent action when none is needed.
-  shell:
+# The 'loop' default will prevent action when none is needed.
+- name: Undefine VM  # noqa: command-instead-of-shell
+  ansible.builtin.shell:
     cmd: "virsh undefine --remove-all-storage --nvram {{ item }}" # community.libvirt.virt undefine doesn't have the ability to specify --nvram
   loop: "{{ vms_to_remove | default([]) }}"
+
+# In some cases the disks removed through the "Undefine" task does not correspond to the disks that
+# could be created with the *current* inventory. This task will remove the disk files that would have
+# been created with the current inventory.
+- name: Remove disk files  # noqa: command-instead-of-shell
+  ansible.builtin.shell:
+    cmd: >-
+      rm -f
+      {% for disk_name, _ in item.disks.items() %}
+      {{ images_dir }}/{{ item.name }}_{{ disk_name }}.qcow2
+      {% endfor %}
+  loop: "{{ kvm_nodes | default([]) }}"
+  loop_control:
+    label: item.name


### PR DESCRIPTION
##### SUMMARY

In some cases the disks removed through the "Undefine" task does not correspond to the disks that could be created with the *current* inventory. This change remove the disk files that would have been created with the current inventory.

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestBos2Sno: sno-ai - https://www.distributed-ci.io/jobs/03041ca3-5e5b-46cd-b2ac-e9c7c30044fa
- [x] TestBos2: assisted-abi - https://www.distributed-ci.io/jobs/476a4da9-dab2-406d-900a-7308a597a707
- [x] TestBos2: assisted - https://www.distributed-ci.io/jobs/b96bd014-b12f-4f5f-9a27-9394fa57ad3d

---

Test-Hints: no-check