### PR TITLE
Not removing the OCP binaries to prevent concurrency issues

### DIFF
--- a/roles/sno_installer/tasks/10_get_oc.yml
+++ b/roles/sno_installer/tasks/10_get_oc.yml
@@ -1,25 +1,4 @@
 ---
-- name: "Find any existing OpenShift binaries"
-  ansible.builtin.find:
-    paths: "{{ ocp_binary_path }}"
-    patterns: 'oc,openshift-install,kubectl'
-  register: binary_results
-  tags:
-    - cleanup
-    - getoc
-
-- name: "Remove any existing OpenShift binaries"
-  ansible.builtin.file:
-    path: "{{ item['path'] }}"
-    state: absent
-  loop: "{{ binary_results['files'] }}"
-  loop_control:
-    label: "{{ item['path'] }}"
-  become: true
-  tags:
-    - cleanup
-    - getoc
-
 - name: "Validate that master cache directory exists"
   ansible.builtin.stat:
     path: "{{ si_cache_dir }}"


### PR DESCRIPTION
##### SUMMARY
Some of the SNO deployment tasks use the oc, kubectl and openshift-install binaries, which must be placed in the provision host's system path.

One of the firsts tasks in the sno_installer role removes these files from the system path so they can be extracted at later tasks and copied back to the path and, eventually, executed.

Concurrent jobs running on the same system may run in a race condition if:

- job A: removes the binaries
- job A: extracts the binaries
- job B: removes the binaries
- job A: executes the binaries

To prevent this from happening we reckon the binary removing tasks may be skipped so we rely on Ansible's idempotency to replace the binaries when any of the files needs updating.

Fixes [CILAB-1063](https://issues.redhat.com/browse/cilab-1063)

##### ISSUE TYPE
- Bug Fix

##### Tests
- [] TestBos2Sno - <JobID>

TestBos2Sno: sno
