### PR TITLE
[ocp_add_users] add retries in add user operations

### DIFF
--- a/roles/ocp_add_users/tasks/add-users.yml
+++ b/roles/ocp_add_users/tasks/add-users.yml
@@ -26,6 +26,10 @@
       type: Opaque
       data:
         htpasswd: "{{ _all_users_text | b64encode }}"
+  register: _oau_result
+  retries: 6
+  delay: 10
+  until: _oau_result is not failed
   no_log: "{{ oau_secure_log | bool }}"
 
 - name: Setup htpasswd auth IdP backend in OCP
@@ -45,3 +49,7 @@
             htpasswd:
               fileData:
                 name: "{{ oau_secret_name }}"
+  register: _oau_result
+  retries: 6
+  delay: 10
+  until: _oau_result is not failed


### PR DESCRIPTION
##### SUMMARY

Sometimes SNO clusters fail at this stage when adding users, adding retries in case the API was not available.

##### ISSUE TYPE

- minimal improvement

##### Tests

- [ ] TestBos2Sno: abi-sno - <JobURL>

---


TestHints: no-check