### PR TITLE
Preflight: Update the role to be able to run with dci container

### DIFF
--- a/roles/preflight/tasks/main_standalone_containers_certification.yml
+++ b/roles/preflight/tasks/main_standalone_containers_certification.yml
@@ -12,6 +12,7 @@
         src: "{{ partner_creds }}"
         dest: "{{ preflight_tmp_dir.path }}/config.json"
         mode: "0644"
+        remote_src: true
       when: partner_creds | length
 
     # Use custom certificate for self sign registry

--- a/roles/preflight/tasks/prepare_custom_certificate.yml
+++ b/roles/preflight/tasks/prepare_custom_certificate.yml
@@ -19,12 +19,14 @@
     src: "{{ preflight_custom_ca }}"
     dest: "{{ preflight_ca_tmp_dir.path }}/ca.crt"
     mode: "0644"
+    remote_src: true
 
 - name: Copy ca in trusted directory
   ansible.builtin.copy:
     src: "{{ preflight_custom_ca }}"
     dest: "/etc/pki/ca-trust/source/anchors/preflight_ca.crt"
     mode: "0644"
+    remote_src: true
   become: true
 
 - name: Update trusted ca

--- a/roles/preflight/tasks/prepare_preflight_image.yml
+++ b/roles/preflight/tasks/prepare_preflight_image.yml
@@ -15,6 +15,7 @@
     src: "{{ preflight_source_dir }}/"
     dest: "{{ preflight_tmp_dir.path }}/preflight-source/"
     mode: "0755"
+    remote_src: true
 
 - name: Set preflight_image name
   ansible.builtin.set_fact:

--- a/roles/preflight/tasks/test_preflight_check_container_one_image.yml
+++ b/roles/preflight/tasks/test_preflight_check_container_one_image.yml
@@ -115,6 +115,7 @@
             src: "{{ item.src }}"
             dest: "{{ job_logs.path }}/{{ preflight_prefix }}_{{ item.path | regex_replace('/', '_') }}"
             mode: "0644"
+            remote_src: true
           with_filetree:  # noqa: schema[moves]
             - "{{ preflight_container_artifacts.path }}"
           when:

--- a/roles/preflight/tasks/test_preflight_container_parallel.yml
+++ b/roles/preflight/tasks/test_preflight_container_parallel.yml
@@ -83,6 +83,7 @@
         src: "{{ item.1.path }}"
         dest: "{{ job_logs.path }}/{{ preflight_prefix }}"
         mode: "0644"
+        remote_src: true
       loop: "{{ preflight_files_context | subelements('files') }}"
       when: "item.1.path | regex_search('\\.(json|log|xml)$')"
 

--- a/roles/preflight/tasks/tests_preflight_check_operator.yml
+++ b/roles/preflight/tasks/tests_preflight_check_operator.yml
@@ -106,6 +106,11 @@
     jid: "{{ preflight_exec.ansible_job_id }}"
     mode: cleanup
 
+- name: Get preflight log files
+  find:
+    paths: "{{ preflight_operator_artifacts.path }}"
+  register: preflight_operator_artifacts_logs
+
 - name: Upload logs for preflight check operator into DCI
   vars:
     preflight_prefix: "preflight_operator_{{ operator.name }}"
@@ -114,8 +119,7 @@
     dest: "{{ job_logs.path }}/{{ preflight_prefix }}_{{ item | basename }}"
     mode: "0644"
     remote_src: true
-  with_fileglob:
-    - "{{ preflight_operator_artifacts.path }}/*"
+  loop: "{{ preflight_operator_artifacts_logs | json_query('files[*].path') }}"
 
 - name: Validate annotations.yaml
   ansible.builtin.include_tasks: test_validate_annotations.yml

--- a/roles/preflight/tasks/tests_preflight_check_operator.yml
+++ b/roles/preflight/tasks/tests_preflight_check_operator.yml
@@ -113,6 +113,7 @@
     src: "{{ item }}"
     dest: "{{ job_logs.path }}/{{ preflight_prefix }}_{{ item | basename }}"
     mode: "0644"
+    remote_src: true
   with_fileglob:
     - "{{ preflight_operator_artifacts.path }}/*"
 

--- a/roles/preflight/tasks/tests_preflight_check_operator.yml
+++ b/roles/preflight/tasks/tests_preflight_check_operator.yml
@@ -107,9 +107,9 @@
     mode: cleanup
 
 - name: Get preflight log files
-  find:
+  ansible.builtin.find:
     paths: "{{ preflight_operator_artifacts.path }}"
-  register: preflight_operator_artifacts_logs
+  register: _preflight_operator_artifacts_logs
 
 - name: Upload logs for preflight check operator into DCI
   vars:
@@ -119,7 +119,7 @@
     dest: "{{ job_logs.path }}/{{ preflight_prefix }}_{{ item | basename }}"
     mode: "0644"
     remote_src: true
-  loop: "{{ preflight_operator_artifacts_logs | json_query('files[*].path') }}"
+  loop: "{{ _preflight_operator_artifacts_logs | json_query('files[*].path') }}"
 
 - name: Validate annotations.yaml
   ansible.builtin.include_tasks: test_validate_annotations.yml


### PR DESCRIPTION
##### SUMMARY

With dci in container, the source is localhost which is not the jumphost. 
- We must do these copies from the jumphost with 'remote_src'.
- Remove 'with_fileglob' which is executed in the control server. 

##### ISSUE TYPE
- Bug (with dci-podman)


