### PR TITLE
Extracting RHEL8 OC client even if related tar.gz file already exists

### DIFF
--- a/roles/mirror_ocp_release/tasks/unpack.yml
+++ b/roles/mirror_ocp_release/tasks/unpack.yml
@@ -57,31 +57,28 @@
     - name: Create a client tarball for el8 on 4.16+ # noqa command-instead-of-module
       ansible.builtin.shell:
         cmd: |
-          if [ ! -f "{{ mor_cache_dir }}/{{ mor_version }}/openshift-client-linux-amd64-rhel8-{{ mor_version }}.tar.gz" ]
+          flock -x -n -E 200 {{ mor_cache_dir }}/{{ mor_version }}/.tar.lock -c '
+          {{ _mor_tmp_dir.path }}/oc adm release extract \
+          --registry-config={{ mor_auths_file }} \
+          --command=oc.rhel8 \
+          --from {{ mor_pull_url }} \
+          --to "{{ mor_cache_dir }}/{{ mor_version }}" \
+          && \
+          tar czf \
+          "{{ mor_cache_dir }}/{{ mor_version }}/openshift-client-linux-amd64-rhel8-{{ mor_version }}.tar.gz" \
+          -C "{{ mor_cache_dir }}/{{ mor_version }}" \
+          oc \
+          kubectl
+          '
+
+          RESULT="$?"
+
+          if [ "$RESULT" -eq 200 ]
           then
-            flock -x -n -E 200 {{ mor_cache_dir }}/{{ mor_version }}/.tar.lock -c '
-            {{ _mor_tmp_dir.path }}/oc adm release extract \
-            --registry-config={{ mor_auths_file }} \
-            --command=oc.rhel8 \
-            --from {{ mor_pull_url }} \
-            --to "{{ mor_cache_dir }}/{{ mor_version }}" \
-            && \
-            tar czf \
-            "{{ mor_cache_dir }}/{{ mor_version }}/openshift-client-linux-amd64-rhel8-{{ mor_version }}.tar.gz" \
-            -C "{{ mor_cache_dir }}/{{ mor_version }}" \
-            oc \
-            kubectl
-            '
-
-            RESULT="$?"
-
-            if [ "$RESULT" -eq 200 ]
-            then
               echo "Waiting for lock release"
               flock -x -w 30 {{ mor_cache_dir }}/{{ mor_version }}/.tar.lock -c 'echo "Lock released"'
-            else
+          else
               exit $RESULT
-            fi
           fi
       changed_when: true
       register: _mor_create_tarball


### PR DESCRIPTION
##### SUMMARY
Fixes CILAB-445

The mirror_ocp_release role runs some tasks over tar.gz archives that we susceptible of fail when multiple jobs were operating over the same files simultaneously.

To overcome this, we introduced some file locks to secure the pieces of code that could cause this conflicts.

Along with this, we introduced an initial check so, if the resulting tar.gz file already existed the code wouldn't run.

This introduced a bug since, as part of the generation of the openshift-client tar.gz file for RHEL8, the RHEL8 OC binary was extracted in the cache directory to replace the existing RHEL9 binary.

If this is not done, running the RHEL9 binary in a later task will fail due to missing glibc libraries.

- Bug

- [x] TestDallas: ocp-4.17-vanilla -  https://www.distributed-ci.io/jobs/acbfe98e-1664-4486-b014-f650626d6310/jobStates

---

Test-Hints: no-check