### PR TITLE
Remove tmp workaround to fix incorrect JUnit file format

### DIFF
--- a/roles/verify_tests/README.md
+++ b/roles/verify_tests/README.md
@@ -9,7 +9,6 @@ Name                  | Default      | Description
 --------------------- | ------------ | -------------
 tests_to_verify       | undefined    | There is a complex list of expected results, where each element contains a JUnit filename (supports globbing) and a corresponding list of expected results. A sublist of expected results could include one or more pairs of 'testcase name' and 'passed'/'failed'.
 skip_absent_testfiles | false        | Use this option to prevent the verification process from failing if the JUnit file listed in the expected results is not present.
-junit_fix_tags        | false        | Please use this option to add the missing <testsuites></testsuites> tags to the JUnit file in order to fix the formatting.
 
 ```yaml
 # Example of the list of expected results per file (supports globbing).

--- a/roles/verify_tests/tasks/parse_junit_file.yml
+++ b/roles/verify_tests/tasks/parse_junit_file.yml
@@ -12,32 +12,14 @@
     # Do not fail when the option to skip missing files is on
     - not skip_absent_testfiles | bool
 
-- name: Parse JUnit file
-  when: junit_file.stat.exists
-  block:
-    - name: Verify JUnit format and fix wrapping testsuites tags if required
-      when: junit_fix_tags | default(false) | bool
-      block:
-        - name: "Insert opening <testsuites> tag"
-          ansible.builtin.lineinfile:
-            path: "{{ item }}"
-            insertbefore: '<testsuite'
-            line: '<testsuites>'
+- name: "Retrieve the actual test results from {{ item | basename }}"
+  ansible.builtin.set_fact:
+    actual_results: "{{ item | redhatci.ocp.junit2dict }}"
 
-        - name: "Insert closing </testsuites> tag"
-          ansible.builtin.lineinfile:
-            path: "{{ item }}"
-            insertafter: EOF
-            line: '</testsuites>'
-
-    - name: "Retrieve the actual test results from {{ item | basename }}"
-      ansible.builtin.set_fact:
-        actual_results: "{{ item | redhatci.ocp.junit2dict }}"
-
-    - name: "Fail if not all test results are as expected for {{ item | basename }}"
-      vars:
-        expectation_failed: "{{ t.expected_results | redhatci.ocp.regex_diff(actual_results) }}"
-      ansible.builtin.fail:
-        msg: "The following expectations failed: {{ expectation_failed }}"
-      when: expectation_failed | length > 0
+- name: "Fail if not all test results are as expected for {{ item | basename }}"
+  vars:
+    expectation_failed: "{{ t.expected_results | redhatci.ocp.regex_diff(actual_results) }}"
+  ansible.builtin.fail:
+    msg: "The following expectations failed: {{ expectation_failed }}"
+  when: expectation_failed | length > 0
 ...


### PR DESCRIPTION
##### SUMMARY
- Remove the tmp workaround that was used to fix the wrong format of JUnit files generated by the Test Harness team
- Fix wrong indent coming from migration to the collections

##### ISSUE TYPE

<!--- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change

##### Tests

[x] TestDallasWorkload: preflight-green

Everything is working as expected for [verify_tests functionality](https://www.distributed-ci.io/jobs/69b32b4f-a334-4aed-8734-c5194b080990/jobStates?sort=date&task=1cf30adf-9935-45c8-abe9-5bc50e6bfd9c).
