### PR TITLE
Deprecate assisted on-prem related roles

### DIFF
--- a/roles/add_day2_node/README.md
+++ b/roles/add_day2_node/README.md
@@ -1,3 +1,5 @@
 # add_day2_node
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Adds as nodes to a pre-existing cluster using a pre-existing on-prem assisted installer instance.

--- a/roles/add_day2_node/tasks/main.yml
+++ b/roles/add_day2_node/tasks/main.yml
@@ -1,3 +1,12 @@
+---
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name: "Install node: {{inventory_hostname }}"
   delegate_to: bastion
   block:

--- a/roles/create_cluster/README.md
+++ b/roles/create_cluster/README.md
@@ -1,3 +1,5 @@
 # create_cluster
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Creates a cluster definition in an on-prem assisted installer instance.

--- a/roles/create_cluster/tasks/main.yml
+++ b/roles/create_cluster/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for create_cluster
 
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name: Set body for create cluster
   set_fact:
     # - `ingress_vip` is not provided in the request body because the value

--- a/roles/create_day2_cluster/README.md
+++ b/roles/create_day2_cluster/README.md
@@ -1,3 +1,5 @@
 # create_day2_cluster
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Creates an add-hosts cluster definition in an on-prem assisted installer instance which can be used to add day2 nodes to the cluster

--- a/roles/create_day2_cluster/tasks/main.yml
+++ b/roles/create_day2_cluster/tasks/main.yml
@@ -1,3 +1,12 @@
+---
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name: Create day 2 cluster
   uri:
     url: "{{ ASSISTED_INSTALLER_BASE_URL }}/clusters/import"

--- a/roles/generate_discovery_iso/README.md
+++ b/roles/generate_discovery_iso/README.md
@@ -1,3 +1,5 @@
 # generate_discovery_iso
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Creates the discovery ISO for a pre-existing cluster definition using a pre-existing on-prem assisted installer

--- a/roles/generate_discovery_iso/tasks/main.yml
+++ b/roles/generate_discovery_iso/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for generate_discovery_iso
 
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name: Set discovery iso body
   set_fact:
     request_body:

--- a/roles/get_image_hash/README.md
+++ b/roles/get_image_hash/README.md
@@ -1,5 +1,7 @@
 # Get image hash role
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Uses `skopeo` to produce a dictionary of image digests for images defined in `images_to_get_hash_for`.
 
 ## Requirements

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -1,3 +1,12 @@
+---
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name: check skopeo is installed
   shell: /usr/bin/skopeo --version
 

--- a/roles/install_cluster/README.md
+++ b/roles/install_cluster/README.md
@@ -1,3 +1,5 @@
 # install_cluster
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
  Waits for nodes to be discovered by the on-prem assisted installer then then patches cluster networking and triggers the install process

--- a/roles/install_cluster/tasks/main.yml
+++ b/roles/install_cluster/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for install_cluster
 
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name: Join list for workers and masters
   set_fact:
     nodes: "{{ groups['masters'] + groups['workers'] | default([]) }}"

--- a/roles/monitor_cluster/README.md
+++ b/roles/monitor_cluster/README.md
@@ -1,3 +1,5 @@
 # monitor_cluster
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Tracks the progress of the cluster installation via an on-prem assisted installer

--- a/roles/monitor_cluster/tasks/main.yml
+++ b/roles/monitor_cluster/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for monitor_cluster
 
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 # Monitor cluster installation
 - name: Wait for up to 90 minutes for the cluster to report as installed
   uri:

--- a/roles/monitor_host/README.md
+++ b/roles/monitor_host/README.md
@@ -1,3 +1,5 @@
 # monitor_host
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Tracks host status during the installation via an on-prem assisted installer and triggers a reboot to disk if needed

--- a/roles/monitor_host/tasks/main.yml
+++ b/roles/monitor_host/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for monitor_cluster
 
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name : Get cluster status during installation
   uri:
     url: "{{ URL_ASSISTED_INSTALLER_CLUSTER }}"

--- a/roles/mount_discovery_iso_for_pxe/tasks/main.yml
+++ b/roles/mount_discovery_iso_for_pxe/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: prepare PXE
   become: true
   block:
+
     - name: Install syslinux
       package:
         name: syslinux

--- a/roles/patch_cluster/README.md
+++ b/roles/patch_cluster/README.md
@@ -1,5 +1,7 @@
 # patch_cluster
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Patches definition of a cluster in an on-prem assisted installer.
 
 Configures network type, image source redirects for disconnected deployments and adds custom manifests.

--- a/roles/patch_cluster/tasks/main.yml
+++ b/roles/patch_cluster/tasks/main.yml
@@ -1,3 +1,11 @@
+---
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
 - name: Get install-config file
   uri:
     url: "{{ URL_ASSISTED_INSTALLER_CLUSTERS }}/{{ patch_cluster_id }}/install-config"

--- a/roles/patch_host_config/README.md
+++ b/roles/patch_host_config/README.md
@@ -1,3 +1,5 @@
 # patch_host_config
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Patches host definition in pre-existing on-prem assisted installer

--- a/roles/patch_host_config/tasks/main.yml
+++ b/roles/patch_host_config/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 # tasks file for patch_host_config
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
 
 - name: Ensure host has inventory
   when: patch_host_config_discovered_host.inventory is not defined

--- a/roles/post_install/README.md
+++ b/roles/post_install/README.md
@@ -1,3 +1,5 @@
 # post_install
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Waits for the cluster to become operational then copies the kubeconfig and kubeadmin

--- a/roles/post_install/tasks/main.yml
+++ b/roles/post_install/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name: Fetch kubeconfig for assisted installer
   ansible.builtin.include_tasks:
     file: fetch_kubeconfg_assisted_installer.yml

--- a/roles/setup_assisted_installer/README.md
+++ b/roles/setup_assisted_installer/README.md
@@ -1,3 +1,5 @@
 # setup_assisted_installer
 
+⚠️ **This Ansible role is deprecated and will be removed in the future.**
+
 Deploys an on-prem assisted installer

--- a/roles/setup_assisted_installer/tasks/main.yml
+++ b/roles/setup_assisted_installer/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Deprecation warning
+  ansible.builtin.debug:
+    msg:
+      - "[DEPRECATION WARNING]: This role will be removed from the collection in the future."
+      - "Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg."
+  when:
+    - lookup('ansible.builtin.config', 'DEPRECATION_WARNINGS')
+
 - name: Setup AI Host
   become: True
   block:


### PR DESCRIPTION
##### SUMMARY

Deprecate the following roles, those have been confirmed not been related to ABI and not used by DCI automation.

create_cluster
generate_discovery_iso
get_image_hash
install_cluster
monitor_cluster
monitor_host
patch_host_config
post_install
setup_assisted_installer
patch_cluster
create_day2_cluster
add_day2_node

##### ISSUE TYPE
- New or Enhanced Feature

##### Tests

Test-Hint: no-check
