### PR TITLE
Remove installation of gh package in GHA

### DIFF
--- a/.github/workflows/preflight-release.yml
+++ b/.github/workflows/preflight-release.yml
@@ -56,10 +56,6 @@ jobs:
             echo "branch_exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install GitHub CLI
-        if: steps.compare_versions.outputs.new_release == 'true' && steps.check_branch.outputs.branch_exists == 'false'
-        run: sudo apt-get install -y gh
-
       - name: Import GPG key
         if: steps.compare_versions.outputs.new_release == 'true' && steps.check_branch.outputs.branch_exists == 'false'
         env:


### PR DESCRIPTION
##### SUMMARY

The gh package is already included in the ubuntu-latest (currently 20.04) runner image:
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#cli-tools

The GHA log shows it is already installed: https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/11380958559/job/31661339609#step:7:8

##### ISSUE TYPE

- Nominal change

##### Tests

Test-Hint: no-check