### PR TITLE
ACM - Apply mirroring config to the Agent Service Config

### DIFF
--- a/roles/acm_setup/tasks/get-mirroring-config.yml
+++ b/roles/acm_setup/tasks/get-mirroring-config.yml
@@ -1,20 +1,20 @@
 ---
-- name: "Get current worker's MCP"
+- name: "Get current master's MCP"
   community.kubernetes.k8s_info:
     api_version: machineconfiguration.openshift.io/v1
     kind: MachineConfigPool
-    name: worker
-  register: _acm_setup_worker_mcp
+    name: master
+  register: _acm_setup_master_mcp
   no_log: true
 
-- name: "Get current worker's Machine Configs"
+- name: "Get current master's Machine Configs"
   vars:
-    acm_mc: "{{ _acm_setup_worker_mcp.resources[0].spec.configuration.name }}"
+    acm_mc: "{{ _acm_setup_master_mcp.resources[0].spec.configuration.name }}"
   community.kubernetes.k8s_info:
     api_version: machineconfiguration.openshift.io/v1
     kind: MachineConfig
     name: "{{ acm_mc }}"
-  register: _acm_setup_worker_mc
+  register: _acm_setup_master_mc
   no_log: true
 
 - name: "Get cluster user-ca certificate"
@@ -29,8 +29,8 @@
 - name: "Create a Config map with registry entries and CA bundle"
   vars:
     acm_user_ca_bundle: '{{ _acm_setup_user_ca_bundle.resources[0].data["ca-bundle.crt"] }}'
-    registry_config: "{{ _acm_setup_worker_mc | json_query('resources[0].spec.config.storage.files[?path==`/etc/containers/registries.conf`].contents.source') |
-                  first | regex_replace('^data:.*;base64,', '') | b64decode }}"
+    registry_config: "{{ (_acm_setup_master_mc | json_query('resources[0].spec.config.storage.files[?path==`/etc/containers/registries.conf`].contents.source'))[0] |
+                      regex_replace('^data:.*;base64,', '') | b64decode }}"
     cm_def: |
       apiVersion: v1
       kind: ConfigMap

--- a/roles/acm_setup/tasks/get-mirroring-config.yml
+++ b/roles/acm_setup/tasks/get-mirroring-config.yml
@@ -7,7 +7,7 @@
   register: _acm_setup_master_mcp
   no_log: false
 
-- name: "Get current master's Machine Configs"
+- name: "Get current master's Machine Config"
   vars:
     acm_mc: "{{ _acm_setup_master_mcp.resources[0].spec.configuration.name }}"
   community.kubernetes.k8s_info:
@@ -16,6 +16,12 @@
     name: "{{ acm_mc }}"
   register: _acm_setup_master_mc
   no_log: false
+  until: >
+    _acm_setup_master_mc is defined
+    and _acm_setup_master_mc.resources is defined
+    and _acm_setup_master_mc.resources | length == 1
+  retries: 10
+  delay: 15
 
 - name: "Get cluster user-ca certificate"
   community.kubernetes.k8s_info:

--- a/roles/acm_setup/tasks/get-mirroring-config.yml
+++ b/roles/acm_setup/tasks/get-mirroring-config.yml
@@ -5,7 +5,7 @@
     kind: MachineConfigPool
     name: master
   register: _acm_setup_master_mcp
-  no_log: true
+  no_log: false
 
 - name: "Get current master's Machine Configs"
   vars:
@@ -15,7 +15,7 @@
     kind: MachineConfig
     name: "{{ acm_mc }}"
   register: _acm_setup_master_mc
-  no_log: true
+  no_log: false
 
 - name: "Get cluster user-ca certificate"
   community.kubernetes.k8s_info:
@@ -24,7 +24,7 @@
     name: "user-ca-bundle"
     namespace: openshift-config
   register: _acm_setup_user_ca_bundle
-  no_log: true
+  no_log: false
 
 - name: "Create a Config map with registry entries and CA bundle"
   vars:

--- a/roles/acm_setup/tasks/get-mirroring-config.yml
+++ b/roles/acm_setup/tasks/get-mirroring-config.yml
@@ -16,12 +16,6 @@
     name: "{{ acm_machine_config }}"
   register: _acm_setup_master_mc
   no_log: true
-  until: >
-    _acm_setup_master_mc is defined
-    and _acm_setup_master_mc.resources is defined
-    and _acm_setup_master_mc.resources | length == 1
-  retries: 10
-  delay: 15
 
 - name: "Get cluster user-ca certificate"
   community.kubernetes.k8s_info:
@@ -34,7 +28,7 @@
 
 - name: "Create a Config map with registry entries and CA bundle"
   vars:
-    acm_user_ca_bundle: '{{ _acm_setup_user_ca_bundle.resources[0].data["ca-bundle.crt"] }}'
+    acm_user_ca_bundle: "{{ _acm_setup_user_ca_bundle.resources[0].data['ca-bundle.crt'] }}"
     registry_config: "{{ (_acm_setup_master_mc | json_query('resources[0].spec.config.storage.files[?path==`/etc/containers/registries.conf`].contents.source'))[0] |
                       regex_replace('^data:.*;base64,', '') | b64decode }}"
     mirror_cm_def: |

--- a/roles/acm_setup/tasks/get-mirroring-config.yml
+++ b/roles/acm_setup/tasks/get-mirroring-config.yml
@@ -1,0 +1,50 @@
+---
+- name: "Get current worker's MCP"
+  community.kubernetes.k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    name: worker
+  register: _acm_setup_worker_mcp
+  no_log: true
+
+- name: "Get current worker's Machine Configs"
+  vars:
+    acm_mc: "{{ _acm_setup_worker_mcp.resources[0].spec.configuration.name }}"
+  community.kubernetes.k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    name: "{{ acm_mc }}"
+  register: _acm_setup_worker_mc
+  no_log: true
+
+- name: "Get cluster user-ca certificate"
+  community.kubernetes.k8s_info:
+    api: v1
+    kind: ConfigMap
+    name: "user-ca-bundle"
+    namespace: openshift-config
+  register: _acm_setup_user_ca_bundle
+  no_log: true
+
+- name: "Create a Config map with registry entries and CA bundle"
+  vars:
+    acm_user_ca_bundle: '{{ _acm_setup_user_ca_bundle.resources[0].data["ca-bundle.crt"] }}'
+    registry_config: "{{ _acm_setup_worker_mc | json_query('resources[0].spec.config.storage.files[?path==`/etc/containers/registries.conf`].contents.source') |
+                  first | regex_replace('^data:.*;base64,', '') | b64decode }}"
+    cm_def: |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: mirror-registry-config-map
+        namespace: multicluster-engine
+        labels:
+          app: assisted-service
+      data:
+        registries.conf: |
+          {{ registry_config | indent(4) }}
+        ca-bundle.crt: |
+          {{ acm_user_ca_bundle | indent(4) }}
+  community.kubernetes.k8s:
+    state: present
+    definition: "{{ cm_def }}"
+...

--- a/roles/acm_setup/tasks/get-mirroring-config.yml
+++ b/roles/acm_setup/tasks/get-mirroring-config.yml
@@ -5,17 +5,17 @@
     kind: MachineConfigPool
     name: master
   register: _acm_setup_master_mcp
-  no_log: false
+  no_log: true
 
 - name: "Get current master's Machine Config"
   vars:
-    acm_mc: "{{ _acm_setup_master_mcp.resources[0].spec.configuration.name }}"
+    acm_machine_config: "{{ _acm_setup_master_mcp.resources[0].spec.configuration.name }}"
   community.kubernetes.k8s_info:
     api_version: machineconfiguration.openshift.io/v1
     kind: MachineConfig
-    name: "{{ acm_mc }}"
+    name: "{{ acm_machine_config }}"
   register: _acm_setup_master_mc
-  no_log: false
+  no_log: true
   until: >
     _acm_setup_master_mc is defined
     and _acm_setup_master_mc.resources is defined
@@ -30,14 +30,14 @@
     name: "user-ca-bundle"
     namespace: openshift-config
   register: _acm_setup_user_ca_bundle
-  no_log: false
+  no_log: true
 
 - name: "Create a Config map with registry entries and CA bundle"
   vars:
     acm_user_ca_bundle: '{{ _acm_setup_user_ca_bundle.resources[0].data["ca-bundle.crt"] }}'
     registry_config: "{{ (_acm_setup_master_mc | json_query('resources[0].spec.config.storage.files[?path==`/etc/containers/registries.conf`].contents.source'))[0] |
                       regex_replace('^data:.*;base64,', '') | b64decode }}"
-    cm_def: |
+    mirror_cm_def: |
       apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -52,5 +52,5 @@
           {{ acm_user_ca_bundle | indent(4) }}
   community.kubernetes.k8s:
     state: present
-    definition: "{{ cm_def }}"
+    definition: "{{ mirror_cm_def }}"
 ...

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -300,7 +300,7 @@
       {% if hub_os_images is defined %}
         osImages: {{ hub_os_images }}
       {% endif %}
-      {% if hub_disconnected %}
+      {% if hub_disconnected | bool %}
         mirrorRegistryRef:
             name: mirror-registry-config-map
       {% endif %}

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -255,6 +255,11 @@
     namespace: multicluster-engine
   register: _asg
 
+- name: "Get Hub Cluster mirroring configuration"
+  ansible.builtin.include_tasks: get-mirroring-config.yml
+  when:
+    - hub_disconnected
+
 - name: "Create the Agent Service config"
   when: _asg.resources | length == 0
   vars:
@@ -294,6 +299,10 @@
               storage: "{{ hub_img_volume_size }}"
       {% if hub_os_images is defined %}
         osImages: {{ hub_os_images }}
+      {% endif %}
+      {% if hub_disconnected %}
+        mirrorRegistryRef:
+            name: mirror-registry-config-map
       {% endif %}
   community.kubernetes.k8s:
     state: present

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -258,7 +258,7 @@
 - name: "Get Hub Cluster mirroring configuration"
   ansible.builtin.include_tasks: get-mirroring-config.yml
   when:
-    - hub_disconnected
+    - hub_disconnected | bool
 
 - name: "Create the Agent Service config"
   when: _asg.resources | length == 0


### PR DESCRIPTION
##### SUMMARY

In a disconnected environment, the AgentServiceConfig must have information about mirroring settings to pull images during agents discovery.

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestDallas - ACM hub https://www.distributed-ci.io/jobs/ca326ee4-94ea-4443-9aa2-76af7cc95ad7/jobStates
- [x] TestDallas - ACM sno https://www.distributed-ci.io/jobs/ca326ee4-94ea-4443-9aa2-76af7cc95ad7/jobStates

Test-Hints: no-check