### PR TITLE
Bump certsuite to v5.3.6

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.3.5
+kbpc_version: v5.3.6
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
##### SUMMARY

Increasing default certsuite version to match latest release

##### ISSUE TYPE

- Nominal change

##### Tests

- [] TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[] - https://www.distributed-ci.io/jobs/4de78666-f5df-42d6-8e07-549c291e0121

---

Test-Hints: no-check