### PR TITLE
hcp - Use version command

### DIFF
--- a/roles/acm_hypershift/tasks/download-cli.yml
+++ b/roles/acm_hypershift/tasks/download-cli.yml
@@ -45,7 +45,7 @@
 - name: Get hcp cli version
   ansible.builtin.shell:
     cmd: >
-      {{ ah_tmp_dir }}/hcp --version
+      {{ ah_tmp_dir }}/hcp version
   register: result
   changed_when: false
 


### PR DESCRIPTION
##### SUMMARY
`--version` is removed, version command must be used

##### ISSUE TYPE
- Fix

##### Tests

- [x] TestDallas - https://www.distributed-ci.io/jobs/ac88e6c3-850c-449a-a9a3-f19acd469307/jobStates?sort=date

Test-Hint: no-check
