### PR TITLE
Fail preflight release action if the retrieved release is null

### DIFF
--- a/.github/workflows/preflight-release.yml
+++ b/.github/workflows/preflight-release.yml
@@ -17,6 +17,10 @@ jobs:
         run: |
           preflight_latest=$(curl -s https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/releases/latest | jq -r .tag_name)
           echo "Preflight latest release: $preflight_latest"
+          if [ "$preflight_latest" == "null" ]; then
+            echo "Failed to retrieve the latest release. Exiting."
+            exit 1
+          fi
           echo "preflight_latest=$preflight_latest" >> $GITHUB_OUTPUT
 
       - name: Get current release version


### PR DESCRIPTION
##### SUMMARY

This PR is to force preflight GH action to fail when the retrieved release is `null` because of the GH API glitch.

##### ISSUE TYPE

Current behavior:
- [GH action](https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/11288743625/job/31397141913) has retrieved the release being null because of an API glitch
```
0s
Run preflight_latest=$(curl -s https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/releases/latest | jq -r .tag_name)
  preflight_latest=$(curl -s https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/releases/latest | jq -r .tag_name)
  echo "Preflight latest release: $preflight_latest"
  echo "preflight_latest=$preflight_latest" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
Preflight latest release: null
```
while the real latest release is not null but 1.10.1

```
$ curl -s https://api.github.com/repos/redhat-openshift-ecosystem/openshift-preflight/releases/latest | jq -r .tag_name
1.10.1
```

- GH action opens weird PR [Move to Preflight release null](https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/463).

The idea for the fix is to fail pipeline asap instead of opening the PR.

Test-Hint: no-check