### PR TITLE
Wait a bit longer for an IP to be available

### DIFF
--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -145,8 +145,8 @@
         namespace: "{{ namespace }}"
       register: _oo_install_plans
       no_log: true
-      retries: 5
-      delay: 5
+      retries: 6
+      delay: 15
       until:
         - _oo_install_plans.resources is defined
         - _oo_install_plans.resources | length


### PR DESCRIPTION
##### SUMMARY

Some operators take longer to extract the IP once the subscription is created, waiting a bit more to increase the odds of installing an operator succesfully.

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestBos2: virt-prega-4.19 libvirt:ansible_extravars=dci_pre_ga_catalog:"quay.io/prega/prega-operator-index:v4.19-20241210T200303" - https://www.distributed-ci.io/jobs/a295e50d-97f2-4c2c-8e63-ee2a847c2486


---

Test-Hints: no-check
