### PR TITLE
sno_installer: allow for external cache server even in connected environments

### DIFF
--- a/roles/sno_installer/README.md
+++ b/roles/sno_installer/README.md
@@ -18,10 +18,14 @@ For any type of SNO installation, these variables are always required
 
 ## Other variables used:
 
-Variable        | Required | Default    | Description
-----------------|----------|------------|-------------
-si_cache_dir    | no       | /opt/cache | Path to the directory in the registry host containing every OCP version installation artifacts.
-si_cache_server | no       | *null*     | In disconnected environments, automatically resolves to the first member of the registry_host group, otherwise resolves to the provision host. If passed as an argument, it must be set to a FQDN for an SSH accessible host containing the cache directory and serving the installation artifacts.
+Variable                      | Required | Default    | Description
+------------------------------|----------|------------|-------------
+si_cache_dir                  | no       | /opt/cache | Path to the directory in the registry host containing every OCP version installation artifacts.
+si_cache_server               | no       | *null*     | In disconnected environments, automatically resolves to the first member of the registry_host group, otherwise resolves to the provision host. If passed as an argument, it must be set to a FQDN for an SSH accessible host containing the cache directory and serving the installation artifacts.
+si_cache_server_major_version | no       | {{ ansible_distribution_major_version }} | Distribution major version for the cache server if it's different than the version in the provision host.
+si_cache_server_user_id       | no       | {{ ansible_user_id }} | User ID in the cache server if the value is different than for the provision host.
+si_cache_server_user_gid      | no       | {{ ansible_user_gid }} | User GID in the cache server if the value is different than for the provision host.
+si_cache_server_user_dir      | no       | {{ ansible_user_dir }} | Home directory for the cache server user if the value is different than the provision host.
 
 ## SNO Virtual
 

--- a/roles/sno_installer/README.md
+++ b/roles/sno_installer/README.md
@@ -16,6 +16,13 @@ For any type of SNO installation, these variables are always required
 - install_type # DCI use only, options: ipi (default), sno
 - pull_image # The "Pull From" `ocp_release` image to use from the release.txt file. In DCI this is provided in the OCP component.
 
+## Other variables used:
+
+Variable        | Required | Default    | Description
+----------------|----------|------------|-------------
+si_cache_dir    | no       | /opt/cache | Path to the directory in the registry host containing every OCP version installation artifacts.
+si_cache_server | no       | *null*     | In disconnected environments, automatically resolves to the first member of the registry_host group, otherwise resolves to the provision host. If passed as an argument, it must be set to a FQDN for an SSH accessible host containing the cache directory and serving the installation artifacts.
+
 ## SNO Virtual
 
 Steps and playbooks to help you setup your environment are documented [here](https://github.com/redhat-cip/dci-openshift-agent/tree/master/samples/sno_on_libvirt#readme)

--- a/roles/sno_installer/defaults/main.yml
+++ b/roles/sno_installer/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # defaults file for sno_installer
 cache_enabled: true
-provision_cache_store: "{{ cache_dir }}"
+si_cache_dir: "/opt/cache"
+provision_cache_store: "{{ si_cache_dir }}"
 webserver_caching_image: "quay.io/fedora/httpd-24:latest"
 webserver_caching_port_container: 8080
 webserver_caching_port: "{{ webserver_caching_port_container }}"

--- a/roles/sno_installer/defaults/main.yml
+++ b/roles/sno_installer/defaults/main.yml
@@ -2,10 +2,15 @@
 # defaults file for sno_installer
 cache_enabled: true
 si_cache_dir: "/opt/cache"
-provision_cache_store: "{{ si_cache_dir }}"
 webserver_caching_image: "quay.io/fedora/httpd-24:latest"
 webserver_caching_port_container: 8080
 webserver_caching_port: "{{ webserver_caching_port_container }}"
 url_passed: false
 tftp_dir: "/var/lib/tftpboot"
 dnsmasq_enabled: true
+
+si_cache_server: "{{ cache_provisioner | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
+si_cache_server_major_version: "{{ ansible_distribution_major_version }}"
+si_cache_server_user_id: "{{ ansible_user_id }}"
+si_cache_server_user_gid: "{{ ansible_user_gid }}"
+si_cache_server_user_dir: "{{ ansible_user_dir }}"

--- a/roles/sno_installer/tasks/10_get_oc.yml
+++ b/roles/sno_installer/tasks/10_get_oc.yml
@@ -98,6 +98,15 @@
     - getoc
     - cache
 
+- name: "Get the distro major version in the cache server"
+  ansible.builtin.setup:
+    gather_subset:
+      - distribution_major_version
+  delegate_to: "{{ si_cache_server }}"
+  tags:
+    - getoc
+    - cache
+
 - name: "Download stable client"
   vars:
     ocp_stable_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp

--- a/roles/sno_installer/tasks/10_get_oc.yml
+++ b/roles/sno_installer/tasks/10_get_oc.yml
@@ -20,14 +20,6 @@
     - cleanup
     - getoc
 
-- name: "Set fact with the host providing the webserver"
-  ansible.builtin.set_fact:
-    si_cache_server: "{{ cache_provisioner | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
-  when: si_cache_server is undefined
-  tags:
-    - getoc
-    - cache
-
 - name: "Validate that master cache directory exists"
   ansible.builtin.stat:
     path: "{{ si_cache_dir }}"
@@ -98,20 +90,11 @@
     - getoc
     - cache
 
-- name: "Get the distro major version in the cache server"
-  ansible.builtin.setup:
-    gather_subset:
-      - distribution_major_version
-  delegate_to: "{{ si_cache_server }}"
-  tags:
-    - getoc
-    - cache
-
 - name: "Download stable client"
   vars:
     ocp_stable_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
   ansible.builtin.unarchive:
-    src: "{{ ocp_stable_url }}/stable/openshift-client-linux-amd64-rhel{{ ansible_distribution_major_version }}.tar.gz"
+    src: "{{ ocp_stable_url }}/stable/openshift-client-linux-amd64-rhel{{ si_cache_server_major_version }}.tar.gz"
     dest: "{{ sno_tmp_dir.path }}"
     remote_src: true
     mode: "0755"
@@ -171,8 +154,8 @@
   ansible.builtin.unarchive:
     src: "{{ si_cache_dir }}/{{ version }}/{{ sno_installer_oc_installer_prefix }}-{{ version }}.tar.gz"
     dest: "{{ si_cache_dir }}/{{ version }}"
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_gid }}"
+    owner: "{{ si_cache_server_user_id }}"
+    group: "{{ si_cache_server_user_gid }}"
     mode: "0755"
     remote_src: true
     exclude:
@@ -191,11 +174,19 @@
 # If the registry host got the oc tools, lets just copy it to the prov host
 - name: "Copy the openshift client tools from control machine to the provisioner host"
   when:
-    - not cache_provisioner | bool
+    - si_cache_server != groups['provisioner'][0]
   tags:
     - getoc
     - cache
   block:
+    - name: "Check that the provision host cluster configs directory exists"
+      ansible.builtin.file:
+        path: "{{ dir }}"
+        state: directory
+        owner: "{{ ansible_user_id }}"
+        group: "{{ ansible_user_gid }}"
+        mode: "0755"
+
     - name: "Get the openshift client tools from registry host into temp file on control machine"
       ansible.builtin.fetch:
         dest: "{{ _si_tmp_dir.path }}/"
@@ -204,7 +195,7 @@
       loop:
         - kubectl
         - oc
-      delegate_to: "{{ groups['registry_host'][0] }}"
+      delegate_to: "{{ si_cache_server }}"
 
     - name: "Copy the openshift client tools from control machine to the provisioner host"
       ansible.builtin.copy:
@@ -250,7 +241,7 @@
   become: true
   loop: "{{ files | product(dest) | list }}"
   when:
-    - cache_provisioner | bool
+    - si_cache_server == groups['provisioner'][0]
   tags:
     - getoc
     - cache

--- a/roles/sno_installer/tasks/10_get_oc.yml
+++ b/roles/sno_installer/tasks/10_get_oc.yml
@@ -22,30 +22,31 @@
 
 - name: "Set fact with the host providing the webserver"
   ansible.builtin.set_fact:
-    cache_server: "{{ cache_provisioner | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
+    si_cache_server: "{{ cache_provisioner | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
+  when: si_cache_server is undefined
   tags:
     - getoc
     - cache
 
 - name: "Validate that master cache directory exists"
   ansible.builtin.stat:
-    path: "{{ cache_dir }}"
+    path: "{{ si_cache_dir }}"
     get_checksum: false
   register: cachedir
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   tags:
     - getoc
     - cache
 
 - name: "Create master cache directory"
   ansible.builtin.file:
-    path: "{{ cache_dir }}"
+    path: "{{ si_cache_dir }}"
     state: directory
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
     mode: "0755"
   become: true
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   when:
     - not cachedir.stat.exists | bool
   tags:
@@ -54,23 +55,23 @@
 
 - name: "Validate if cache dir for release exists"
   ansible.builtin.stat:
-    path: "{{ cache_dir }}/{{ version }}"
+    path: "{{ si_cache_dir }}/{{ version }}"
     get_checksum: false
   register: cachedir_rel
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   tags:
     - getoc
     - cache
 
 - name: "Create cache directory for release"
   ansible.builtin.file:
-    path: "{{ cache_dir }}/{{ version }}"
+    path: "{{ si_cache_dir }}/{{ version }}"
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
     mode: "0755"
     state: directory
   become: true
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   when:
     - not cachedir_rel.stat.exists | bool
   tags:
@@ -79,10 +80,10 @@
 
 - name: "Check if release.txt exists"
   ansible.builtin.stat:
-    path: "{{ cache_dir }}/{{ version }}/release.txt"
+    path: "{{ si_cache_dir }}/{{ version }}/release.txt"
     get_checksum: false
   register: release_txt
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   tags:
     - getoc
     - cache
@@ -92,7 +93,7 @@
     state: directory
     prefix: sno_oc.
   register: sno_tmp_dir
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   tags:
     - getoc
     - cache
@@ -109,7 +110,7 @@
   retries: 3
   delay: 10
   until: result is not failed
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   tags:
     - getoc
     - cache
@@ -121,8 +122,8 @@
       --registry-config {{ pullsecret_file }}
       --tools
       --from {{ pull_url }}
-      --to "{{ cache_dir }}/{{ version }}"
-  delegate_to: "{{ cache_server }}"
+      --to "{{ si_cache_dir }}/{{ version }}"
+  delegate_to: "{{ si_cache_server }}"
   tags:
     - getoc
     - cache
@@ -131,7 +132,7 @@
   ansible.builtin.file:
     path: "{{ sno_tmp_dir.path }}"
     state: absent
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   tags:
     - getoc
     - cache
@@ -149,18 +150,18 @@
 
 - name: "Check if clients exists"
   ansible.builtin.stat:
-    path: "{{ cache_dir }}/{{ version }}/client_tools.done"
+    path: "{{ si_cache_dir }}/{{ version }}/client_tools.done"
     get_checksum: false
   register: client_tools_done
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   tags:
     - getoc
     - cache
 
 - name: "Unarchive client tarball"
   ansible.builtin.unarchive:
-    src: "{{ cache_dir }}/{{ version }}/{{ sno_installer_oc_installer_prefix }}-{{ version }}.tar.gz"
-    dest: "{{ cache_dir }}/{{ version }}"
+    src: "{{ si_cache_dir }}/{{ version }}/{{ sno_installer_oc_installer_prefix }}-{{ version }}.tar.gz"
+    dest: "{{ si_cache_dir }}/{{ version }}"
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
     mode: "0755"
@@ -171,7 +172,7 @@
   retries: 3
   delay: 10
   until: result is not failed
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   when:
     - not client_tools_done.stat.exists or force_mirroring
   tags:
@@ -190,7 +191,7 @@
       ansible.builtin.fetch:
         dest: "{{ _si_tmp_dir.path }}/"
         flat: true
-        src: "{{ cache_dir }}/{{ version }}/{{ item }}"
+        src: "{{ si_cache_dir }}/{{ version }}/{{ item }}"
       loop:
         - kubectl
         - oc
@@ -231,7 +232,7 @@
       - "{{ ocp_binary_path }}"
       - "{{ dir }}"
   ansible.builtin.copy:
-    src: "{{ cache_dir }}/{{ version }}/{{ item[0] }}"
+    src: "{{ si_cache_dir }}/{{ version }}/{{ item[0] }}"
     dest: "{{ item[1] }}/{{ item[0] }}"
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
@@ -247,10 +248,10 @@
 
 - name: "Marker for client tools downloaded"
   ansible.builtin.file:
-    dest: "{{ cache_dir }}/{{ version }}/client_tools.done"
+    dest: "{{ si_cache_dir }}/{{ version }}/client_tools.done"
     state: touch
     mode: "0644"
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   when:
     - not client_tools_done.stat.exists or force_mirroring
   tags:

--- a/roles/sno_installer/tasks/20_extract_installer.yml
+++ b/roles/sno_installer/tasks/20_extract_installer.yml
@@ -43,14 +43,14 @@
     remote_src: true
   become: true
   when:
-    - cache_provisioner | bool
+    - si_cache_server == groups['provisioner'][0]
   tags:
     - extract
 
 # If the registry host got the installer, lets just copy it to the prov host
 - name: "Copy PullSecret and extract/copy openshit installer in disconnected mode"
   when:
-    - not cache_provisioner | bool
+    - si_cache_server != groups['provisioner'][0]
   tags:
     - extract
   block:
@@ -59,7 +59,7 @@
         dest: "{{ _si_tmp_dir.path }}/"
         flat: true
         src: "{{ si_cache_dir }}/{{ version }}/openshift-install"
-      delegate_to: "{{ groups['registry_host'][0] }}"
+      delegate_to: "{{ si_cache_server }}"
 
     - name: "Copy the openshift installer from control machine to the provisioner host"
       ansible.builtin.copy:

--- a/roles/sno_installer/tasks/20_extract_installer.yml
+++ b/roles/sno_installer/tasks/20_extract_installer.yml
@@ -10,23 +10,23 @@
 
 - name: "Check if commands were extracted"
   ansible.builtin.stat:
-    path: "{{ cache_dir }}/{{ version }}/openshift-install"
+    path: "{{ si_cache_dir }}/{{ version }}/openshift-install"
     get_checksum: false
   register: extracted_cmd
-  delegate_to: "{{ cache_server }}" # This fact was defined in 10_get_oc.yml
+  delegate_to: "{{ si_cache_server }}" # This fact was defined in 10_get_oc.yml
   tags: extract
 
 - name: "Unarchive installer tarball"
   ansible.builtin.unarchive:
-    src: "{{ cache_dir }}/{{ version }}/openshift-install-linux-{{ version }}.tar.gz"
-    dest: "{{ cache_dir }}/{{ version }}"
+    src: "{{ si_cache_dir }}/{{ version }}/openshift-install-linux-{{ version }}.tar.gz"
+    dest: "{{ si_cache_dir }}/{{ version }}"
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
     mode: "0755"
     remote_src: true
     exclude:
       - README.md
-  delegate_to: "{{ cache_server }}"
+  delegate_to: "{{ si_cache_server }}"
   when:
     - not extracted_cmd.stat.exists
   tags:
@@ -35,7 +35,7 @@
 # If the provisioner host got the installer, lets just copy it to /usr/local/bin
 - name: "Copy openshift-install binary to binary path"
   ansible.builtin.copy:
-    src: "{{ cache_dir }}/{{ version }}/openshift-install"
+    src: "{{ si_cache_dir }}/{{ version }}/openshift-install"
     dest: "{{ ocp_binary_path }}/openshift-install"
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
@@ -58,7 +58,7 @@
       ansible.builtin.fetch:
         dest: "{{ _si_tmp_dir.path }}/"
         flat: true
-        src: "{{ cache_dir }}/{{ version }}/openshift-install"
+        src: "{{ si_cache_dir }}/{{ version }}/openshift-install"
       delegate_to: "{{ groups['registry_host'][0] }}"
 
     - name: "Copy the openshift installer from control machine to the provisioner host"

--- a/roles/sno_installer/tasks/21_rhcos_image_paths.yml
+++ b/roles/sno_installer/tasks/21_rhcos_image_paths.yml
@@ -1,24 +1,24 @@
 ---
 - name: "Check if rhcos.json exists"
   ansible.builtin.stat:
-    path: "{{ cache_dir }}/{{ version }}/rhcos.json"
+    path: "{{ si_cache_dir }}/{{ version }}/rhcos.json"
     get_checksum: false
   register: rhcos_json
-  delegate_to: "{{ cache_server }}" # This fact was defined in 10_get_oc.yml
+  delegate_to: "{{ si_cache_server }}" # This fact was defined in 10_get_oc.yml
   tags: rhcospath
 
 - name: "Fetch rhcos.json File"
   ansible.builtin.shell: >
     set -o pipefail &&
-    {{ cache_dir }}/{{ version }}/openshift-install coreos print-stream-json |
-    tee {{ cache_dir }}/{{ version }}/rhcos.json
+    {{ si_cache_dir }}/{{ version }}/openshift-install coreos print-stream-json |
+    tee {{ si_cache_dir }}/{{ version }}/rhcos.json
   register: rhcos_json_file
   retries: 3
   delay: 10
   until: rhcos_json_file is not failed
   changed_when: false
   no_log: true
-  delegate_to: "{{ cache_server }}" # This fact was defined in 10_get_oc.yml
+  delegate_to: "{{ si_cache_server }}" # This fact was defined in 10_get_oc.yml
   when:
     - not rhcos_json.stat.exists or force_mirroring
   tags: rhcospath
@@ -27,8 +27,8 @@
   ansible.builtin.fetch:
     dest: "{{ _si_tmp_dir.path }}/"
     flat: true
-    src: "{{ cache_dir }}/{{ version }}/rhcos.json"
-  delegate_to: "{{ cache_server }}"
+    src: "{{ si_cache_dir }}/{{ version }}/rhcos.json"
+  delegate_to: "{{ si_cache_server }}"
 
 - name: "Load variables from rhcos.json"
   ansible.builtin.include_vars:

--- a/roles/sno_installer/tasks/22_rhcos_image_cache.yml
+++ b/roles/sno_installer/tasks/22_rhcos_image_cache.yml
@@ -4,24 +4,24 @@
 # 2. Access to www.redhat.com has been confirmed
 
 # SELinux when already has httpd_sys_content_t giving issues changing,thus
-# leaving it the same for the provision_cache_store to prevent issues. Also
-# removing ":z" from podman_container for provision_cache_store in the later
+# leaving it the same for the si_cache_dir to prevent issues. Also
+# removing ":z" from podman_container for si_cache_dir in the later
 # task.
 - name: "Create provision cache store on host with online access"
   ansible.builtin.file:
     path: "{{ item[0] }}"
     state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
+    owner: "{{ si_cache_server_user_id }}"
+    group: "{{ si_cache_server_user_gid }}"
     setype: "{{ item[1] }}"
     mode: '755'
   with_nested:
-    - ["{{ provision_cache_store }}"]
+    - ["{{ si_cache_dir }}"]
     - ['httpd_sys_content_t']
   tags: cache
 
 # Leaving SELinux details alone and not using ":z"
-# for the provision_cache_store due to issues attempting
+# for the si_cache_dir due to issues attempting
 # to revert context. Leaving behavior as it was previously
 # to avoid breaking other user environments.
 - name: "Start RHCOS image cache container"
@@ -32,7 +32,7 @@
     publish:
       - "{{ webserver_caching_port_container }}:8080"
     volumes:
-      - "{{ provision_cache_store }}:/var/www/html"
+      - "{{ si_cache_dir }}:/var/www/html"
   register: rhcos_image_cache_info
   tags: cache
 
@@ -47,14 +47,14 @@
   block:
     - name: "Ensure user specific systemd instance are persistent"
       ansible.builtin.command: |
-        /usr/bin/loginctl enable-linger {{ ansible_user }}
+        /usr/bin/loginctl enable-linger {{ si_cache_server_user_id }}
 
     - name: "Create systemd user directory"
       ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/.config/systemd/user"
+        path: "{{ si_cache_server_user_dir }}/.config/systemd/user"
         state: directory
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
+        owner: "{{ si_cache_server_user_id }}"
+        group: "{{ si_cache_server_user_gid }}"
         mode: '0775'
 
     - name: "Copy the systemd service file"
@@ -71,9 +71,9 @@
           PIDFile={{ rhcos_image_cache_pidfile }}
           [Install]
           WantedBy=default.target
-        dest: "{{ ansible_user_dir }}/.config/systemd/user/container-cache.service"
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
+        dest: "{{ si_cache_server_user_dir }}/.config/systemd/user/container-cache.service"
+        owner: "{{ si_cache_server_user_id }}"
+        group: "{{ si_cache_server_user_gid }}"
         mode: '0644'
 
     - name: "Reload systemd service"

--- a/roles/sno_installer/tasks/23_rhcos_image_pxetftp.yml
+++ b/roles/sno_installer/tasks/23_rhcos_image_pxetftp.yml
@@ -98,7 +98,7 @@
     - name: "Download PXE rootfs for cache"
       ansible.builtin.get_url:
         url: "{{ rhcos_pxe_rootfs_url }}"
-        dest: "{{ provision_cache_store }}/{{ rhcos_pxe_rootfs_name }}"
+        dest: "{{ si_cache_dir }}/{{ rhcos_pxe_rootfs_name }}"
         mode: '0644'
         setype: httpd_sys_content_t
         checksum: "sha256:{{ rhcos_pxe_rootfs_sha256 }}"

--- a/roles/sno_installer/tasks/23_rhcos_image_pxetftp.yml
+++ b/roles/sno_installer/tasks/23_rhcos_image_pxetftp.yml
@@ -84,11 +84,11 @@
       tags: rhcospxe
 
 - name: "Setting rootfs image on cache server"
-  delegate_to: "{{ cache_server }}" # This fact was defined in 10_get_oc.yml
+  delegate_to: "{{ si_cache_server }}" # This fact was defined in 10_get_oc.yml
   block:
     - name: "Check if rootfs image exists"
       ansible.builtin.stat:
-        path: "{{ cache_dir }}/{{ rhcos_pxe_rootfs_name }}"
+        path: "{{ si_cache_dir }}/{{ rhcos_pxe_rootfs_name }}"
         get_checksum: false
       register: rootfs_img
       tags:
@@ -132,7 +132,7 @@
 
 - name: "Set rootfs image URL override if not provided by the user"
   ansible.builtin.set_fact:
-    coreos_pxe_rootfs_url: "http://{{ cache_server }}:{{ webserver_caching_port }}/{{ rhcos_pxe_rootfs_name }}"
+    coreos_pxe_rootfs_url: "http://{{ si_cache_server }}:{{ webserver_caching_port }}/{{ rhcos_pxe_rootfs_name }}"
   when: coreos_pxe_rootfs_url is not defined or coreos_pxe_rootfs_url|length < 1
   tags:
     - cache

--- a/roles/sno_installer/tasks/24_rhcos_image_live.yml
+++ b/roles/sno_installer/tasks/24_rhcos_image_live.yml
@@ -12,7 +12,7 @@
 
 - name: "Check if LIVE image exists"
   ansible.builtin.stat:
-    path: "{{ cache_dir }}/{{ rhcos_live_iso_name }}"
+    path: "{{ si_cache_dir }}/{{ rhcos_live_iso_name }}"
     get_checksum: false
   register: live_img
   tags: rhcos_live
@@ -20,7 +20,7 @@
 - name: "Download LIVE image"
   ansible.builtin.get_url:
     url: "{{ rhcos_path }}"
-    dest: "{{ cache_dir }}/{{ rhcos_live_iso_name }}"
+    dest: "{{ si_cache_dir }}/{{ rhcos_live_iso_name }}"
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
     mode: "0644"
@@ -37,14 +37,14 @@
 
 - name: "Set a public SELinux context"
   ansible.builtin.file:
-    path: "{{ cache_dir }}/{{ rhcos_live_iso_name }}"
+    path: "{{ si_cache_dir }}/{{ rhcos_live_iso_name }}"
     setype: "public_content_t"
   become: true
   tags: rhcos_live
 
 - name: "Apply new SELinux file context"
   ansible.builtin.command: >
-    /usr/sbin/restorecon -R "{{ cache_dir }}/{{ rhcos_live_iso_name }}"
+    /usr/sbin/restorecon -R "{{ si_cache_dir }}/{{ rhcos_live_iso_name }}"
   become: true
   tags: rhcos_live
 ...

--- a/roles/sno_installer/tasks/55_create_ignition.yml
+++ b/roles/sno_installer/tasks/55_create_ignition.yml
@@ -13,7 +13,7 @@
 
 - name: "Extra tasks to get ignition file for baremetal SNO in disconnected mode"
   when:
-    - not cache_provisioner | bool
+    - si_cache_server != groups['provisioner'][0]
     - sno_install_type is defined
     - sno_install_type == "baremetal"
   tags:
@@ -36,7 +36,7 @@
 
 - name: "Extra tasks to get ignition file for baremetal SNO"
   when:
-    - cache_provisioner | bool
+    - si_cache_server == groups['provisioner'][0]
     - sno_install_type is defined
     - sno_install_type == "baremetal"
   tags:

--- a/roles/sno_installer/tasks/55_create_ignition.yml
+++ b/roles/sno_installer/tasks/55_create_ignition.yml
@@ -9,7 +9,7 @@
 
 - name: "Set coreos sno ignition facts"
   ansible.builtin.set_fact:
-    coreos_sno_ignition: "{{ cache_dir }}/{{ cluster }}.ign"
+    coreos_sno_ignition: "{{ si_cache_dir }}/{{ cluster }}.ign"
 
 - name: "Extra tasks to get ignition file for baremetal SNO in disconnected mode"
   when:
@@ -56,7 +56,7 @@
 
 - name: "Set coreos_sno_ignition_url fact"
   ansible.builtin.set_fact:
-    coreos_sno_ignition_url: "http://{{ cache_server }}:{{ webserver_caching_port }}/{{ cluster }}.ign"
+    coreos_sno_ignition_url: "http://{{ si_cache_server }}:{{ webserver_caching_port }}/{{ cluster }}.ign"
   when:
     - (coreos_sno_ignition_url is not defined or coreos_sno_ignition_url|length < 1)
     - sno_install_type is defined

--- a/roles/sno_installer/tasks/57_embed_ignition_into_iso.yml
+++ b/roles/sno_installer/tasks/57_embed_ignition_into_iso.yml
@@ -8,7 +8,7 @@
       --rm
       -v /dev:/dev
       -v /run/udev:/run/udev
-      -v "{{ cache_dir }}:/iso_input"
+      -v "{{ si_cache_dir }}:/iso_input"
       -v "{{ dir }}:/data"
       --workdir /data
       quay.io/coreos/coreos-installer:release

--- a/roles/sno_installer/tasks/main.yml
+++ b/roles/sno_installer/tasks/main.yml
@@ -35,7 +35,7 @@
   tags: rhcospath
 
 - name: Setup RHCOS image cache
-  delegate_to: "{{ cache_server }}"  # This fact was defined in 10_get_oc.yml
+  delegate_to: "{{ si_cache_server }}"  # This fact was defined in 10_get_oc.yml
   when:
     - sno_install_type is defined
     - sno_install_type == "baremetal"

--- a/roles/sno_installer/vars/main.yml
+++ b/roles/sno_installer/vars/main.yml
@@ -4,3 +4,5 @@ pullsecret_file: "{{ si_cache_dir }}/pull-secret.txt"
 default_libvirt_pool_dir: "/var/lib/libvirt/images"
 force_mirroring: false
 ocp_binary_path: "/usr/local/bin"
+
+snp_cache_dir: "{{ si_cache_dir }}"

--- a/roles/sno_installer/vars/main.yml
+++ b/roles/sno_installer/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 # vars file for sno_installer
-cache_dir: "/opt/cache"
-pullsecret_file: "{{ cache_dir }}/pull-secret.txt"
+pullsecret_file: "{{ si_cache_dir }}/pull-secret.txt"
 default_libvirt_pool_dir: "/var/lib/libvirt/images"
 force_mirroring: false
 ocp_binary_path: "/usr/local/bin"

--- a/roles/sno_node_prep/tasks/10_validation.yml
+++ b/roles/sno_node_prep/tasks/10_validation.yml
@@ -161,7 +161,7 @@
 
 - name: "Ensure cache_dir is created"
   ansible.builtin.file:
-    path: "{{ cache_dir }}"
+    path: "{{ snp_cache_dir }}"
     state: directory
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"

--- a/roles/sno_node_prep/vars/main.yml
+++ b/roles/sno_node_prep/vars/main.yml
@@ -25,4 +25,4 @@ snobm_pkg_list:
   - shim-x64
   - dnsmasq
 
-pullsecret_file: "{{ cache_dir }}/pull-secret.txt"
+pullsecret_file: "{{ snp_cache_dir }}/pull-secret.txt"


### PR DESCRIPTION
##### SUMMARY
The SNO Installer role delegates the OCP installation artifacts to the host set in the cache_server variable.

The role either sets this variable to the provision host, if the environment is connected, or to a host identified as the registry_host in the inventory in case of disconnected networks.

This change allows to provide the role with an explicitly identified cache server, even in connected environments, in order to save resources by sharing the cache server between different deployment types.

##### ISSUE TYPE

- Enhanced feature

##### Tests

TestBos2Sno: sno

