### PR TITLE
Certsuite v5.4.2

### DIFF
--- a/roles/k8s_best_practices_certsuite/README.md
+++ b/roles/k8s_best_practices_certsuite/README.md
@@ -4,6 +4,8 @@ This role encapsulates the logic for the [Red Hat Best Practices Test Suite for 
 
 Before executing the certsuite, it's important to label the pods to test using the auto-discovery feature. You can do it manually or programmatically. An example of this can be found in [this example from DCI](https://github.com/redhat-cip/dci-openshift-app-agent/blob/master/samples/tnf_test_example/README.md).
 
+> Disclaimer: From Certsuite [v5.4.2](https://github.com/redhat-best-practices-for-k8s/certsuite/releases/tag/v5.4.2), it is possible to automatically upload the tar.gz results files directly to the Red Hat Connect API if you have a valid API Key and Project ID. This feature is still NOT supported by this role and it is under evaluation.
+
 ## Variables
 
 Name                                    | Default                                                                                                                                                                                                                                 | Description

--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.4.1
+kbpc_version: v5.4.2
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
##### SUMMARY

- Bump to certsuite v5.4.2
- Added disclaimer regarding the automatic submission of certsuite results, still not supported in the automation

##### ISSUE TYPE

Version bump

##### Tests

- [x] TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[] - https://www.distributed-ci.io/jobs/e1b4438f-09ca-43aa-87d0-b9e8d0676502/jobStates

Test-Hints: no-check
