### PR TITLE
[ocp_add_users] add missing default var oau_secure_log

### DIFF
--- a/roles/ocp_add_users/defaults/main.yml
+++ b/roles/ocp_add_users/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 oau_passwd_len: 15
+oau_secure_log: true


### PR DESCRIPTION
##### SUMMARY
using this role is currently causing failures because  `oau_secure_log` does not have a default value.

##### ISSUE TYPE
- Bug Fix or other nominal change


##### Tests

- [x] TestBos2: virt -  https://www.distributed-ci.io/jobs/e515570b-0ba4-4857-8a6f-6525e2f8cae2

---

Test-Hints: no-check
