### PR TITLE
Make available the kubernetes.core collection

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.24.EPOCH
+Version:        0.25.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -21,6 +21,7 @@ Requires: ansible-collection-community-general
 Requires: ansible-collection-community-kubernetes
 Requires: ansible-collection-community-libvirt
 Requires: ansible-collection-containers-podman
+Requires: ansible-collection-kubernetes-core
 Requires: git
 Requires: jq
 Requires: podman
@@ -52,6 +53,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Wed Jan  8 2025 Tony Garcia <tonyg@redhat.com> - 0.25.EPOCH-VERS
+- Introduce kubernetes.core collection as a dependency package
+
 * Tue Jan  7 2025 Tony Garcia <tonyg@redhat.com> - 0.24.EPOCH-VERS
 - Version bump for setup_gitea role updates
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.24.0
+version: 0.25.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md
@@ -103,6 +103,7 @@ dependencies:
   "community.kubernetes": "1.2.1"
   "community.libvirt": "*"
   "containers.podman": "*"
+  "kubernetes.core": "2.4.2"
 
 # The URL of the originating SCM repository
 repository: https://github.com/redhatci/ansible-collection-redhatci-ocp


### PR DESCRIPTION
##### SUMMARY

Introduce the kubernetes.core collection that will eventually deprecate the community.kubernetes collection.

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

- [x] TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[] - https://www.distributed-ci.io/jobs/9b09965b-4997-4251-9c9e-34498ae872c4/jobStates
- [x] TestDallasSno: ocp-4.16-sno-abi - https://www.distributed-ci.io/jobs/edc92c69-3ff6-4715-814c-1d832de78704

Also RPM dependency has been tested with these instructions:

```Shell
$ podman run -it --rm quay.io/centos/centos:stream8
```

Then in the container:
```ShellSession
# sed -i -e '/mirrorlist/d' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos/vault.centos/' /etc/yum.repos.d/CentOS-Stream-{BaseOS,AppStream,Extras,Extras-common}.repo

# dnf install centos-release-ansible-29.noarch -y
# sed -i -e '/mirrorlist/d' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos/vault.centos/' /etc/yum.repos.d/CentOS-SIG-ansible-29.repo

# dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
# dnf -y install https://packages.distributed-ci.io/dci-release.el8.noarch.rpm
# dnf config-manager --add-repo=https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo

# dnf -y install ansible-collection-redhatci-ocp
# dnf -y install ansible-collection-kubernetes-core

# ansible-doc -t module kubernetes.core.k8s |head -1
> K8S    (/usr/share/ansible/collections/ansible_collections/kubernetes/core/plugins/modules/k8s.py)
# rpm -qf /usr/share/ansible/collections/ansible_collections/kubernetes/core/plugins/modules/k8s.py
ansible-collection-kubernetes-core-2.4.2-1.202412092243git54b964f0.el8.noarch
```
---

Test-Hints: no-check