### PR TITLE
Update cluster compare supported version

### DIFF
--- a/roles/cluster_compare/README.md
+++ b/roles/cluster_compare/README.md
@@ -12,7 +12,7 @@ Features
 
 ## Requirements
 
-  - A reachable OCP cluster running ocp-4.14 or newer.
+  - A reachable OCP cluster running ocp-4.16 or newer.
   - A valid KUBECONFIG file is accessible. The KUBECONFIG file path must be provided as an environment variable.
 
 ## Variables

--- a/roles/cluster_compare/defaults/main.yml
+++ b/roles/cluster_compare/defaults/main.yml
@@ -7,6 +7,6 @@
 # cc_compare_container_executable: "/usr/share/openshift/linux_amd64/kube-compare.rhel8"
 # cc_report_creator_version: "latest"
 cc_infra_type: core
-cc_ocp_supported: 4.14
+cc_ocp_supported: 4.16
 cc_logging: true
 ...


### PR DESCRIPTION
##### SUMMARY

There are no manifest.yml for cluster_compare for OCP <=4.16.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change


##### Tests
- [x ] TestBos2: virt - https://www.distributed-ci.io/jobs/27fd4077-a88a-4296-aada-617a4381d785/jobStates


Test-Hint: no-check

