### PR TITLE
Setup role for the Router Advertisement Daemon or radvd

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Name | Description
 [redhatci.ocp.setup_mirror_registry](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_mirror_registry/README.md) | Deploys a local container registry
 [redhatci.ocp.setup_netobserv_stack](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_netobserv_stack/README.md) | Set up the OCP Network Observability subsystem
 [redhatci.ocp.setup_ntp](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_ntp/README.md) | Deploys chrony
+[redhatci.ocp.setup_radvd](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_radvd/README.md) | Deploys the router advertisement daemon (radvd) for IPV6 installations
 [redhatci.ocp.setup_selfsigned_cert](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_selfsigned_cert/README.md) | Generates self signed SSL certs
 [redhatci.ocp.setup_sushy_tools](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_sushy_tools/README.md) | deploys virtual redfish for kvm
 [redhatci.ocp.setup_tftp](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_tftp/README.md) | Deploys a TFTP server

--- a/roles/setup_radvd/README.md
+++ b/roles/setup_radvd/README.md
@@ -1,0 +1,23 @@
+# Set Up the Router ADVertisement Daemon (radvd) role
+
+The purpose of this role is to set up an infrastructure host with a basic IPv6 radvd to facilitate
+self-management of IPv6 DHCP6 IP address management in a lab subnet.
+
+This requires switch configuration to ensure they are not competing with your infrastructure host to answer requests.
+
+## Variables
+
+All the variables defined are employed exclusively in the radvd.conf Jinja template to create the configuration file.
+
+- `setup_radvd_ipv6_network_cidr` This defines the IPv6 network segment (in CIDR
+notation) for which radvd will advertise itself as the default route. No default
+is provided and the role will error out if it is undefined.
+
+The remaining variables are provided to allow tweaking of settings. Sane defaults have been set for these.
+
+- `setup_radvd_baremetal_bridge` This defines the interface radvd will listen
+on, typically a bridge accessible to libvirt virtual machines and OCP cluster
+nodes. Defaults to "baremetal".
+- `setup_radvd_min_interval` Default 30 seconds
+- `setup_radvd_max_interval` Default 100 seconds
+- `setup_radvd_default_lifetime` Default 9000 seconds (2.5 hours)

--- a/roles/setup_radvd/defaults/main.yaml
+++ b/roles/setup_radvd/defaults/main.yaml
@@ -1,0 +1,12 @@
+# The interface name (usually a bridge) on which radvd will listen
+setup_radvd_baremetal_bridge: "baremetal"
+
+# The minimum time allowed between sending unsolicited multicast router advertisements from the interface, in seconds.
+setup_radvd_min_interval: 30
+
+# The maximum time allowed between sending unsolicited multicast router advertisements from the interface, in seconds.
+setup_radvd_max_interval: 100
+
+# The lifetime associated with the default router in units of seconds.
+# A lifetime of 0 indicates that the router is not a default router and should not appear on the default router list.
+setup_radvd_default_lifetime: 9000

--- a/roles/setup_radvd/files/sysctl.d/ipv6.conf
+++ b/roles/setup_radvd/files/sysctl.d/ipv6.conf
@@ -1,0 +1,4 @@
+net.ipv4.conf.all.rp_filter=0
+net.ipv6.conf.all.forwarding=1
+net.ipv6.conf.all.accept_ra=2
+net.ipv6.conf.lo.disable_ipv6=0

--- a/roles/setup_radvd/handlers/main.yaml
+++ b/roles/setup_radvd/handlers/main.yaml
@@ -1,0 +1,5 @@
+- name: Restart radvd
+  ansible.builtin.service:
+    name: radvd
+    state: restarted
+  listen: restart_service

--- a/roles/setup_radvd/tasks/main.yaml
+++ b/roles/setup_radvd/tasks/main.yaml
@@ -1,0 +1,29 @@
+- name: Perform validations
+  ansible.builtin.include_tasks: pre-requisites.yaml
+
+- name: Install radvd
+  ansible.builtin.package:
+    name: radvd
+    state: present
+
+- name: Create sysctl file for ipv6 settings
+  ansible.builtin.copy:
+    dest: /etc/sysctl.d/ipv6.conf
+    src: sysctl.d/ipv6.conf
+    mode: "0644"
+    owner: root
+    group: root
+  notify: restart_service
+
+- name: Create radvd.conf file
+  ansible.builtin.template:
+    src: radvd.conf.j2
+    dest: "/etc/radvd.conf"
+    mode: "0644"
+  notify: restart_service
+
+- name: Start radv daemon
+  ansible.builtin.service:
+    name: radvd
+    state: started
+    enabled: true

--- a/roles/setup_radvd/tasks/pre-requisites.yaml
+++ b/roles/setup_radvd/tasks/pre-requisites.yaml
@@ -1,0 +1,27 @@
+---
+- name: "Validate required parameters are defined"
+  ansible.builtin.assert:
+    that: "{{ item }} is defined"
+    fail_msg: "The parameter {{ item }} is required. See README.md for more details."
+  loop:
+    - setup_radvd_baremetal_bridge
+    - setup_radvd_ipv6_network_cidr
+
+- name: "Validate values of interval and lifetime parameters are positive integers"
+  ansible.builtin.assert:
+    that: "{{ item }} | int > 0"
+    fail_msg: "The interval parameters must be positive integers."
+  loop:
+    - setup_radvd_min_interval
+    - setup_radvd_max_interval
+    - setup_radvd_default_lifetime
+
+- name: "Validate for intervals, min < max"
+  ansible.builtin.assert:
+    that: setup_radvd_min_interval | int < setup_radvd_max_interval | int
+    fail_msg: "Min must be less than Max."
+
+- name: "Validate that setup_radvd_ipv6_network_cidr is a proper ipv6 network address"
+  ansible.builtin.assert:
+    that: setup_radvd_ipv6_network_cidr | ansible.utils.ipv6('network')
+    fail_msg: "setup_radvd_ipv6_network_cidr must be a valid IPv6 network address."

--- a/roles/setup_radvd/templates/radvd.conf.j2
+++ b/roles/setup_radvd/templates/radvd.conf.j2
@@ -1,0 +1,29 @@
+interface {{ setup_radvd_baremetal_bridge }}
+{
+    # When set, hosts use the administered (stateful) protocol for address autoconfiguration in addition to any addresses
+    # autoconfigured using stateless address autoconfiguration. The use of this flag is described in RFC 4862.
+    AdvManagedFlag on;
+    # A flag indicating whether or not the router sends periodic router advertisements and responds to router solicitations.
+    # It needs to be on to enable advertisement on this interface.
+    AdvSendAdvert on;
+    MinRtrAdvInterval {{ setup_radvd_min_interval }};
+    MaxRtrAdvInterval {{ setup_radvd_max_interval }};
+    AdvDefaultLifetime {{ setup_radvd_default_lifetime }};
+    prefix {{ setup_radvd_ipv6_network_cidr }}
+    {
+        # Indicates that this prefix can be used for on-link determination.
+        AdvOnLink on;
+        # Indicates that this prefix can be used for autonomous address configuration as specified in RFC 4862.
+        AdvAutonomous off;
+        # Indicates that the address of interface is sent instead of network prefix.
+        AdvRouterAddr on;
+    };
+    route ::/0 {
+        # The lifetime associated with the route in units of seconds.
+        AdvRouteLifetime {{ setup_radvd_default_lifetime }};
+        # The preference associated with the default router, as either "low", "medium", or "high".
+        AdvRoutePreference low;
+        # Upon shutdown, announce this route with a zero second lifetime.
+        RemoveRoute on;
+    };
+};


### PR DESCRIPTION
##### SUMMARY

Adds a role that installs the router advertisement daemon (radvd) that is a necessary component of dhcpv6 non SLAAC ipv6 deployments.

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

If existing labs use SLAAC or no ipv6, it may not be advised to test this module in those labs until we can inspect their configuration.

TestBos2Sno: sno