### PR TITLE
Create the logs directory if defined but does not exist

### DIFF
--- a/roles/get_logs_from_namespace/tasks/main.yml
+++ b/roles/get_logs_from_namespace/tasks/main.yml
@@ -5,14 +5,12 @@
       - glfn_ns | string
       - glfn_oc | string
 
-- name: Check provided logs directory exists
-  ansible.builtin.stat:
+- name: Create the logs directory if defined but does not exist
+  ansible.builtin.file:
     path: "{{ glfn_dir }}"
-  register: dir_stat
+    state: directory
+    mode: '0775'
   when: glfn_dir is defined
-  failed_when:
-    - glfn_dir is defined
-    - not dir_stat.stat.exists
 
 - name: Create logs directory when not provided
   when: glfn_dir is not defined


### PR DESCRIPTION
Trying to fix [failed multibench job issue](https://www.distributed-ci.io/jobs/21e8918c-ca1c-4825-b2fc-def978033117/jobStates?sort=date&task=699a85a1-91cb-4b78-9a25-47ffcde7d403).

```
TASK [redhatci.ocp.get_logs_from_namespace : Check provided logs directory exists]
2025-01-03T03:54:27.566367
0s
task path: /usr/share/ansible/collections/ansible_collections/redhatci/ocp/roles/get_logs_from_namespace/tasks/main.yml:8
fatal: [jumphost]: FAILED! => {"changed": false, "failed_when_result": true, "stat": {"exists": false}}
```

Tested:
The job failed but the log gathering [worked out just fine](https://www.distributed-ci.io/jobs/91263427-5141-4b6c-95cd-26ee6261c304/jobStates?sort=date&task=e3de6d51-e3cb-4610-942d-25d78e7947b4):
```
TASK [redhatci.ocp.get_logs_from_namespace : Create the logs directory if defined but does not exist]
2025-01-06T10:19:59.388034
0s
task path: /home/dciteam/github/ansible-collection-redhatci-ocp-pr518-ac524850637cc28ea515e8ed40e713b4/collections/ansible_collections/redhatci/ocp/roles/get_logs_from_namespace/tasks/main.yml:8
changed: [jumphost] => {"changed": true, "gid": 1004, "group": "dciteam", "mode": "0775", "owner": "dciteam", "path": "/tmp/dci_logs.0ioye81e", "secontext": "unconfined_u:object_r:user_tmp_t:s0", "size": 6, "state": "directory", "uid": 1004}
```

Test-Hint: no-check