### PR TITLE
create_vms: add additional_virt_install_options arg to template

### DIFF
--- a/roles/create_vms/templates/create_vm.sh.j2
+++ b/roles/create_vms/templates/create_vm.sh.j2
@@ -32,6 +32,9 @@ virt-install \
     --features smm=on \
     {% endif %}
     {% endif %}
+    {% if additional_virt_install_options is defined %}
+    {{ additional_virt_install_options }}
+    {% endif %}
     --events on_reboot=restart \
     --autostart \
     --print-xml > /tmp/{{item.name}}.xml


### PR DESCRIPTION
##### SUMMARY
Updated the create_vms role by adding the additional_virt_install_options argument to the template. This enhancement improves the role's flexibility, enabling the addition of any extra arguments to the installation script.

Test-Hints: no-check