### PR TITLE
use SCSI bus device id rather than sdX to discover OCS disks

### DIFF
--- a/roles/ocp_on_libvirt/templates/hosts.j2
+++ b/roles/ocp_on_libvirt/templates/hosts.j2
@@ -25,7 +25,7 @@ externalMACAddress={{ externalMACAddress }}
 
 {% if enable_lso | default(false) | bool %}
 ocs_install_type=internal
-local_storage_devices=["/dev/sdb"]
+local_storage_devices=["scsi0-0-0-1"]
 
 [ocs_nodes:children]
 workers

--- a/roles/odf_setup/README.md
+++ b/roles/odf_setup/README.md
@@ -27,7 +27,7 @@ Role Variables
 | default_storageclass_annotation  | '{"storageclass.kubernetes.io/is-default-class": "true"}'  | String       | No          | Default storageclass annotation             |
 | external_ceph_data               |                               | JSON         | No          | A JSON payload generated from RHCS                                       |
 | ocs_install_type                 |                               | String       | Yes         | `internal` for LSO, `external` for Ceph/RHCS                             |
-| local_storage_devices            |                               | List         | Yes          | For LSO, a list of local devices that will be use as backend             |
+| local_storage_devices            |                               | List         | Yes         | For LSO, a list of local devices that will be use as backend             |
 | ocs_default_storage_class        | storagecluster-cephfs         | String       | No          | Default storage class name                                               |
 | gatherer_image                   | registry.access.redhat.com/ubi8/ubi | String | No          | Image for disk-gatherer deployment                                       |
 | odf_setup_oc_tool_path                   | '/usr/local/bin/oc` | String | No          | Path to the OpenShift Command Line Interface binary.
@@ -47,7 +47,9 @@ external_ceph_data='JSON_PAYLOAD'
 
 # When enable_lso=true, list of disk devices per node to use for LSO
 # Comma separated, all servers must have the same
-local_storage_devices=["/dev/sdX", "/dev/sdY", "/dev/sdZ"]
+# RHCOS (RHEL 9.x) detects the disk devices in an asynchronous manner.  One can no longer rely on /dev/sd* since they are not guaranteed to persist across reboots.
+# The most reliable for physical and logical devices is the HCTL Device ID
+local_storage_devices=["scsi0-0-0-1", "scsi0-0-0-2", "scsi0-2-1-0"]
 
 # (Optional) Default storage class name
 ocs_default_storage_class=ocs-storagecluster-cephfs
@@ -79,7 +81,7 @@ File: /etc/dci-openshift-agent/hosts
 [all:vars]
 ...
 ocs_install_type=internal
-local_storage_devices=["/dev/sdb", "/dev/sdc", "/dev/sdd"]
+local_storage_devices=["scsi0-0-0-1", "scsi0-0-0-2", "scsi0-2-1-0"]
 
 [ocs_nodes:children]
 workers

--- a/roles/odf_setup/templates/ocs-disk-gatherer.yml.j2
+++ b/roles/odf_setup/templates/ocs-disk-gatherer.yml.j2
@@ -81,11 +81,11 @@ spec:
           while true;
           do
 {% if local_storage_devices is defined and local_storage_devices | length != 0 %}
-          for disk in $(readlink -f $(ls -1 /dev/disk/by-id/* | egrep -v 'DVD|dm|ceph|luks|part|lvm') | grep '{% for dev in local_storage_devices%}{{ dev }}{% if not loop.last%}\|{% endif %}{% endfor %}' | sort|uniq); do
+          for disk in $(ls -1 /dev/disk/by-id/* | egrep -v 'DVD|dm|ceph|luks|part|lvm' | grep '{% for dev in local_storage_devices%}{{ dev }}{% if not loop.last%}\|{% endif %}{% endfor %}' | sort|uniq); do
 {% else %}
-          for disk in $(readlink -f $(ls -1 /dev/disk/by-id/* | egrep -v 'DVD|dm|ceph|luks|part|lvm') | sort|uniq); do
+          for disk in $(ls -1 /dev/disk/by-id/* | egrep -v 'DVD|dm|ceph|luks|part|lvm' | sort|uniq); do
 {% endif %}
-            DISKNAME=$(basename $disk)
+            DISKNAME=$(basename $disk);
             echo " - $(ls -l /dev/disk/by-id/*|grep "$DISKNAME" | head -n1 | awk '{print $9}')";
           done;
           sleep '600';


### PR DESCRIPTION
##### SUMMARY
RHCOS (RHEL 9.x) detects the disk devices in an asynchronous manner. One can no longer rely on /dev/sd* since they are not guaranteed to persist across reboots. Using the HCTL Device ID is more accurate.

##### ISSUE TYPE

Enhanced role disk detection capabilities

##### Tests

- [x] TestBos2 - https://www.distributed-ci.io/jobs/828c9ef7-521c-435d-a3dd-e89de001c528/jobStates


Test-Hint: no-check