### PR TITLE
Increase certsuite default version - v5.3.4

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 kbpc_check_commit_sha: false
 kbpc_repository: "https://github.com/redhat-best-practices-for-k8s/certsuite"
-kbpc_version: v5.3.3
+kbpc_version: v5.3.4
 kbpc_project_name: certsuite
 kbpc_test_labels: "all"
 kbpc_test_config:


### PR DESCRIPTION
##### SUMMARY

Increasing default certsuite version to match latest release

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[] - https://www.distributed-ci.io/jobs/79e48faf-ce55-4eb3-93d3-862573dea238

---

Test-Hints: no-check