### PR TITLE
Bump to certsuite v5.4.1

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.4.0
+kbpc_version: v5.4.1
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"
@@ -53,7 +53,6 @@ kbpc_feedback:
   access-control-security-context-non-root-user-check: ""
   access-control-security-context-privilege-escalation: ""
   access-control-security-context-read-only-file-system: ""
-  access-control-security-context-run-as-non-root-user-check: ""
   access-control-service-type: ""
   access-control-ssh-daemons: ""
   access-control-sys-admin-capability-check: ""


### PR DESCRIPTION
##### SUMMARY

Bump to certsuite v5.4.1, where `access-control-security-context-run-as-non-root-user-check` is removed

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x] TestDallasWorkload: tnf-test-cnf-green tnf-test-cnf-green:ansible_extravars=kbpc_version:v5.4.1 - https://www.distributed-ci.io/jobs/b2a5673a-73f7-4138-ad0c-140970fda691/jobStates

Test-Hints: no-check