### PR TITLE
k8s_best_practices_certsuite: use git instead of ansible.builtin.git

### DIFF
--- a/roles/k8s_best_practices_certsuite/tasks/pre-run.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/pre-run.yml
@@ -156,7 +156,7 @@
         kbpc_certsuite_image: "{{ kbpc_image_name }}:{{ kbpc_image_tag }}"
 
     - name: Clone certsuite repository
-      ansible.builtin.git:
+      git:
         repo: "{{ kbpc_repository }}"
         version: "{{ kbpc_version }}"
         dest: "{{ kbpc_certsuite_dir }}"


### PR DESCRIPTION

##### SUMMARY

Testing differences between calling the git module as `git` vs `ansible.builtin.git`.

##### ISSUE TYPE

<!--- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change
- New or Enhanced Feature

##### Tests

Depends-On: https://softwarefactory-project.io/r/c/dci-ansible/+/32330
TestDallasWorkload: tnf-test-cnf-green
