### PR TITLE
generate_agent_iso | Explicitly set PATH env var when generating the agent ISO

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        0.26.EPOCH
+Version:        0.27.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -53,6 +53,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Fri Jan 17 2025 Ramon Perez <raperez@redhat.com> - 0.27.EPOCH-VERS
+- Version bump for updated generate_agent_iso role
+
 * Fri Jan 10 2025 Beto Rdz <joserod@redhat.com> - 0.26.EPOCH-VERS
 - Add cluster_compare role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 0.3.2147483647
-version: 0.26.0
+version: 0.27.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/generate_agent_iso/README.md
+++ b/roles/generate_agent_iso/README.md
@@ -1,3 +1,34 @@
 # generate_agent_iso
 
 Creates the boot ISO using openshift_installer's agent sub-command
+
+## Role Variables
+
+Name                           | Type   | Required | Default                                          | Description
+------------------------------ | ------ | -------- | ------------------------------------------------ | ------------
+gai_cluster_name               | string | yes      | -                                                | Cluster name, typically defined in the inventory file.
+gai_repo_root_path             | string | yes      | -                                                | Root path to place all files and folders required to build the agent ISO.
+gai_pull_secret                | string | yes      | -                                                | Pull secret to download images required to build the agent ISO.
+gai_agent_based_installer_path | string | yes      | -                                                | Path to find `openshift-install` binary
+gai_discovery_iso_name         | string | yes      | -                                                | Relateive path to discovery ISO name, typically defined in ABI inventories.
+gai_path_var                   | string | no       | "/sbin:/usr/sbin:/usr/local/bin/"                | String to append to `PATH` environment variable when creating the agent ISO.
+gai_generated_dir              | string | no       | "{{ gai_repo_root_path }}/generated"             | Directory to place pull secret, using it afterwards as value for `XDG_RUNTIME_DIR` environment variable when creating the agent ISO.
+gai_manifests_dir              | string | no       | "{{ gai_generated_dir }}/{{ gai_cluster_name }}" | Directory to save the manifests that are lately used to save the generated ISO.
+gai_iso_download_dest_path     | string | no       | "/opt/http_store/data"                           | Root directory to eventually save the generated agent ISO.
+gai_arch                       | string | no       | "x86_64"                                         | Cluster architecture.
+
+## Example
+
+You can call this role in the following way, as an example of usage:
+
+```yaml
+- name: Generate agent ISO
+  vars:
+    gai_cluster_name: "my-cluster"
+    gai_repo_root_path: "/path/to/root_path"
+    gai_pull_secret: "/path/to/pull_secret"
+    gai_agent_based_installer_path: "/path/to/openshift-install"
+    gai_discovery_iso_name: "relative/path/to/discovery.iso"
+  ansible.builtin.include_role:
+    name: redhatci.ocp.generate_agent_iso
+```

--- a/roles/generate_agent_iso/defaults/main.yml
+++ b/roles/generate_agent_iso/defaults/main.yml
@@ -1,8 +1,5 @@
-generated_dir: "{{ repo_root_path }}/generated"
-manifests_dir: "{{ generated_dir }}/{{ cluster_name }}"
-download_agent_dest_file: "{{ discovery_iso_name }}"
-download_dest_path: "{{ iso_download_dest_path | default('/opt/http_store/data') }}"
-arch: x86_64
-version_filter: "[?(openshift_version == '{{ openshift_version }}') && (cpu_architecture == '{{ arch }}')]"
-release_image: "{{ (assisted_installer_release_images | json_query(version_filter))[0].url }}"
-use_local_mirror_registry: false
+gai_path_var: "/sbin:/usr/sbin:/usr/local/bin/"
+gai_generated_dir: "{{ gai_repo_root_path }}/generated"
+gai_manifests_dir: "{{ gai_generated_dir }}/{{ gai_cluster_name }}"
+gai_iso_download_dest_path: "/opt/http_store/data"
+gai_arch: x86_64

--- a/roles/generate_agent_iso/tasks/main.yml
+++ b/roles/generate_agent_iso/tasks/main.yml
@@ -1,14 +1,29 @@
+---
+- name: Assert the required variables are defined
+  ansible.builtin.assert:
+    that:
+      - gai_cluster_name is defined
+      - gai_cluster_name | length > 0
+      - gai_repo_root_path is defined
+      - gai_repo_root_path | length > 0
+      - gai_pull_secret is defined
+      - gai_pull_secret | length > 0
+      - gai_agent_based_installer_path is defined
+      - gai_agent_based_installer_path | length > 0
+      - gai_discovery_iso_name is defined
+      - gai_discovery_iso_name | length > 0
+
 - name: Create podman auth dir
   ansible.builtin.file:
-    path: "{{ generated_dir }}/containers/"
+    path: "{{ gai_generated_dir }}/containers/"
     state: directory
     mode: '0755'
     recurse: true
 
 - name: Copy pull_secrets file.
   ansible.builtin.copy:
-    content: "{{ pull_secret }}"
-    dest: "{{ generated_dir }}/containers/auth.json"
+    content: "{{ gai_pull_secret }}"
+    dest: "{{ gai_generated_dir }}/containers/auth.json"
     mode: "0644"
     remote_src: true
 
@@ -20,10 +35,11 @@
 
 - name: Generate agent ISO
   ansible.builtin.command:
-    cmd: "{{ agent_based_installer_path }} --log-level=debug agent create image"
-    chdir: "{{ manifests_dir }}"
+    cmd: "{{ gai_agent_based_installer_path }} --log-level=debug agent create image"
+    chdir: "{{ gai_manifests_dir }}"
   environment:
-    XDG_RUNTIME_DIR: "{{ generated_dir }}"
+    XDG_RUNTIME_DIR: "{{ gai_generated_dir }}"
+    PATH: "{{ ansible_env.PATH }}:{{ gai_path_var }}"
   changed_when: _gai_gen_iso.rc != 0
   register: _gai_gen_iso
   retries: 3
@@ -37,12 +53,12 @@
   block:
     - name: Create discovery directory
       ansible.builtin.file:
-        path: "{{ download_dest_path }}/{{ download_agent_dest_file | dirname }}"
+        path: "{{ gai_iso_download_dest_path }}/{{ gai_discovery_iso_name | dirname }}"
         recurse: true
         state: directory
 
     - name: Copy agent iso to discovery directory
       ansible.builtin.copy:
-        src: "{{ manifests_dir }}/agent.{{ arch }}.iso"
-        dest: "{{ download_dest_path }}/{{ download_agent_dest_file }}"
+        src: "{{ gai_manifests_dir }}/agent.{{ gai_arch }}.iso"
+        dest: "{{ gai_iso_download_dest_path }}/{{ gai_discovery_iso_name }}"
         mode: '0644'


### PR DESCRIPTION
##### SUMMARY

We've seen cases like [this one](https://www.distributed-ci.io/jobs/33c420f6-7535-498b-80e5-4cde52841837/jobStates?sort=date&task=261cd5a0-62ba-4bea-a91e-0fd109164904), where the agent ISO generation is not working because `oc` binary cannot be found in `PATH`, but in fact it is. This could be because `PATH` env var seen by Ansible has a different value than running it locally.

Let's explicitly set PATH env var in this case.

Also, refactoring the whole role to follow best practices from redhatci.ocp collection.

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestBos2: abi - https://www.distributed-ci.io/jobs/2970906d-7043-477f-86ab-0d678d1aee14/jobStates
- [x] deployment where we found the issue and now it's working - https://www.distributed-ci.io/jobs/2fa10b28-4881-4ab4-b4c0-0fd5a174f310/jobStates?sort=date&task=d244c1b7-c67e-4b48-b88e-6c384a0604c1

Test-Hints: no-check

build-depends: 32860