### PR TITLE
Added task to wait for GitOps plugin activation

### DIFF
--- a/roles/configure_ztp_gitops_apps/tasks/main.yaml
+++ b/roles/configure_ztp_gitops_apps/tasks/main.yaml
@@ -208,6 +208,22 @@
             .dockerconfigjson: "{{ _czga_encoded_pull_secret['content'] }}"
       no_log: true
 
+    - name: Wait for the GitOps ZTP plugin activation
+      community.kubernetes.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: openshift-gitops
+        label_selectors:
+          - app.kubernetes.io/name = openshift-gitops-repo-server
+      register: _czga_repo_server_pod
+      retries: 39
+      delay: 14
+      until:
+        - _czga_repo_server_pod.resources is defined
+        - _czga_repo_server_pod.resources | length == 1
+        - _czga_repo_server_pod.resources[0] | community.general.json_query("status.conditions[?type=='Ready'].status") == ["True"]
+        - '"kustomize" in _czga_repo_server_pod.resources[0] | community.general.json_query("spec.volumes[].name")'
+
     - name: Run the policies and cluster apps
       ansible.builtin.shell: |
         {{ czga_oc_tool_path }} --kubeconfig="{{ temp_dir.path }}/kubeconfig" apply -k "{{ temp_dir.path }}/ztp/argocd/deployment"


### PR DESCRIPTION
##### SUMMARY
In order to run ZTP spoke cluster deployments, the OpenShift GitOps operator must be complemented with the ztp site generator plugin.

The plugin is enabled through the argocd CR in the hub cluster.

Upon updating the CR, the openshift-gitops-repo-server deployment is updated with the mounted volume containing the new kustomize configuration.

This task involves pulling two images to run as initContainers to the repo server pod.

The problem is the pulling of the images may take too much time in disconnected networks, causing the job to time out while waiting for the deployment to start.

This PR adds a tasks that waits for the repo server container to be updated before the role creates the GitOps applications, so once the application is created the job may move directly to the deployment stage.

##### ISSUE TYPE

- Bug

##### Tests

- [] TestBos2 

TestBos2: bevo/acm-hub bevo/ztp-spoke-4.15
Build-Depends: 32490
