### PR TITLE
Fix typo in var name

### DIFF
--- a/roles/ocp_add_users/tasks/add-users.yml
+++ b/roles/ocp_add_users/tasks/add-users.yml
@@ -4,7 +4,7 @@
     current_users: "{{ (_oau_secret.resources[0].data.htpasswd | default('Cg==') | b64decode).split() }}"
     new_users: "{{ (_oau_new_encoded_users.content | b64decode).split() }}"
   ansible.builtin.set_fact:
-    oau_all_users: "{{ _oau_all_users | default({}) | combine({item.split(':')[0]: item.split(':')[1]}) }}"
+    oau_all_users: "{{ oau_all_users | default({}) | combine({item.split(':')[0]: item.split(':')[1]}) }}"
   loop: "{{ current_users + new_users }}"
   loop_control:
     label: "{{ item.split(':')[0] }}"


### PR DESCRIPTION
##### SUMMARY

Fix a typo in var name causing a single user to be defined.

##### ISSUE TYPE

- Bug

##### Tests

- [ ] TestBos2Sno: sno - https://www.distributed-ci.io/jobs/39dfe09c-3c80-43f6-baf0-3b942c11c597

---

Test-Hints: no-check