### PR TITLE
Add support to private repos in gitea role

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.23.EPOCH
+Version:        0.24.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -52,6 +52,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Tue Jan  7 2025 Tony Garcia <tonyg@redhat.com> - 0.24.EPOCH-VERS
+- Version bump for setup_gitea role updates
+
 * Wed Oct 16 2024 Tony Garcia <tonyg@redhat.com> - 0.23.EPOCH-VERS
 - Repurpose oc_setup role, into ocp_add_users role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.23.0
+version: 0.24.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/setup_gitea/README.md
+++ b/roles/setup_gitea/README.md
@@ -14,19 +14,20 @@ Role tasks:
 
 ## Variables
 
-| Variable              | Default     | Required | Description                                             |
-| --------------------- | ----------- | -------- | ------------------------------------------------------- |
-| sg_action             | install     | No       | Default role's action                                   |
-| sg_gitea_image        | docker.io/gitea/gitea:latest-rootless | No       | Default Gitea server image    |
-| sg_namespace          | gitea       | No       | Deployment Namespace                                    |
-| sg_url                | http://localhost:3000                 | No       | Root URL to the Gitea service |
-| sg_username           | *undefined* | No       | Gitea's initial username. Mandatory if the initial repository (sg_repository) is created. |
-| sg_password           | *undefined* | No       | Gitea's initial password. Mandatory if the initial user (sg_username) is created. |
-| sg_email              | *undefined* | No       | E-mail address for the initial user. Mandatory if the initial user (sg_username) is created. |
-| sg_repository         | *undefined* | No       | Initial repository name. Mandatory if an external repository to mirror (sg_repo_mirror_url) is set. |
-| sg_repo_branch        | main        | No       | Main branch in the initial repository                   |
-| sg_repo_mirror_url    | *undefined* | No       | Git URL to mirror into the initial repository           |
-| sg_repo_mirror_branch | main        | No       | Branch to mirror from the repository                    |
+| Variable              | Default                               | Required | Description
+| --------              | -------                               | -------- | -----------
+| sg_action             | install                               | No       | Default role's action
+| sg_gitea_image        | docker.io/gitea/gitea:latest-rootless | No       | Default Gitea server image
+| sg_namespace          | gitea                                 | No       | Deployment Namespace
+| sg_url                | http://localhost:3000                 | No       | Root URL to the Gitea service
+| sg_username           | *undefined*                           | No       | Gitea's initial username. Mandatory if the initial repository (sg_repository) is created.
+| sg_password           | *undefined*                           | No       | Gitea's initial password. Mandatory if the initial user (sg_username) is created.
+| sg_email              | *undefined*                           | No       | E-mail address for the initial user. Mandatory if the initial user (sg_username) is created.
+| sg_repository         | *undefined*                           | No       | Initial repository name. Mandatory if an external repository to mirror (sg_repo_mirror_url) is set.
+| sg_repo_branch        | main                                  | No       | Main branch in the initial repository
+| sg_repo_mirror_url    | *undefined*                           | No       | Git URL to mirror into the initial repository
+| sg_repo_mirror_branch | main                                  | No       | Branch to mirror from the repository
+| sg_repo_sshkey        | *undefined*                           | No       | The sshkey to clone the initial repository when the repo requires ssh authentication.
 
 ## Role requirements
   - The Ansible control node must have access to the registry where the `sg_gitea_image` is stored.

--- a/roles/setup_gitea/tasks/install.yml
+++ b/roles/setup_gitea/tasks/install.yml
@@ -150,10 +150,14 @@
       notify: Clear mirror temp dir
 
     - name: Clone reference repository
+      # Use sshkey file when provided, otherwise omit it in the module
+      vars:
+        keyfile: "{{ sg_repo_sshkey | default('') }}"
       ansible.builtin.git:
         dest: "{{ _sg_mirror_repo.path }}/mirror"
         repo: "{{ sg_repo_mirror_url }}"
         version: "{{ sg_repo_mirror_branch }}"
+        key_file: "{{ keyfile | length | ternary(keyfile, omit) }}"
 
     - name: Mirror the repository # noqa command-instead-of-module
       ansible.builtin.shell:


### PR DESCRIPTION
##### SUMMARY

Allows to the role to clone an initial repository that is private and requires ssh private key to clone it

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

- [x] TestDallasSno: ocp-4.16-sno-abi - https://www.distributed-ci.io/jobs/06cd1335-c133-49ee-8285-ea82364311db/jobStates

Test-Hints: no-check

