### PR TITLE
Added role setup_cluster_image_set

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Name | Description
 [redhatci.ocp.vendors.supermicro](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/vendors/supermicro/README.md) | Boots a supermicro machine to iso or disk via redfish
 [redhatci.ocp.vendors.zt](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/vendors/zt/README.md) | Boots a zt machine to iso or disk via redfish
 [redhatci.ocp.verify_tests](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/verify_tests/README.md) | Verification of tests based on rules
+[redhatci.ocp.ztp.setup_cluster_image_set](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/ztp/setup_cluster_image_set/README.md) | Create a clusterImageSet object in the hub cluster aligned with the values in the site config manifest.
 
 
 ## Plugins

--- a/roles/ztp/setup_cluster_image_set/README.md
+++ b/roles/ztp/setup_cluster_image_set/README.md
@@ -1,0 +1,35 @@
+# Setup Cluster Image Set
+
+This role creates a Cluster Image Set with the OCP release to install in a ZTP spoke cluster and matches it to the Cluster Image Set Name Ref value specified in the Site Config manifest in the GitOps repository.
+
+To achieve this, it receives the URL to the release image as in input variable and gets the name of the Cluster Image Set object from the Site Config manifest, after cloning the GitOps repository and reading the ClusterImageSetNameRef field in the manifest.
+
+This means the value in the ClusterImageSetNameRef has no effect or control on the actual OCP version to be deployed. The version is determined by the provided URL. Therefore, the ClusterImageSetNameRef may take any value, and this role will make sure a valid Cluster Image Set of that name exists in the hub cluster.
+
+It's worth mentioning that, for your spoke cluster deployment to work, the hub cluster must have network access to the provided release image URL.
+
+## Variables
+
+Variable               | Default | Required      | Description
+-----------------------|---------|---------------|-------------
+scis_repo_url          |         | yes           | URL to the repository with the GitOps manifests.
+scis_sites_path        |         | yes           | Path in the repository to the directory containing the site config manifests.
+scis_branch            | main    | no            | Branch to clone.
+scis_key_path          |         | when SSH git  |
+scis_username          |         | when HTTP git | Username to log into the repository.
+scis_password          |         | when HTTP git | Password to log into the repository.
+scis_release_image_url |         | yes           | URL to the OCP release image to use.
+
+## Usage example
+
+```yaml
+- name: Setup Cluster Image Sets
+  ansible.builtin.include_role:
+    name: redhatci.ocp.ztp.cluster_image_set
+  vars:
+    scis_repo_url: https://github.com/ztp/gitops.git
+    scis_site_configs_path: sites
+    scis_username: gituser
+    scis_password: gitpassword123!
+    scis_release_image_url: "quay.io/openshift-release-dev/ocp-release@sha256:80078b22e5e6e215141bd8300c0e0392ada651334a6f3f4fc340f6a8076d1166"
+```

--- a/roles/ztp/setup_cluster_image_set/defaults/main.yml
+++ b/roles/ztp/setup_cluster_image_set/defaults/main.yml
@@ -1,0 +1,1 @@
+scis_branch: main

--- a/roles/ztp/setup_cluster_image_set/tasks/main.yml
+++ b/roles/ztp/setup_cluster_image_set/tasks/main.yml
@@ -1,0 +1,75 @@
+- name: Identify the Git repo transport protocol
+  ansible.builtin.set_fact:
+    scis_repo_protocol_http: "{{ scis_repo_url | regex_search('https?://') | type_debug == 'str' }}"
+
+- name: "Validate required variables"
+  ansible.builtin.assert:
+    that:
+      - scis_repo_url is defined
+      - scis_repo_url | length > 0
+      - scis_sites_path is defined
+      - scis_sites_path | length > 0
+      - scis_branch is defined
+      - scis_branch | length > 0
+      - scis_release_image_url is defined
+      - scis_release_image_url | length > 0
+      - >
+        (scis_repo_protocol_http and
+        scis_username is defined and scis_username | length > 0 and
+        scis_password is defined and scis_password | length > 0) or
+        (scis_key_path is defined and scis_key_path | length > 0)
+
+- name: Process data from site config manifests
+  block:
+    - name: Create temporary directory
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: scis-
+      register: scis_tmp
+
+    - name: Git checkout (HTTP)
+      ansible.builtin.expect:
+        command: "git clone --single-branch --branch {{ scis_branch }} {{ scis_repo_url }} {{ scis_tmp.path }}/gitops"
+        responses:
+          Username: "{{ scis_username }}"
+          Password: "{{ scis_password }}"
+      no_log: true
+      when: scis_repo_protocol_http
+
+    - name: Git checkout (SSH)
+      ansible.builtin.git:
+        repo: "{{ scis_repo_url }}"
+        dest: "{{ scis_tmp.path }}/gitops"
+        version: "{{ scis_branch }}"
+        key_file: "{{ scis_key_path }}"
+      when: not scis_repo_protocol_http
+
+    - name: Get cluster image sets
+      ansible.builtin.shell:
+        cmd: |
+          set -eo pipefail
+          grep -r clusterImageSetNameRef {{ scis_tmp.path }}/gitops/{{ scis_sites_path }} | awk '{ print $NF }' | sed -e 's/"//g'
+      register: scis_cluster_image_sets_output
+
+  always:
+    - name: Delete temporary directory
+      ansible.builtin.file:
+        path: "{{ scis_tmp.path }}"
+        state: absent
+
+- name: Set list of ClusterImageSets
+  ansible.builtin.set_fact:
+    scis_cluster_image_sets: "{{ scis_cluster_image_sets_output.stdout_lines | unique }}"
+
+- name: Create requested ClusterImageSets
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: hive.openshift.io/v1
+      kind: ClusterImageSet
+      metadata:
+        name: "{{ _scis_set }}"
+      spec:
+        releaseImage: "{{ scis_release_image_url }}"
+  loop: "{{ scis_cluster_image_sets }}"
+  loop_control:
+    loop_var: _scis_set


### PR DESCRIPTION
##### SUMMARY

When deploying a ZTP GitOps spoke cluster, the cluster image set is specified in the site config manifest.

This field must match the value of any of the cluster image set objects in the hub cluster.

This role, clones and reads the site config manifests to retrieve the cluster image sets defined there, and creates the object in the hub cluster, so it's made available before hand in order to deploy the spoke clusters.

##### ISSUE TYPE

- Enhanced Feature

##### Tests


- [ ] [TestDallas: ocp-4.16-ztp-sno](https://www.distributed-ci.io/jobs/cb336400-5c7e-4b3a-932c-58c2f8a72922/jobStates?sort=date)
- [x] [TestBos2: acm-hub ztp-spoke-vm-4.16](https://www.distributed-ci.io/jobs/6d95633c-2ee4-4017-ba11-2fc99b41d445/jobStates?sort=date)

---

Testing with commands:

Dallas:
```
dci-pipeline-check https://github.com/dci-labs/inventories/pull/251 -p sno ocp-4.16-ztp-sno openshift-ztp-sno:ansible_extravars=hub_kubeconfig_path:/home/dciteam/clusterconfigs-sno2/kubeconfig
```

BOS2:
```
dci-pipeline-check 32870 -p mno_baremetal acm-hub-baremetal ztp-spoke-baremetal
```
