### PR TITLE
Handle startingCSV cases

### DIFF
--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -130,13 +130,45 @@
             namespace: "{{ namespace }}"
           spec:
             channel: "{{ desired_channel }}"
-            installPlanApproval: "Automatic"
+            installPlanApproval: "{{ (starting_csv | default('') | length) | ternary('Manual', 'Automatic') }}"
             config:
               resources: {}
             name: "{{ operator }}"
             source: "{{ source }}"
             sourceNamespace: "{{ source_ns }}"
             startingCSV: "{{ operator_csv }}"
+
+    - name: Approve the install plan for the desired StartingCSV
+      when:
+        - starting_csv | default('') | length
+      block:
+        - name: Get created install plans
+          community.kubernetes.k8s_info:
+            api: operators.coreos.com/v1alpha1
+            kind: InstallPlan
+            namespace: "{{ namespace }}"
+          register: _oo_install_plans
+          retries: 5
+          delay: 5
+          until:
+            - _oo_install_plans.resources is defined
+            - _oo_install_plans.resources | length
+
+        - name: Approve the install plan for the specific CSV
+          vars:
+            query: "resources[? spec.approved == `false` && contains(spec.clusterServiceVersionNames, '{{ starting_csv }}')]"
+          community.kubernetes.k8s:
+            definition:
+              apiVersion: operators.coreos.com/v1alpha1
+              kind: InstallPlan
+              metadata:
+                name: "{{ install_plan.metadata.name }}"
+                namespace: "{{ namespace }}"
+              spec:
+                approved: true
+          loop: "{{ _oo_install_plans | json_query(query) }}"
+          loop_control:
+            loop_var: install_plan
 
     - name: Wait for CSV to be ready
       community.kubernetes.k8s_info:

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -157,7 +157,6 @@
         - name: Approve the install plan for the specific CSV
           vars:
             query: "resources[? !spec.approved && contains(spec.clusterServiceVersionNames, '{{ starting_csv }}')]"
-``
           community.kubernetes.k8s:
             definition:
               apiVersion: operators.coreos.com/v1alpha1

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -138,37 +138,36 @@
             sourceNamespace: "{{ source_ns }}"
             startingCSV: "{{ operator_csv }}"
 
-    - name: Approve the install plan for the desired StartingCSV
+    - name: Check for install plans
+      community.kubernetes.k8s_info:
+        api: operators.coreos.com/v1alpha1
+        kind: InstallPlan
+        namespace: "{{ namespace }}"
+      register: _oo_install_plans
+      no_log: true
+      retries: 5
+      delay: 5
+      until:
+        - _oo_install_plans.resources is defined
+        - _oo_install_plans.resources | length
+
+    - name: Approve only the install plan for the specific CSV
+      vars:
+        query: "resources[? spec.approved == `false` && contains(spec.clusterServiceVersionNames, '{{ starting_csv }}')]"
+      community.kubernetes.k8s:
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: InstallPlan
+          metadata:
+            name: "{{ install_plan.metadata.name }}"
+            namespace: "{{ namespace }}"
+          spec:
+            approved: true
+      loop: "{{ _oo_install_plans | json_query(query) | default([]) }}"
+      loop_control:
+        loop_var: install_plan
       when:
         - starting_csv | default('') | length > 0
-      block:
-        - name: Get created install plans
-          community.kubernetes.k8s_info:
-            api: operators.coreos.com/v1alpha1
-            kind: InstallPlan
-            namespace: "{{ namespace }}"
-          register: _oo_install_plans
-          retries: 5
-          delay: 5
-          until:
-            - _oo_install_plans.resources is defined
-            - _oo_install_plans.resources | length
-
-        - name: Approve the install plan for the specific CSV
-          vars:
-            query: "resources[? !spec.approved && contains(spec.clusterServiceVersionNames, '{{ starting_csv }}')]"
-          community.kubernetes.k8s:
-            definition:
-              apiVersion: operators.coreos.com/v1alpha1
-              kind: InstallPlan
-              metadata:
-                name: "{{ install_plan.metadata.name }}"
-                namespace: "{{ namespace }}"
-              spec:
-                approved: true
-          loop: "{{ _oo_install_plans | json_query(query) }}"
-          loop_control:
-            loop_var: install_plan
 
     - name: Wait for CSV to be ready
       community.kubernetes.k8s_info:

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -156,7 +156,8 @@
 
         - name: Approve the install plan for the specific CSV
           vars:
-            query: "resources[? spec.approved == `false` && contains(spec.clusterServiceVersionNames, '{{ starting_csv }}')]"
+            query: "resources[? !spec.approved && contains(spec.clusterServiceVersionNames, '{{ starting_csv }}')]"
+``
           community.kubernetes.k8s:
             definition:
               apiVersion: operators.coreos.com/v1alpha1

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -140,7 +140,7 @@
 
     - name: Approve the install plan for the desired StartingCSV
       when:
-        - starting_csv | default('') | length
+        - starting_csv | default('') | length > 0
       block:
         - name: Get created install plans
           community.kubernetes.k8s_info:


### PR DESCRIPTION
##### SUMMARY

Add back the feature to handle cases where a starting CSV is defined. When a CSV is newer than the StartingCSV the install plans to reach the latest versions are created and the actual CSV will be the one for the newest version. 

This is mainly a rollback of commit: https://github.com/redhatci/ansible-collection-redhatci-ocp/commit/c2e9f0510f2584058773f1c42f508f7cfdaced8a

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

- [x] TestDallas: ocp-4.16-acm-hub -  https://www.distributed-ci.io/jobs/14c5b971-d071-4d51-9c93-ca63d16238f4/jobStates

##### Tests

Test-Hint: no-check
