### PR TITLE
sriov_config | Add plugins field in SriovNetwork

### DIFF
--- a/roles/sriov_config/README.md
+++ b/roles/sriov_config/README.md
@@ -73,6 +73,7 @@ The `sriov_config_file` **must** meet the following requirements
 | meta_plugins      | No       | String  | MetaPluginsConfig configuration to be used in order to chain metaplugins to the sriov interface returned by the operator.
 | min_tx_rate       | No       | Int     | Minimum tx rate, in Mbps, for the VF, min_tx_rate should be <= max_tx_rate.
 | network_namespace | No       | String  | Namespace of the NetworkAttachmentDefinition custom resource
+| plugins           | No       | String  | Plugins to be configured for this network.
 | spoof_chk         | No       | String  | VF spoof check, (on|off)
 | trust             | No       | String  | VF trust mode (on|off)
 | vlan              | No       | Int     | VLAN ID to assign for the VF.
@@ -122,6 +123,7 @@ sriov_network_configs:
       spoof_chk: on
       trust: on
       capabilities: '{ "mac": true, "ips": true }'
+      plugins: '[{"type": "sriov", "mtu": 9000}]'
 ```
 
 > NOTE: SR-IOV operator requires nodes to use the `worker` role.

--- a/roles/sriov_config/templates/sriov-network.yml.j2
+++ b/roles/sriov_config/templates/sriov-network.yml.j2
@@ -25,6 +25,9 @@ spec:
 {% if sriov.network.network_namespace is defined %}
   networkNamespace: "{{ sriov.network.network_namespace }}"
 {% endif %}
+{% if sriov.network.plugins is defined %}
+  plugins: {{ sriov.network.plugins | to_json }}
+{% endif %}
   resourceName: "{{ sriov.resource }}"
 {% if sriov.network.spoof_chk is defined %}
   spoofChk: "{{ sriov.network.spoof_chk }}"


### PR DESCRIPTION
##### SUMMARY

Allow the user to provide [plugins](https://docs.openshift.com/container-platform/4.17/networking/configure-syscontrols-interface-tuning-cni.html) field within the SriovNetwork resource, so that this can be propagated to the NetworkAttachmentDefinition resource.

##### ISSUE TYPE

- Enhanced Feature

##### TESTS

- [] example-cnf test

Testing will be made in a separate PR