### PR TITLE
Filter out OCP and K8s SA when assessing workload deprecation

### DIFF
--- a/roles/deprecated_api/tasks/get_api_request_counts_per_namespace.yml
+++ b/roles/deprecated_api/tasks/get_api_request_counts_per_namespace.yml
@@ -38,6 +38,16 @@
   ansible.builtin.debug:
     var: da_removed_api
 
+- name: "Filter out openshift and kube related service accounts from OCP compatibility list for {{ da_ns }}"
+  ansible.builtin.set_fact:
+    da_removed_api: >-
+      {{
+        da_removed_api |
+        selectattr('serviceAccounts', 'search', 'serviceaccount:') |
+        selectattr('serviceAccounts', 'search', '^(?!.*(openshift|kube)).*') |
+        list
+      }}
+
 - name: "Compute OCP compatibility of the workload API for {{ da_ns }}"
   vars:
     ocp_filename: "{{ deprecated_api_logs.path }}/apirequestcounts_ocp_compatibility_{{ da_ns }}_junit.xml"


### PR DESCRIPTION
##### SUMMARY
[CILAB-1840](https://issues.redhat.com/browse/CILAB-1840)

##### ISSUE TYPE

Fix

##### Tests

[Ctrl PL check after install-4.12](https://www.distributed-ci.io/jobs/b6d4c508-bd4e-4ab0-858a-c5812cceb397/jobStates?sort=date&task=5e1dee2f-b45e-4821-af6c-6e53007905af)

```
TASK [redhatci.ocp.deprecated_api : Filter out openshift and kube related service accounts from OCP compatibility list for cnf-app-mac-operator]
0s
task path: /home/dciteam/github/ansible-collection-redhatci-ocp-pr474-4003a1a3168013a28a941847b31104ec/collections/ansible_collections/redhatci/ocp/roles/deprecated_api/tasks/get_api_request_counts_per_namespace.yml:41
ok: [jumphost] => {"ansible_facts": {"da_removed_api": []}, "changed": false}

TASK [redhatci.ocp.deprecated_api : Compute OCP compatibility of the workload API for cnf-app-mac-operator]
0s
task path: /home/dciteam/github/ansible-collection-redhatci-ocp-pr474-4003a1a3168013a28a941847b31104ec/collections/ansible_collections/redhatci/ocp/roles/deprecated_api/tasks/get_api_request_counts_per_namespace.yml:51
ok: [jumphost] => {"ansible_facts": {"ocp_compatibility": {"4.12": "compatible", "4.13": "compatible"}}, "changed": false}
```