### PR TITLE
Retry ABI installation monitoring

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        1.0.EPOCH
+Version:        1.1.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -52,6 +52,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Mon Jan 27 2025 Ramon Perez <raperez@redhat.com> - 1.1.EPOCH-VERS
+- Version bump for updated monitor_agent_based_installer role
+
 * Tue Jan 21 2025 Tony Garcia <tonyg@redhat.com> - 1.0.EPOCH-VERS
 - Removes community.kubernetes collection as dependency
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 1.3.2147483647
-version: 1.0.0
+version: 1.1.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/monitor_agent_based_installer/defaults/main.yml
+++ b/roles/monitor_agent_based_installer/defaults/main.yml
@@ -3,3 +3,6 @@ manifests_dir: "{{ generated_dir}}/{{ cluster_name }}"
 
 agent_based_installer_bootstrap_node: "{{ groups['masters'][0] }}"
 host_ip_keyword: ansible_host
+
+# Retry install complete check in case of finding issues with API VIP reachability
+mabi_retry_install_complete_check: false

--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -6,11 +6,21 @@
 
 - name: Check installation and gather jobs if it fails
   block:
-    - name: Wait for install complete
-      ansible.builtin.shell:
+    - name: Wait for install complete - without retries
+      ansible.builtin.command:
         cmd: "{{ agent_based_installer_path }} --log-level=debug agent wait-for install-complete"
         chdir: "{{ manifests_dir }}"
+      when: not mabi_retry_install_complete_check|bool
 
+    - name: Wait for install complete - with retries
+      ansible.builtin.command:
+        cmd: "{{ agent_based_installer_path }} --log-level=debug agent wait-for install-complete"
+        chdir: "{{ manifests_dir }}"
+      when: mabi_retry_install_complete_check|bool
+      register: _mabi_install_output
+      retries: 10
+      delay: 60
+      until: "'Attempted to gather ClusterOperator status after wait failure: Listing ClusterOperator objects' not in _mabi_install_output.stderr"
   rescue:
     # Using master-0 IP address to reach the bootstrap VM
     # Placing the logs in repo_root_path


### PR DESCRIPTION
##### SUMMARY

This intends to address [OCPBUGS-49157](https://issues.redhat.com/browse/OCPBUGS-49157), where it has been observed that a failure from API VIP reachability check affects to the execution of openshift-install, so that the automation can be broken at that point.

If enabling a flag (false by default), retry the execution of openshift-install when waiting for install complete.

##### ISSUE TYPE

- Bug

##### Tests

- [x] ABI deployment hitting the OCPBUGS and using this retry: https://www.distributed-ci.io/jobs/526450a5-87b2-41e2-8ee1-e583a15f67f0/jobStates
- [x] SNO deployment hitting the OCPBUGS and using this retry: https://www.distributed-ci.io/jobs?limit=20&offset=0&sort=-created_at&where=pipeline_id:fa239e5f-62ae-4bce-a278-789a026628e0,state:active
- [x] ABI deployment not hitting the OCPBUGS and not using this retry (to confirm it works fine): https://www.distributed-ci.io/jobs/666c4944-8c09-49f8-a518-6944754cd45d/jobStates?sort=date

Test-Hints: no-check

build-depends: 32895