### PR TITLE
Use installedCSV to validate the subscription

### DIFF
--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -151,7 +151,7 @@
         - sub.resources is defined
         - sub.resources | length == 1
         - "'status' in sub.resources[0]"
-        - "'installedCSV' in sub.resources[0].status"
+        - sub.resources[0].status.installedCSV is defined
         - sub.resources[0].status.installedCSV == operator_csv
 
     - name: Handle with a starting CSV

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -151,8 +151,8 @@
         - sub.resources is defined
         - sub.resources | length == 1
         - "'status' in sub.resources[0]"
-        - "'currentCSV' in sub.resources[0].status"
-        - sub.resources[0].status.currentCSV | length > 0
+        - "'installedCSV' in sub.resources[0].status"
+        - sub.resources[0].status.installedCSV == operator_csv
 
     - name: Handle with a starting CSV
       when:


### PR DESCRIPTION
##### SUMMARY

Improve the subscription validation. Use installedCSV to validate that the requested CSV is installed. 
##### ISSUE TYPE
- Bug

- [x] TestDallas: ocp-4.18-vanilla - https://www.distributed-ci.io/jobs/7db328a8-9b33-49ba-a3c5-dd42f2579693/jobStates

##### Tests
Test-Hint: no-check
