### PR TITLE
Use legacy plugin

### DIFF
--- a/roles/k8s_best_practices_certsuite/tasks/pre-run.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/pre-run.yml
@@ -156,7 +156,7 @@
         kbpc_certsuite_image: "{{ kbpc_image_name }}:{{ kbpc_image_tag }}"
 
     - name: Clone certsuite repository
-      ansible.builtin.git:
+      ansible.legacy.git:
         repo: "{{ kbpc_repository }}"
         version: "{{ kbpc_version }}"
         dest: "{{ kbpc_certsuite_dir }}"


### PR DESCRIPTION
##### SUMMARY

Use legacy fqcn to consume the DCI git action plugin.

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=kbpc_version:v5.3.3 - https://www.distributed-ci.io/jobs/d1a6cf8f-3173-44a6-af8b-c622500adc34

---

Build-depends: https://softwarefactory-project.io/r/c/dci-ansible/+/32330
Test-Hint: no-check
