### PR TITLE
multibench: Create TMPDIR directory if it's defined

### DIFF
--- a/roles/multibench_run/tasks/main.yml
+++ b/roles/multibench_run/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Ensure tmp directory existes"
+- name: "Ensure tmp directory exists"
   ansible.builtin.file:
     state: directory
     path: "{{ ansible_env.TMPDIR }}"

--- a/roles/multibench_run/tasks/main.yml
+++ b/roles/multibench_run/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: "Ensure tmp directory existes"
+  ansible.builtin.file:
+    state: directory
+    path: "{{ ansible_env.TMPDIR }}"
+    mode: "0755"
+  when: ansible_env.TMPDIR is defined
+
 - name: Check if multibench host has the crucible binaries
   ansible.builtin.shell: >
     crucible help


### PR DESCRIPTION
##### SUMMARY

By default, tmp dir is created in the $HOME/tmp directory, 
https://github.com/redhat-cip/dci-openshift-app-agent/blob/master/plays/check_kubeconfig.yml#L32-L36

In the multibench use case it also needs to be created in the multibench host.


##### ISSUE TYPE

- Bug
