### PR TITLE
Added default "oay_secure_log: true"

### DIFF
--- a/roles/ocp_add_users/defaults/main.yml
+++ b/roles/ocp_add_users/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 oau_passwd_len: 15
+oau_secure_log: true


### PR DESCRIPTION
##### SUMMARY
Fixes "CILAB-1868: Failed at redhatci.ocp.ocp_add_users : Read OAuth cluster"

No default value for variable oau_secure_log is define in ocp_add_users role causing the task to fail.

##### ISSUE TYPE
- Bug Fix

##### Tests

- [] TestBos2 - [e1b67c63-13a6-45c7-9f1d-1c4a619be0a7](https://www.distributed-ci.io/jobs/e1b67c63-13a6-45c7-9f1d-1c4a619be0a7/jobStates?sort=date&task=a86d0fab-bd9e-44b6-8df2-ab9f55482368)

---

TestBos2: assisted-abi
