### PR TITLE
Bump to certsuite v5.3.3

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 kbpc_check_commit_sha: false
 kbpc_repository: "https://github.com/redhat-best-practices-for-k8s/certsuite"
-kbpc_version: v5.3.2
+kbpc_version: v5.3.3
 kbpc_project_name: certsuite
 kbpc_test_labels: "all"
 kbpc_test_config:

--- a/roles/k8s_best_practices_certsuite/tasks/teardown.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/teardown.yml
@@ -27,11 +27,11 @@
   block:
     - name: Define probe daemonset namespace
       ansible.builtin.set_fact:
-        kbpc_probe_ds_ns: "{{ (kbpc_version == 'HEAD') | ternary('certsuite', 'cnf-suite') }}"
+        kbpc_probe_ds_ns: "{{ (kbpc_version is version('v5.3.3', '>=') or kbpc_version == 'HEAD') | ternary('certsuite', 'cnf-suite') }}"
 
     - name: Ensure probe DaemonSet is absent
       vars:
-        kbpc_probe_ds_name: "{{ (kbpc_version == 'HEAD') | ternary('certsuite-debug', 'tnf-debug') }}"
+        kbpc_probe_ds_name: "{{ (kbpc_version is version('v5.3.3', '>=') or kbpc_version == 'HEAD') | ternary('certsuite-debug', 'tnf-debug') }}"
       community.kubernetes.k8s:
         api_version: v1
         kind: DaemonSet

--- a/roles/k8s_best_practices_certsuite/tasks/tests.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/tests.yml
@@ -13,7 +13,7 @@
 
 - name: Template config file
   vars:
-    kbpc_config_file_name: "{{ (kbpc_version == 'HEAD') | ternary('certsuite_config', 'tnf_config') }}"
+    kbpc_config_file_name: "{{ (kbpc_version is version('v5.3.3', '>=') or kbpc_version == 'HEAD') | ternary('certsuite_config', 'tnf_config') }}"
   ansible.builtin.template:
     src: "templates/{{ kbpc_config_file_name }}.yml.j2"
     dest: "{{ kbpc_certsuite_dir }}/config_files/{{ kbpc_config_file_name }}.yml"
@@ -38,7 +38,7 @@
         _kbpc_repo_org_name: "{{ (kbpc_version is version('v5.2.3', '>=') or kbpc_version == 'HEAD') | ternary('redhat-best-practices-for-k8s', 'testnetworkfunction') }}"
         kbpc_partner_repo: "{{ (kbpc_registry | length) | ternary(kbpc_registry, 'quay.io') }}/{{ _kbpc_repo_org_name }}"
         kbpc_support_image: "{{ kbpc_support_image_name }}:{{ kbpc_support_image_version }}"
-        kbpc_config_file_name: "{{ (kbpc_version == 'HEAD') | ternary('certsuite_config', 'tnf_config') }}"
+        kbpc_config_file_name: "{{ (kbpc_version is version('v5.3.3', '>=') or kbpc_version == 'HEAD') | ternary('certsuite_config', 'tnf_config') }}"
         kbpc_container_command: |
           ./certsuite run \
           {% if kbpc_test_labels | length > 0 %}
@@ -52,7 +52,7 @@
           --offline-db=/usr/offline-db \
           --config-file=/usr/certsuite/config/{{ kbpc_config_file_name }}.yml \
           --kubeconfig=/usr/certsuite/config/kubeconfig \
-          {% if kbpc_version == 'HEAD' %}
+          {% if kbpc_version is version('v5.3.3', '>=') or kbpc_version == 'HEAD' %}
           --certsuite-probe-image={{ kbpc_partner_repo }}/{{ kbpc_support_image }} \
           {% else %}
           --tnf-image-repository={{ kbpc_partner_repo }} \


### PR DESCRIPTION
##### SUMMARY

- Increase default version of certsuite in k8s_best_practices_certsuite role
- Include conditions only related to HEAD version, now they have to include v5.3.3

##### ISSUE TYPE

- New

##### Tests

- [ ] TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[]

---

TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[]