### PR TITLE
Wait for file retrival, use random file names

### DIFF
--- a/roles/validate_http_store/defaults/main.yml
+++ b/roles/validate_http_store/defaults/main.yml
@@ -1,4 +1,5 @@
+---
 http_store_dir : "{{ iso_download_dest_path | default('/opt/http_store/data') }}"
 http_port: 80
 http_host: "{{ discovery_iso_server | default('http://' + hostvars['http_store']['ansible_host']) }}:{{ http_port }}"
-test_file_name: http_test
+...

--- a/roles/validate_http_store/defaults/main.yml
+++ b/roles/validate_http_store/defaults/main.yml
@@ -2,4 +2,5 @@
 http_store_dir : "{{ iso_download_dest_path | default('/opt/http_store/data') }}"
 http_port: 80
 http_host: "{{ discovery_iso_server | default('http://' + hostvars['http_store']['ansible_host']) }}:{{ http_port }}"
+test_file_name: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
 ...

--- a/roles/validate_http_store/defaults/main.yml
+++ b/roles/validate_http_store/defaults/main.yml
@@ -2,5 +2,4 @@
 http_store_dir : "{{ iso_download_dest_path | default('/opt/http_store/data') }}"
 http_port: 80
 http_host: "{{ discovery_iso_server | default('http://' + hostvars['http_store']['ansible_host']) }}:{{ http_port }}"
-test_file_name: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
 ...

--- a/roles/validate_http_store/tasks/main.yml
+++ b/roles/validate_http_store/tasks/main.yml
@@ -15,8 +15,11 @@
   uri:
     url: "{{ http_host }}/{{ test_file_name }}"
     return_content: true
-  register: response
+  register: _vhs_response
   delegate_to: bastion
+  retries: 10
+  delay: 3
+  until: _vhs_response.status == 200
 
 - name: Check content matches
   assert:

--- a/roles/validate_http_store/tasks/main.yml
+++ b/roles/validate_http_store/tasks/main.yml
@@ -16,16 +16,16 @@
   uri:
     url: "{{ http_host }}/{{ test_file_name }}"
     return_content: true
-  register: _vhs_response
+  register: response
   delegate_to: bastion
   retries: 12
   delay: 5
-  until: _vhs_response.status == 200
+  until: response.status == 200
 
 - name: Check content matches
   assert:
     that:
-      _vhs_response.content == contents
+      response.content == contents
     quiet: true
 
 - name: Remove file on http_store

--- a/roles/validate_http_store/tasks/main.yml
+++ b/roles/validate_http_store/tasks/main.yml
@@ -1,3 +1,8 @@
+---
+- name: Create a random name for the test file
+  ansible.builtin.set_fact:
+    vhs_test_file_name: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
+
 - name: Set test file contents
   set_fact:
     contents: "{{ lookup('template', 'test_file.j2') }}"
@@ -5,7 +10,7 @@
 - name: Copy file to http_store
   copy:
     content: "{{ contents }}"
-    dest: "{{ http_store_dir }}/{{ test_file_name }}"
+    dest: "{{ http_store_dir }}/{{ vhs_test_file_name }}"
     mode: 0644
     setype: httpd_sys_content_t
   become: true
@@ -13,23 +18,23 @@
 
 - name: Retrieve file from http_store
   uri:
-    url: "{{ http_host }}/{{ test_file_name }}"
+    url: "{{ http_host }}/{{ vhs_test_file_name }}"
     return_content: true
   register: _vhs_response
   delegate_to: bastion
-  retries: 10
-  delay: 3
+  retries: 12
+  delay: 5
   until: _vhs_response.status == 200
 
 - name: Check content matches
   assert:
     that:
-      response.content == contents
+      _vhs_response.content == contents
     quiet: true
 
 - name: Remove file on http_store
   file:
-    path: "{{ http_store_dir }}/{{ test_file_name }}"
+    path: "{{ http_store_dir }}/{{ vhs_test_file_name }}"
     state: absent
   become: true
   delegate_to: http_store

--- a/roles/validate_http_store/tasks/main.yml
+++ b/roles/validate_http_store/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Create a random name for the test file
-  ansible.builtin.set_fact:
-    vhs_test_file_name: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
-
 - name: Set test file contents
   set_fact:
     contents: "{{ lookup('template', 'test_file.j2') }}"
@@ -10,7 +6,7 @@
 - name: Copy file to http_store
   copy:
     content: "{{ contents }}"
-    dest: "{{ http_store_dir }}/{{ vhs_test_file_name }}"
+    dest: "{{ http_store_dir }}/{{ test_file_name }}"
     mode: 0644
     setype: httpd_sys_content_t
   become: true
@@ -18,7 +14,7 @@
 
 - name: Retrieve file from http_store
   uri:
-    url: "{{ http_host }}/{{ vhs_test_file_name }}"
+    url: "{{ http_host }}/{{ test_file_name }}"
     return_content: true
   register: _vhs_response
   delegate_to: bastion
@@ -34,7 +30,7 @@
 
 - name: Remove file on http_store
   file:
-    path: "{{ http_store_dir }}/{{ vhs_test_file_name }}"
+    path: "{{ http_store_dir }}/{{ test_file_name }}"
     state: absent
   become: true
   delegate_to: http_store

--- a/roles/validate_http_store/tasks/main.yml
+++ b/roles/validate_http_store/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set a random name for the test file
-  set_fact:
+  ansible.builtin.set_fact:
     vhs_test_file_name: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
 
 - name: Set test file contents

--- a/roles/validate_http_store/tasks/main.yml
+++ b/roles/validate_http_store/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set a random name for the test file
+  set_fact:
+    vhs_test_file_name: "{{ lookup('password', '/dev/null length=12 chars=ascii_letters,digits') }}"
+
 - name: Set test file contents
   set_fact:
     contents: "{{ lookup('template', 'test_file.j2') }}"
@@ -6,7 +10,7 @@
 - name: Copy file to http_store
   copy:
     content: "{{ contents }}"
-    dest: "{{ http_store_dir }}/{{ test_file_name }}"
+    dest: "{{ http_store_dir }}/{{ vhs_test_file_name }}"
     mode: 0644
     setype: httpd_sys_content_t
   become: true
@@ -14,7 +18,7 @@
 
 - name: Retrieve file from http_store
   uri:
-    url: "{{ http_host }}/{{ test_file_name }}"
+    url: "{{ http_host }}/{{ vhs_test_file_name }}"
     return_content: true
   register: response
   delegate_to: bastion
@@ -30,7 +34,7 @@
 
 - name: Remove file on http_store
   file:
-    path: "{{ http_store_dir }}/{{ test_file_name }}"
+    path: "{{ http_store_dir }}/{{ vhs_test_file_name }}"
     state: absent
   become: true
   delegate_to: http_store


### PR DESCRIPTION
##### SUMMARY
This used to fail the first time the http_store pod was created, as there is a short time between the pod creation and attempting to get the file.

Also in parallel executions, another deployment could modify the content of the test file, so creating random file names,

##### ISSUE TYPE

- nominal change

##### Tests

- [ ] TestBos2: abi - https://www.distributed-ci.io/jobs/cfe2ce6c-3900-4ece-8710-dc13d5aeef73/jobStates

---
