### PR TITLE
populate_mirror_registry | Select RHEL version for oc binary for >=4.16

### DIFF
--- a/roles/populate_mirror_registry/defaults/main.yml
+++ b/roles/populate_mirror_registry/defaults/main.yml
@@ -21,7 +21,8 @@ image_name_registry: ocpdiscon-registry
 #   Stable client is also used to extract the artifacts from release image
 # - opm tar always has to come from stable release URL, so that its name is well known
 stable_release_url: "https://mirror.openshift.com/pub/openshift-v{{ openshift_version_parts[0] }}/clients/ocp/stable-4.14"
-oc_tar: "openshift-client-linux-{{ openshift_full_version }}.tar.gz"
+oc_tar_prefix: "{{ (openshift_full_version is ansible.builtin.version('4.16', '>=')) | ternary('amd64-rhel' + ansible_distribution_major_version + '-', '') }}" # noqa: redhat-ci[no-role-prefix]
+oc_tar: "openshift-client-linux-{{ oc_tar_prefix }}{{ openshift_full_version }}.tar.gz" # noqa: redhat-ci[no-role-prefix]
 stable_oc_tar: "openshift-client-linux.tar.gz"
 stable_opm_tar: "opm-linux.tar.gz"
 


### PR DESCRIPTION
##### SUMMARY

oc binary extracted from OCP 4.16 nightly builds hits the GLIBC library not found issue, typically an issue related to using a RHEL9 binary in a RHEL8 server.

In theory, this is covered with this task from [mirror_ocp_release role](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/mirror_ocp_release/tasks/unpack.yml#L53-L90), where we already have a correct binary, but right now, with the introduction of a flock block that is not really working, this task is not working properly and the oc binary is not correctly regenerated.

This eventually affects to populate_mirror_registry role, where we are hitting in a partner execution the GLIBC issue [example](https://www.distributed-ci.io/jobs/7568927e-7298-46d4-859a-e8e1fea225ff/jobStates?sort=date&task=4abdffd5-6b03-4402-be56-2862e9bae551)

Making sure in this change that we're always downloading the RHEL8 binary for `oc` command starting from OCP 4.16

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestDallas - ocp-4.16-acm-hub - https://www.distributed-ci.io/jobs/fdf5af13-6dc7-478c-a44c-347ad7e77663/jobStates?sort=date

---

Test-Hints: no-check