### PR TITLE
Address CI failures by updating apt-get cache before installing packages

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,6 +107,7 @@ jobs:
         run: |
           set -x
           # Prefer using podman over docker
+          sudo apt-get update
           apt-get download podman-docker
           sudo dpkg --force-all -i podman-docker*.deb 2>/dev/null
           EXCLUDE="--exclude hack/ --exclude plugins/modules/nmcli.py"


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/7452 for more
explanation.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

##### SUMMARY

As described in, https://github.com/actions/runner-images/issues/7452, it's
important to `apt-get update` before installing packages to make sure we get
up-to-date mirror and cache information.

Fixes #493

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### Tests

- GitHub PR test only

Test-Hint: no-check

