### PR TITLE
Add more time to pull the nfs-provisioner images

### DIFF
--- a/roles/nfs_external_storage/tasks/main.yml
+++ b/roles/nfs_external_storage/tasks/main.yml
@@ -213,7 +213,7 @@
     label_selectors:
       - app=nfs-client-provisioner
   register: nfs_pod
-  retries: 15
+  retries: 30
   delay: 10
   until:
     - nfs_pod.resources is defined


### PR DESCRIPTION
##### SUMMARY

This image pulling is taking to much time

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Nominal change

##### Tests

- [ ] TestBos2: virt


TestBos2: virt
