### PR TITLE
Bump certsuite to v5.4.0

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.3.7
+kbpc_version: v5.4.0
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"
@@ -100,11 +100,13 @@ kbpc_feedback:
   observability-crd-status: ""
   observability-pod-disruption-budget: ""
   observability-termination-policy: ""
+  operator-catalogsource-bundle-count: ""
   operator-crd-openapi-schema: ""
   operator-crd-versioning: ""
   operator-install-source: ""
   operator-install-status-no-privileges: ""
   operator-install-status-succeeded: ""
+  operator-multiple-same-operators: ""
   operator-olm-skip-range: ""
   operator-pods-no-hugepages: ""
   operator-semantic-versioning: ""


### PR DESCRIPTION
##### SUMMARY

Bump certsuite to v5.4.0

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x] tnf-test-cnf-green (disconnected) - https://www.distributed-ci.io/jobs/684f6f2e-fe5b-4722-9faa-9a302f4ed9bd/jobStates?sort=date
- [x] tnf-test-cnf (disconnected) - https://www.distributed-ci.io/jobs/aecc684f-1e91-41b6-a41a-3f048305c5ad/jobStates?sort=date
- [x] tnf-test (connected) -https://www.distributed-ci.io/jobs/fd4b38ba-e285-4eca-8c5f-b42ade80e0a9/jobStates

Test-Hints: no-check
