### PR TITLE
Execute dci component task in localhost

### DIFF
--- a/roles/k8s_best_practices_certsuite/tasks/pre-run.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/pre-run.yml
@@ -198,6 +198,8 @@
     - name: Create DCI component for certsuite
       ansible.builtin.include_role:
         name: redhatci.ocp.include_components
+        apply:
+          delegate_to: localhost
       vars:
         ic_gits: # noqa: redhat-ci[no-role-prefix]
           - "{{ kbpc_certsuite_dir }}"

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -60,6 +60,8 @@
     - name: Create a DCI component from Preflight image
       ansible.builtin.include_role:
         name: redhatci.ocp.include_components
+        apply:
+          delegate_to: localhost
       vars:
         ic_commit_urls:
           - "{{ preflight_repo_https }}/commit/{{ preflight_commit_id.stdout }}"


### PR DESCRIPTION
##### SUMMARY

When DCI is executed on podman, dci tasks must be executed in the container(localhost) instead of the jumphost.


##### ISSUE TYPE

- Enhanced Feature

Test-Hints: no-check
