### PR TITLE
Fix Unit test output + TELCOV10N-472 related broken test

### DIFF
--- a/tests/unit/filter/test_ocp_compatibility.py
+++ b/tests/unit/filter/test_ocp_compatibility.py
@@ -53,19 +53,18 @@ class TestOcpCompatibility(unittest.TestCase):
 
             expected_result = {
                 "4.11": "compatible",
-                "4.12": " ".join([
-                    "events.v1beta1.events.k8s.io (service accounts: system:serviceaccount:default:",
-                    "eventtest-operator-service-account), podsecuritypolicies.v1beta1.policy ",
-                    "(service accounts: system:kube-controller-manager)"
+                "4.12": ", ".join([
+                    "events.v1beta1.events.k8s.io (service accounts: system:serviceaccount:default:eventtest-operator-service-account)",
+                    "podsecuritypolicies.v1beta1.policy (service accounts: system:kube-controller-manager)"
                 ]),
-                "4.13": " ".join([
-                    "events.v1beta1.events.k8s.io (service accounts: system:serviceaccount:default:",
-                    "eventtest-operator-service-account), podsecuritypolicies.v1beta1.policy ",
-                    "(service accounts: system:kube-controller-manager), flowschemas.v1beta1.",
-                    "flowcontrol.apiserver.k8s.io (service accounts: system:serviceaccount:",
-                    "openshift-cluster-version:default), prioritylevelconfigurations.v1beta1.",
-                    "flowcontrol.apiserver.k8s.io (service accounts: system:serviceaccount:",
-                    "openshift-cluster-version:default)"
+                "4.13": ", ".join([
+                    "events.v1beta1.events.k8s.io (service accounts: system:serviceaccount:default:eventtest-operator-service-account)",
+                    "podsecuritypolicies.v1beta1.policy (service accounts: system:kube-controller-manager)",
+                    "flowschemas.v1beta1.flowcontrol.apiserver.k8s.io (service accounts: system:serviceaccount:openshift-cluster-version:default)",
+                    " ".join([
+                        "prioritylevelconfigurations.v1beta1.flowcontrol.apiserver.k8s.io",
+                        "(service accounts: system:serviceaccount:openshift-cluster-version:default)",
+                    ])
                 ])
             }
 


### PR DESCRIPTION
- fixes #531 (fix test_ocp_compatibility)

##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->
reorganize expected text to match the actual output (changes to APIs cause this)
<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #531 
##### ISSUE TYPE

regression
<!-- Pick one below and delete the other: -->
- Regression Bug

##### Tests

<!-- Document the tests for this change, if any -->
running before:
```
ansible-test units --verbose --docker --python 3.11 --color
```
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->
- [ ]  `tests/unit/filter/test_ocp_compatibility.py::TestOcpCompatibility::test_filter_with_deprecated_api_in_non_empty_list`

After applying, only the warning remains:
```
 ansible-test units --verbose --docker --python 3.11 --color
Configured locale: en_US.UTF-8
Loaded configuration: tests/config.yml
Run command: podman -v
Detected "podman" container runtime version: podman version 5.3.1
Run command: podman system connection list --format=json
Run command: podman info --format '{{ json . }}'
Run command: podman version --format '{{ json . }}'
Container runtime: podman client=5.3.1 server=5.3.1 cgroup=v2
Assuming Docker is available on localhost.
Run command: podman image inspect quay.io/ansible/ansible-test-utility-container:3.1.0
Run command: podman run --volume /sys/fs/cgroup:/probe:ro --name ansible-test-probe-NdFtEWCV --rm quay.io/ansible/ansible-test-utility-container:3.1.0 sh -c 'audit-status && cat /proc/sys/fs/nr_open && ulimit -Hn && (cat /pro ...
Container host audit status: EPERM (-1)
Container host max open files: 1048576
Container loginuid: 4294967295 (not set)
Starting new "ansible-test-controller-NdFtEWCV" container.
Run command: podman image inspect quay.io/ansible/default-test-container:10.9.0
Run command: podman network inspect podman
Run command: podman run --tmpfs /tmp:exec --tmpfs /run:exec --tmpfs /run/lock --cap-add SYS_CHROOT --cap-add AUDIT_WRITE --systemd always --cgroupns private -dt --ulimit nofile=10240 --name ansible-test-controller-NdFtEWCV -- ...
Adding "ansible-test-controller-NdFtEWCV" to container database.
Run command: podman container inspect ansible-test-controller-NdFtEWCV
Stream command with data: podman exec -i ansible-test-controller-NdFtEWCV /bin/sh
Bootstrapping Python 3.11 at: /usr/bin/python3.11
Scanning collection root: /Users/makovgan/src/github.com/workspace/collections/ansible_collections
junit_xml
Created a 9115653 byte payload archive containing 2076 files in 0 seconds.
Run command with stdin: podman exec -i ansible-test-controller-NdFtEWCV tar oxzf - -C /root
Creating container database.
Run command: podman exec ansible-test-controller-NdFtEWCV mkdir -p /root/ansible_collections/redhatci/ocp/tests/output/junit /root/ansible_collections/redhatci/ocp/tests/output/coverage
Run command: podman exec ansible-test-controller-NdFtEWCV chmod 777 /root/ansible_collections/redhatci/ocp/tests/output/junit /root/ansible_collections/redhatci/ocp/tests/output/coverage
Run command: podman exec ansible-test-controller-NdFtEWCV chmod 755 /root
Run command: podman exec ansible-test-controller-NdFtEWCV useradd pytest --create-home
Stream command: podman exec ansible-test-controller-NdFtEWCV /usr/bin/env ANSIBLE_TEST_CONTENT_ROOT=/root/ansible_collections/redhatci/ocp LC_ALL=en_US.UTF-8 /usr/bin/python3.11 /root/ansible/bin/ansible-test units --containe ...
Configured locale: en_US.UTF-8
Parsing container database.
Installing requirements for Python 3.11
Stream command with data: /usr/bin/python3.11
Execute command: /usr/bin/python3.11 /tmp/ansible-test-wzfmm7_y-pip.py install --disable-pip-version-check -r requirements/ansible.txt -r requirements/units.txt -c requirements/constraints.txt
Execute command: /usr/bin/python3.11 /tmp/ansible-test-wzfmm7_y-pip.py install --disable-pip-version-check -r tests/unit/requirements.txt -c requirements/constraints.txt
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<pip._vendor.urllib3.connection.HTTPSConnection object at 0xffffbbd290d0>: Failed to establish a new connection: [Errno -2] Name or service not known')': /simple/junit-xml/
Collecting junit_xml (from -r tests/unit/requirements.txt (line 1))
  Downloading junit_xml-1.9-py2.py3-none-any.whl.metadata (3.2 kB)
Collecting semver (from -r tests/unit/requirements.txt (line 2))
  Downloading semver-3.0.2-py3-none-any.whl.metadata (5.0 kB)
Collecting six (from junit_xml->-r tests/unit/requirements.txt (line 1))
  Downloading six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Downloading junit_xml-1.9-py2.py3-none-any.whl (7.1 kB)
Downloading semver-3.0.2-py3-none-any.whl (17 kB)
Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: six, semver, junit_xml
Successfully installed junit_xml-1.9 semver-3.0.2 six-1.17.0
Run command: /usr/bin/python3.11 /root/ansible/test/lib/ansible_test/_util/target/tools/yamlcheck.py
Run command: podman container inspect ansible-test-controller-NdFtEWCV
Run command: podman network disconnect podman ansible-test-controller-NdFtEWCV
Stream command: podman exec --user pytest ansible-test-controller-NdFtEWCV /usr/bin/env ANSIBLE_TEST_CONTENT_ROOT=/root/ansible_collections/redhatci/ocp LC_ALL=en_US.UTF-8 /usr/bin/python3.11 /root/ansible/bin/ansible-test un ...
Configured locale: en_US.UTF-8
Unit test controller with Python 3.11
Initializing "/tmp/ansible-test-5k7mraoi-injector" as the temporary injector directory.
Injecting "/tmp/python-j4vh9gme-ansible/python" as a execv wrapper for the "/usr/bin/python3.11" interpreter.
Stream command: pytest -r a -n auto --color yes -p no:cacheprovider -c /root/ansible/test/lib/ansible_test/_data/pytest/config/default.ini --junit-xml /root/ansible_collections/redhatci/ocp/tests/output/junit/python3.11-contr ...
============================= test session starts ==============================
platform linux -- Python 3.11.10, pytest-8.3.3, pluggy-1.5.0 -- /usr/bin/python3.11
rootdir: /root/ansible_collections/redhatci/ocp
configfile: ../../../ansible/test/lib/ansible_test/_data/pytest/config/default.ini
plugins: mock-3.14.0, xdist-3.6.1
created: 4/4 workers
4 workers [2 items]

scheduling tests via LoadScheduling

tests/unit/filter/test_ocp_compatibility.py::TestOcpCompatibility::test_filter_with_deprecated_api_in_non_empty_list
tests/unit/filter/test_ocp_compatibility.py::TestOcpCompatibility::test_filter_with_no_deprecated_api_with_empty_array
[gw1] [ 50%] PASSED tests/unit/filter/test_ocp_compatibility.py::TestOcpCompatibility::test_filter_with_no_deprecated_api_with_empty_array
[gw0] [100%] PASSED tests/unit/filter/test_ocp_compatibility.py::TestOcpCompatibility::test_filter_with_deprecated_api_in_non_empty_list

=============================== warnings summary ===============================
tests/unit/filter/test_ocp_compatibility.py::TestOcpCompatibility::test_filter_with_deprecated_api_in_non_empty_list
tests/unit/filter/test_ocp_compatibility.py::TestOcpCompatibility::test_filter_with_no_deprecated_api_with_empty_array
  /usr/local/lib/python3.11/dist-packages/junit_xml/__init__.py:268: DeprecationWarning: Testsuite.to_file is deprecated. It will be removed in version 2.0.0. Use function to_xml_report_file
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated xml file: /root/ansible_collections/redhatci/ocp/tests/output/junit/python3.11-controller-units.xml -
======================== 2 passed, 2 warnings in 0.19s =========================
Run command with stdout: podman exec --user pytest -i ansible-test-controller-NdFtEWCV sh -c 'tar cf - -C /root/ansible_collections/redhatci/ocp/tests --exclude .tmp output | gzip'
Run command with stdin: tar oxzf - -C /Users/makovgan/src/github.com/workspace/collections/ansible_collections/redhatci/ocp/tests
Run command: podman stop --time 0 ansible-test-controller-NdFtEWCV
Run command: podman rm ansible-test-controller-NdFtEWCV
```

---

<!-- Include the test and dependencies for this change -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->


<!-- Examples:

Test-Hint: no-check
Depends-on: https://path/to/depending/change

-->

Test-Hints: no-check