### PR TITLE
Update kernel side load job status check

### DIFF
--- a/roles/sideload_kernel/tasks/main.yml
+++ b/roles/sideload_kernel/tasks/main.yml
@@ -107,7 +107,9 @@
   delay: 15
 
 - name: Ensure the job completed successfully
+  vars:
+    query_complete: "status.conditions[?type=='Complete'].status"
   ansible.builtin.fail:
-    msg: "Job state is {{ job_state.resources[0].status.conditions[0].type }}"
-  when: job_state.resources[0].status.conditions[0].type != 'Complete'
+    msg: "Job state is {{ job_state.resources[0] | community.general.json_query(query_complete) }}"
+  when: "'True' not in job_state.resources[0] | community.general.json_query(query_complete)"
 ...


### PR DESCRIPTION
##### SUMMARY

The kernel sideload job check can face a race condition in a final job success task and/or the Complete message may not be the last one.

##### ISSUE TYPE

-  Enhanced Feature

##### Tests

Test-Hints: no-check


