### PR TITLE
Add more space to image service

### DIFF
--- a/roles/acm_setup/defaults/main.yml
+++ b/roles/acm_setup/defaults/main.yml
@@ -8,6 +8,6 @@ hub_hugepages_type: hugepages-2Mi
 hub_hugepages_size: 1024Mi
 hub_db_volume_size: 40Gi
 hub_fs_volume_size: 50Gi
-hub_img_volume_size: 40Gi
+hub_img_volume_size: 80Gi
 hub_vm_external_network: true
 ...


### PR DESCRIPTION
##### SUMMARY

More space to the images-service pod. The current 40GB set as default is not enough to allow all live ISOs to be saved.

##### ISSUE TYPE

- Fix

##### Tests

- [x] TestBos2 - https://www.distributed-ci.io/jobs/f78166fb-1c09-4538-8def-249a8be1ffd0/jobStates?sort=date

Test-Hints: no-check
