### PR TITLE
expand oc_setup role to set MC with SSH pub keys

### DIFF
--- a/roles/oc_setup/README.md
+++ b/roles/oc_setup/README.md
@@ -3,17 +3,20 @@
 This role allows the setup of additional credentials for a running OCP cluster.
 It configures the htpasswd identity provider to allow users to log in to OpenShift Container Platform with credentials from an htpasswd file.
 It creates three accounts with different role each: `nonadmin`, `admin`, and `cluster_admin`.
+It also allows to set SSH Public Keys at day2 to SSH the cluster nodes.
 
 ## Variables
 
-| Variable                             | Default                     | Required  | Description                                   |
-| ------------------------------------ | --------------------------- | --------- | --------------------------------------------- |
-| os_config_dir                        | undefined                   | Yes       | Directory where the credentials will be saved |
+| Variable                             | Default                     | Required  | Description                                                             |
+| ------------------------------------ | --------------------------- | --------- | ----------------------------------------------------------------------- |
+| os_config_dir                        | undefined                   | Yes       | Directory where the credentials will be saved                           |
+| oc_ssh_extra_keys_paths              | undefined                   | No        | List of paths where SSH keys are located in the ansible controller node |
 
 
 ## Requirements
 
-Access to a valid kubeconfig file via an `KUBECONFIG` environment variable.
+- Access to a valid kubeconfig file via an `KUBECONFIG` environment variable.
+- `check_resource` role from ansible-collection-redhatci-ocp.
 
 ```Shell
 export KUBECONFIG=<kubeconfig_path>
@@ -23,3 +26,11 @@ export KUBECONFIG=<kubeconfig_path>
 
 A file with the created accounts is saved in the `os_config_dir` directory as `ocp_cred.txt`.
 
+
+# Example of how to pass SSH public Keys
+
+```Shell
+oc_ssh_extra_keys_paths:
+  - ~/.ssh/id_rsa.pub
+  - ~/.ssh/id_ed25519.pub
+```

--- a/roles/oc_setup/tasks/main.yml
+++ b/roles/oc_setup/tasks/main.yml
@@ -105,4 +105,52 @@
       subjects:
         - kind: User
           name: "admin"
+
+- name: Add SSH keys to cluster nodes at day2
+  when:
+    - oc_ssh_extra_keys_paths is defined
+    - oc_ssh_extra_keys_paths | length > 0
+  block:
+    - name: Check if SSH keys exist
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      loop: "{{ oc_ssh_extra_keys_paths }}"
+      register: _os_ssh_path
+
+    - name: "Fail if any ssh path does not exist"
+      ansible.builtin.fail:
+        msg: "SSH public key {{ key.item }} file does not exist"
+      when: not key.stat.exists
+      loop: "{{ _os_ssh_path.results }}"
+      loop_control:
+        loop_var: key
+        label: "{{ key.item }}"
+
+    - name: Set SSH Keys manifests in master group
+      vars:
+        os_role: master
+      community.kubernetes.k8s:
+        state: present
+        definition: "{{ lookup('template', '99_ssh_mc.yml.j2') }}"
+
+    - name: Set SSH Keys manifests in worker group
+      vars:
+        os_role: worker
+      community.kubernetes.k8s:
+        state: present
+        definition: "{{ lookup('template', '99_ssh_mc.yml.j2') }}"
+
+    - name: Pause 60 seconds to wait for MC triggered by SSH pub key config
+      ansible.builtin.pause:
+        seconds: 60
+      no_log: true
+
+    - name: Wait for MCP status
+      ansible.builtin.include_role:
+        name: redhatci.ocp.check_resource
+      vars:
+        resource_to_check: "MachineConfigPool" # noqa: redhat-ci[no-role-prefix]
+        check_wait_retries: 10 # noqa: redhat-ci[no-role-prefix]
+        check_wait_delay: 30 # noqa: redhat-ci[no-role-prefix]
+        check_reason: "SSH Key updates" # noqa: redhat-ci[no-role-prefix]
 ...

--- a/roles/oc_setup/templates/99_ssh_mc.yml.j2
+++ b/roles/oc_setup/templates/99_ssh_mc.yml.j2
@@ -1,0 +1,22 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: {{ os_role }}
+  name: 99-{{ os_role }}-ssh
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    passwd:
+      users:
+      - name: core
+        sshAuthorizedKeys:
+  {% for ssh_key_path in oc_ssh_extra_keys_paths %}
+      - '{{ lookup('file', ssh_key_path ) }}'
+  {% endfor %}
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: ""
+  osImageURL: ""


### PR DESCRIPTION
##### SUMMARY
This will allow to specify multiple SSH key paths
to be applied at day2 and SSH can be performed
from multiple sources.

##### ISSUE TYPE

- Enhanced Feature in an existing role

##### Tests

- [] TestDallas - <JobID>
- [] TestBos2: - <JobID>


TestBos2: virt