### PR TITLE
Wait twice longer for crucible ns to be destroyed

### DIFF
--- a/roles/get_logs_from_namespace/tasks/main.yml
+++ b/roles/get_logs_from_namespace/tasks/main.yml
@@ -10,7 +10,9 @@
     path: "{{ glfn_dir }}"
   register: dir_stat
   when: glfn_dir is defined
-  failed_when: not dir_stat.stat.exists
+  failed_when:
+    - glfn_dir is defined
+    - not dir_stat.stat.exists
 
 - name: Create logs directory when not provided
   when: glfn_dir is not defined
@@ -22,12 +24,16 @@
       register: logs
 
     - name: Set logs directory
-      set_fact:
+      ansible.builtin.set_fact:
         glfn_dir: "{{ logs.path }}"
 
     - name: Logs path
-      debug:
+      ansible.builtin.debug:
         msg: "{{ job_logs.path }}"
+
+- name: Display the logs directory path
+  ansible.builtin.debug:
+    msg: "Logs directory is set to: {{ glfn_dir }}"
 
 - name: "Get a list of all pods from {{ glfn_ns }}"
   community.kubernetes.k8s_info:

--- a/roles/multibench_run/tasks/main.yml
+++ b/roles/multibench_run/tasks/main.yml
@@ -82,7 +82,7 @@
         name: crucible-rickshaw
       register: _multibench_run_namespace_info
       until: _multibench_run_namespace_info.resources | length == 0
-      retries: 10
+      retries: 20
       delay: 5
 
     - name: "Retry launching the multibench workload"


### PR DESCRIPTION
##### SUMMARY

- Trying to wait twice longer when destroying crucible namespace to [allow for the remaining pod to be deleted](https://www.distributed-ci.io/jobs/475e63a3-e915-45c8-9307-6a9e5066e9df/jobStates?sort=date&task=14be164d-2ce6-4891-8ed4-30d46e110708).
- [failed_when](https://www.distributed-ci.io/jobs/475e63a3-e915-45c8-9307-6a9e5066e9df/jobStates?sort=date&task=a2f220af-4b15-4ddf-a4e9-004d7621a7dc) is evaluated even if glfn_dir is not defined causing the task to fail. Ensured failed_when is only evaluated when glfn_dir is defined.

##### Tests

Test-Hint: no-check
