### PR TITLE
Use Hydra CNF submission provided by k8s_best_practices_certsuite

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -14,6 +14,10 @@ kbpc_test_config:
 kbpc_accepted_kernel_taints: []
 kbpc_services_ignore_list: []
 kbpc_allow_preflight_insecure: false
+# CWE Hydra apikey for automated results submission
+# It must be created manually in Connect UI
+# Do not forget to define kbpc_cwe_project_id as well
+kbpc_cwe_apikey_path: "/opt/cache/cwe-apikey.txt"
 # If this is not set to true, JUnit file will not be created
 kbpc_enable_xml_creation: true
 kbpc_non_intrusive_only: false

--- a/roles/k8s_best_practices_certsuite/tasks/tests.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/tests.yml
@@ -11,6 +11,20 @@
     state: directory
     mode: '0755'
 
+- name: Tasks related to Certsuite submission through CWE Hydra API
+  when: kbpc_version is version('v5.4.2', '>=') or kbpc_version == 'HEAD'
+  block:
+    - name: Verify if the CWE Hydra API key file exists
+      ansible.builtin.stat:
+        path: "{{ kbpc_cwe_apikey_path }}"
+      register: _kbpc_cwe_apikey_file
+
+    - name: Set kbpc_cwe_apikey if the token file exists
+      ansible.builtin.set_fact:
+        kbpc_cwe_apikey: "{{ lookup('file', kbpc_cwe_apikey_path) }}"
+      when: _kbpc_cwe_apikey_file.stat.exists
+      no_log: true
+
 - name: Template config file
   ansible.builtin.template:
     src: "templates/certsuite_config.yml.j2"

--- a/roles/k8s_best_practices_certsuite/templates/certsuite_config.yml.j2
+++ b/roles/k8s_best_practices_certsuite/templates/certsuite_config.yml.j2
@@ -50,6 +50,17 @@ servicesignorelist:
   - {{ item }}
 {% endfor %}
 
+{% if kbpc_version is version('v5.4.2', '>=') or kbpc_version == 'HEAD' %}
+{% if kbpc_cwe_apikey is defined and kbpc_cwe_project_id is defined %}
+connectAPIConfig:
+  baseURL: "https://access.redhat.com/hydra/cwe/rest/v1.0"
+  apiKey: {{ kbpc_cwe_apikey }}
+  projectID: {{ kbpc_cwe_project_id }}
+  proxyURL: ""
+  proxyPort: ""
+{% endif %}
+{% endif %}
+
 ## fields below are not currently used, leaving placeholder in case they were needed in the future
 #managedDeployments:
 


### PR DESCRIPTION
##### SUMMARY

Use new feature from certsuite included in v5.4.2 to be able to submit cert result to an existing CNF project using Hydra API.

##### ISSUE TYPE

- New feature

##### Tests

- [x] Successful submission on a dummy cert project: https://www.distributed-ci.io/jobs/77fd4bd2-5d4e-49a4-9c8f-6b152a8d6cab/jobStates. Details here: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/540#issuecomment-2621040773

Test-Hints: no-check
