### PR TITLE
[DNM] add NTP to infraenv.spec to discard sync issue

### DIFF
--- a/roles/acm_sno/tasks/create-cluster.yml
+++ b/roles/acm_sno/tasks/create-cluster.yml
@@ -307,6 +307,8 @@
         clusterRef:
           name: "{{ acm_cluster_name }}"
           namespace: "{{ acm_cluster_name }}"
+        additionalNTPSources:
+          - "{{ acm_ntp_server }}"
         agentLabels:
           agentclusterinstalls.extensions.hive.openshift.io/location: "{{ acm_cluster_location }}"
         cpuArchitecture: x86_64


### PR DESCRIPTION
Testing possible fix to bootstrapping issues of Spoke cluster.

build-depends: https://github.com/dci-labs/inventories/pull/242

