### PR TITLE
Create admin user in oc_setup role

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.20.EPOCH
+Version:        0.21.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -51,6 +51,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Fri Sep 27 2024 Tony Garcia <tonyg@redhat.com> - 0.21.EPOCH-VERS
+- Version bump for ocp_setup role updates
+
 * Thu Sep 12 2024 Manuel Rodriguez <manrodri@redhat.com> - 0.20.EPOCH-VERS
 - Version bump for installer and node_prep roles updates
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.20.0
+version: 0.21.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/oc_setup/README.md
+++ b/roles/oc_setup/README.md
@@ -1,6 +1,8 @@
 # oc_setup role
 
-This role allows the setup of additional credentials for a running OCP cluster. It configures the htpasswd identity provider to allow users to log in to OpenShift Container Platform with credentials from an htpasswd file.
+This role allows the setup of additional credentials for a running OCP cluster.
+It configures the htpasswd identity provider to allow users to log in to OpenShift Container Platform with credentials from an htpasswd file.
+It creates three accounts with different role each: `nonadmin`, `admin`, and `cluster_admin`.
 
 ## Variables
 
@@ -13,10 +15,11 @@ This role allows the setup of additional credentials for a running OCP cluster. 
 
 Access to a valid kubeconfig file via an `KUBECONFIG` environment variable.
 
-```shell
-export KUBECONFIG=<path_kubeconfig>
+```Shell
+export KUBECONFIG=<kubeconfig_path>
 ```
+
 # Role Outputs
 
-A file with the created accounts is saved in the `os_config_dir` directory as ocp_cred.txt
+A file with the created accounts is saved in the `os_config_dir` directory as `ocp_cred.txt`.
 

--- a/roles/oc_setup/tasks/main.yml
+++ b/roles/oc_setup/tasks/main.yml
@@ -9,18 +9,23 @@
     msg: "Configs directory does not exist"
   when: not path_check.stat.exists
 
-- name: "Generate Random passwords for users htpasswd IdP"
-  ansible.builtin.set_fact:
+- name: Generate Random passwords for users htpasswd IdP
+  ansible.builtin.set_fact: # noqa: redhat-ci[no-role-prefix]
     admin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
+    cluster_admin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
     nonadmin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
 
 - name: "Save passwords to the cluster configs directory"
   ansible.builtin.copy:
-    content: "OCP automatically generated credentials for the API/GUI\nadmin:{{ admin_pass }} \nnonadmin:{{ nonadmin_pass }}\n"
+    content: |
+      OCP automatically generated credentials for the API/GUI
+      admin:{{ admin_pass }}
+      cluster_admin:{{ cluster_admin_pass }}
+      nonadmin:{{ nonadmin_pass }}
     dest: "{{ os_config_dir }}/ocp_creds.txt"
     mode: '0640'
 
-- name: "Create http auth file"
+- name: Create http auth file
   ansible.builtin.htpasswd:
     path: "{{ os_config_dir }}/users.htpasswd"
     name: "{{ item.user }}"
@@ -29,6 +34,8 @@
   loop:
     - user: admin
       password: "{{ admin_pass }}"
+    - user: cluster_admin
+      password: "{{ cluster_admin_pass }}"
     - user: nonadmin
       password: "{{ nonadmin_pass }}"
 
@@ -67,7 +74,7 @@
               fileData:
                 name: htpass-secret
 
-- name: "Grant cluster-admin permissions to admin user"
+- name: Grant cluster-admin permissions to cluster_admin user
   community.kubernetes.k8s:
     state: present
     definition:
@@ -79,6 +86,22 @@
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: cluster-admin
+      subjects:
+        - kind: User
+          name: "cluster_admin"
+
+- name: Grant admin permissions to admin user
+  community.kubernetes.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: admin-0
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: admin
       subjects:
         - kind: User
           name: "admin"


### PR DESCRIPTION
##### SUMMARY

The previous admin user in the oc_setup rule was created with a cluster-admin role. Because there is an admin role, we are now creating three users: admin, cluster_admin, nonadmin.

nonadmin remains without change, this user has no role associated, so nothing can be done with it, other than authenticate.

cluster_admin, is a new user and is now assigned the cluster-admin role, previoulsy this was the role assigned to the admin user.

admin, this user now has the admin role, it has less priviledges as before when it had cluster-admin role.

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

- [x] TestBos2Sno - https://www.distributed-ci.io/jobs/9f175cc8-ae49-4b57-a5e7-b31058b482a8

---

Test-Hints: no-check
