### PR TITLE
[DNM] testing to disable ClusterLogging CRD check

### DIFF
--- a/roles/ocp_logging/tasks/pre-run.yml
+++ b/roles/ocp_logging/tasks/pre-run.yml
@@ -66,10 +66,10 @@
   register: cl_crd
   no_log: true
 
-- name: "Fail if ClusterLogging CRD is not present"
-  ansible.builtin.fail:
-    msg: "ClusterLogging CRD is not present"
-  when: cl_crd.resources | list | count == 0
+#- name: "Fail if ClusterLogging CRD is not present"
+#  ansible.builtin.fail:
+#    msg: "ClusterLogging CRD is not present"
+#  when: cl_crd.resources | list | count == 0
 
 - name: "Get Storage Classes"
   community.kubernetes.k8s_info:


### PR DESCRIPTION
##### SUMMARY

4.17 OCP with cluster-logging.v6.1.0 is not showing ClusterLogging CRD, testing if installation completes without that resource.

##### ISSUE TYPE

- Bug

