### PR TITLE
Add basic-user to oc_setup

### DIFF
--- a/roles/oc_setup/README.md
+++ b/roles/oc_setup/README.md
@@ -20,7 +20,9 @@ export KUBECONFIG=<kubeconfig_path>
 
 ## Users
 
-These are the users created and the roles associated to them. See [official documentation about the default roles](https://docs.openshift.com/container-platform/4.17/post_installation_configuration/preparing-for-users.html#default-roles_post-install-preparing-for-users)
+## Users
+
+These are the users created and the roles associated to them. See [official documentation about the default roles](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/postinstallation_configuration/post-install-preparing-for-users#default-roles_post-install-preparing-for-users)
 
 | Username      | Role          | Description
 | ------------- | ------------- | -----------

--- a/roles/oc_setup/README.md
+++ b/roles/oc_setup/README.md
@@ -2,14 +2,13 @@
 
 This role allows the setup of additional credentials for a running OCP cluster.
 It configures the htpasswd identity provider to allow users to log in to OpenShift Container Platform with credentials from an htpasswd file.
-It creates three accounts with different role each: `nonadmin`, `admin`, and `cluster_admin`.
+See the [Users](./#Users) for information about the users and its roles created.
 
 ## Variables
 
 | Variable                             | Default                     | Required  | Description                                   |
 | ------------------------------------ | --------------------------- | --------- | --------------------------------------------- |
 | os_config_dir                        | undefined                   | Yes       | Directory where the credentials will be saved |
-
 
 ## Requirements
 
@@ -18,6 +17,17 @@ Access to a valid kubeconfig file via an `KUBECONFIG` environment variable.
 ```Shell
 export KUBECONFIG=<kubeconfig_path>
 ```
+
+## Users
+
+These are the users created and the roles associated to them. See [official documentation about the default roles](https://docs.openshift.com/container-platform/4.17/post_installation_configuration/preparing-for-users.html#default-roles_post-install-preparing-for-users)
+
+| Username      | Role          | Description
+| ------------- | ------------- | -----------
+| admin         | admin         | A project manager. If used in a local binding, an admin has rights to view any resource in the project and modify any resource in the project except for quota.
+| basic_user    | basic-user    | A user that can get basic information about projects and users.
+| cluster_admin | cluster-admin | A super-user that can perform any action in any project. When bound to a user with a local binding, they have full control over quota and every action on every resource in the project.
+| nonadmin      | None          | A user without any role assigned.
 
 # Role Outputs
 

--- a/roles/oc_setup/tasks/main.yml
+++ b/roles/oc_setup/tasks/main.yml
@@ -86,7 +86,7 @@
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: "{{ user }}-0"
+        name: "{{ user | replace('_', '-') }}-0"
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole

--- a/roles/oc_setup/tasks/main.yml
+++ b/roles/oc_setup/tasks/main.yml
@@ -10,18 +10,20 @@
   when: not path_check.stat.exists
 
 - name: Generate Random passwords for users htpasswd IdP
-  ansible.builtin.set_fact: # noqa: redhat-ci[no-role-prefix]
-    admin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
-    cluster_admin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
-    nonadmin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
+  ansible.builtin.set_fact:
+    os_admin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
+    os_basic_user_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
+    os_cluster_admin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
+    os_nonadmin_pass: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits') }}"
 
 - name: "Save passwords to the cluster configs directory"
   ansible.builtin.copy:
     content: |
-      OCP automatically generated credentials for the API/GUI
-      admin:{{ admin_pass }}
-      cluster_admin:{{ cluster_admin_pass }}
-      nonadmin:{{ nonadmin_pass }}
+      # OCP automatically generated credentials for the API/GUI
+      admin:{{ os_admin_pass }}
+      basic_user:{{ os_basic_user_pass }}
+      cluster_admin:{{ os_cluster_admin_pass }}
+      nonadmin:{{ os_nonadmin_pass }}
     dest: "{{ os_config_dir }}/ocp_creds.txt"
     mode: '0640'
 
@@ -33,11 +35,13 @@
     mode: "0640"
   loop:
     - user: admin
-      password: "{{ admin_pass }}"
+      password: "{{ os_admin_pass }}"
+    - user: basic_user
+      password: "{{ os_basic_user_pass }}"
     - user: cluster_admin
-      password: "{{ cluster_admin_pass }}"
+      password: "{{ os_cluster_admin_pass }}"
     - user: nonadmin
-      password: "{{ nonadmin_pass }}"
+      password: "{{ os_nonadmin_pass }}"
 
 - name: "Encoding the password file"
   ansible.builtin.slurp:
@@ -55,6 +59,7 @@
       type: Opaque
       data:
         htpasswd: "{{ encoded_password.content }}"
+  no_log: true
 
 - name: "Setup htpasswd auth IDP backend in openshift"
   community.kubernetes.k8s:
@@ -74,37 +79,27 @@
               fileData:
                 name: htpass-secret
 
-- name: Grant cluster-admin permissions to cluster_admin user
+- name: Grant permissions to users
   community.kubernetes.k8s:
     state: present
     definition:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: cluster-admin-admin
+        name: "{{ user }}-0"
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: cluster-admin
+        name: "{{ user | replace('_', '-') }}"
       subjects:
         - kind: User
-          name: "cluster_admin"
-
-- name: Grant admin permissions to admin user
-  community.kubernetes.k8s:
-    state: present
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: admin-0
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: admin
-      subjects:
-        - kind: User
-          name: "admin"
+          name: "{{ user }}"
+  loop:
+    - "admin"
+    - "basic_user"
+    - "cluster_admin"
+  loop_control:
+    loop_var: user
 
 - name: Wait for MCP status  # noqa: redhat-ci[no-role-prefix]
   ansible.builtin.include_role:


### PR DESCRIPTION
##### SUMMARY

Include a 4th account using basic-user role.

##### ISSUE TYPE

- New Feature

##### Tests

- [x] TestBos2Sno: sno - https://www.distributed-ci.io/jobs/7f1aa833-6147-4b5e-99ef-35ea122761b9

---

Test-Hints: no-check