### PR TITLE
Fix condition in git component

### DIFF
--- a/roles/include_components/tasks/track_git_repo.yml
+++ b/roles/include_components/tasks/track_git_repo.yml
@@ -21,6 +21,7 @@
   when:
     - _ic_search_git_component is defined
     - _ic_search_git_component is not changed
+    - last_commit_id.rc == 0
   block:
     - name: Create git repo component
       ansible.legacy.dci_component:


### PR DESCRIPTION
##### SUMMARY

Only attempt to create git components when a git repo has been detected

##### ISSUE TYPE

- Bug fix

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/423e2220-d7c0-41b8-9958-d9dffce76548
- [x] TestBos2Sno: sno - https://www.distributed-ci.io/jobs/bb740eb9-6681-4002-af0f-4cc7a0ee5ddc

---

Test-Hints: no-check