### PR TITLE
Modify lookup file usage to enable remote file retrieval

### DIFF
--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -1,7 +1,12 @@
 ---
-- name: "Read release_image from release.txt"
-  ansible.builtin.set_fact:
-    mor_release_image: "{{ lookup('file', (mor_cache_dir + '/' + mor_version + '/release.txt')) | regex_search('(?<=^Pull From: )(.*)$', multiline=true) }}"
+- name: "Get content of release.txt"
+  slurp:
+    src: "{{ mor_cache_dir }}/{{ mor_version }}/release.txt"
+  register: mor_release_content
+
+- name: "Read release_image from release content"
+  set_fact:
+    mor_release_image: "{{mor_release_content.content | b64decode | regex_search('(?<=^Pull From: )(.*)$', multiline=true)}}"
 
 - name: "Write rhcos.json from command 4.8+"
   when:

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -6,7 +6,7 @@
 
 - name: "Read release_image from release content"
   set_fact:
-    mor_release_image: "{{mor_release_content.content | b64decode | regex_search('(?<=^Pull From: )(.*)$', multiline=true)}}"
+    mor_release_image: "{{ mor_release_content.content | b64decode | regex_search('(?<=^Pull From: )(.*)$', multiline=true) }}"
 
 - name: "Write rhcos.json from command 4.8+"
   when:

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -1,11 +1,11 @@
 ---
 - name: "Get content of release.txt"
-  slurp:
+  ansible.builtin.slurp:
     src: "{{ mor_cache_dir }}/{{ mor_version }}/release.txt"
   register: mor_release_content
 
 - name: "Read release_image from release content"
-  set_fact:
+  ansible.builtin.set_fact:
     mor_release_image: "{{ mor_release_content.content | b64decode | regex_search('(?<=^Pull From: )(.*)$', multiline=true) }}"
 
 - name: "Write rhcos.json from command 4.8+"

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -2,11 +2,11 @@
 - name: "Get content of release.txt"
   ansible.builtin.slurp:
     src: "{{ mor_cache_dir }}/{{ mor_version }}/release.txt"
-  register: mor_release_content
+  register: _mor_release_content
 
 - name: "Read release_image from release content"
   ansible.builtin.set_fact:
-    mor_release_image: "{{ mor_release_content.content | b64decode | regex_search('(?<=^Pull From: )(.*)$', multiline=true) }}"
+    mor_release_image: "{{ _mor_release_content.content | b64decode | regex_search('(?<=^Pull From: )(.*)$', multiline=true) }}"
 
 - name: "Write rhcos.json from command 4.8+"
   when:


### PR DESCRIPTION
##### SUMMARY
This commit changes the way the lookup file is handled in the DCI OpenShift Agent. Previously, the lookup file could only access local files, which posed a limitation for containerized deployments.

With this update, the lookup file can now retrieve content from a remote system, specifically allowing for the cache files to reside on the jumphost.

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests


- [x] TestBos2

---

TestBos2: virt 


