### PR TITLE
Reuse git components in the tracking of dev git repos

### DIFF
--- a/roles/include_components/tasks/track_dev_git_repo.yml
+++ b/roles/include_components/tasks/track_dev_git_repo.yml
@@ -36,8 +36,14 @@
   when: last_commit_id.rc == 0
   no_log: true
 
-# create the component the same way as in
-# dci-ansible/action_plugins/git.py
+- name: Search for the git component
+  ansible.legacy.dci_component:
+    state: search
+    topic_id: "{{ job_info['job']['topic_id'] }}"
+    uid: "{{ last_commit_id.stdout }}"
+  register: _ic_search_git_component
+  when: last_commit_id.rc == 0
+
 - name: Create git repo component
   ansible.legacy.dci_component:
     display_name: "{{ repo_url.stdout | basename | regex_replace('[.]git$', '') }} {{ last_commit_id.stdout[:7] }}"
@@ -49,15 +55,24 @@
     url: "{{ repo_url.stdout | regex_replace('^(.*):(.*)@(.*)', 'https://\\3') | regex_replace('^ssh://(.*)@(.*)', 'https://\\2') | regex_replace('[.]git$', '') }}/commit/{{ last_commit_id.stdout }}"
     state: present
   register: git_component
-  when: last_commit_id.rc == 0
+  when:
+    - last_commit_id.rc == 0
+    - _ic_search_git_component.components | length == 0
 
 - name: 'Attach git component to the job'
+  # dci_component plugin does not provide a consistent return value
+  # In a search returns a list of components, in a create returns a single component
+  # We need to default values to avoid errors during the assignment of the component id
+  vars:
+    c_id: "{{ git_component.changed | ternary(git_component.component.id | default(''), _ic_search_git_component.components[0].id | default('')) }}"
   ansible.legacy.dci_job_component:
-    component_id: "{{ git_component.component.id }}"
+    component_id: "{{ c_id }}"
     job_id: " {{ job_id }} "
   register: job_component_result
   until: job_component_result is not failed
   retries: 5
   delay: 20
-  when: last_commit_id.rc == 0
+  when:
+    - last_commit_id.rc == 0
+    - git_component.changed or _ic_search_git_component.components | length > 0
 ...


### PR DESCRIPTION
##### SUMMARY

When attempting to create an existent component the dci_component plugin  did not returned the value of the component. This caused a failure when attaching the component to the job. To avoid this, the role now searches for the git component and obtains its id.


Attempting to re-create a component caused the component to not show its details:

```yaml
ok: [localhost] => {
    "git_component": {
        "changed": false,
        "failed": false
    }
}
```

Now the search retrieves the component and that info is used to attach it to a job.

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestBos2Sno:  sno sno:ansible_tags=job,dci,pre-run,success
  - [x] First attempt - https://www.distributed-ci.io/jobs/6f0ef8b7-0ec0-43ed-af6e-c44e9c7052fa/jobStates?sort=date&task=60442fe7-641a-4134-9aab-720a66eed74c
  - [x] Subsequent attempt - https://www.distributed-ci.io/jobs/f2e2aa43-d0b7-4c4c-82b0-20a8c24b27bf/jobStates?sort=date&task=53a392e3-a5e3-4ad4-bd7e-21ffd0b65dea

---

Test-Hints: no-check