### PR TITLE
Trigger unit tests in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -131,12 +131,12 @@ jobs:
             sed -e 's/3.5 //g')
           for version in $PY_VERS; do
             ansible-test sanity $EXCLUDE --verbose --docker --python $version --color --coverage --failure-ok
-            ansible-test units $EXCLUDE --verbose --docker --python $version --color --coverage || :
+            ansible-test units --verbose --docker --python $version --color --coverage || :
           done 2> >(tee -a branch.output >&2)
           git checkout main
           for version in $PY_VERS; do
             ansible-test sanity $EXCLUDE --verbose --docker --python $version --color --coverage --failure-ok
-            ansible-test units $EXCLUDE --verbose --docker --python $version --color --coverage || :
+            ansible-test units --verbose --docker --python $version --color --coverage || :
           done 2> main.output 1>/dev/null
           for key in branch main; do
             grep -E "((ERROR|FATAL):|FAILED )" "$key.output" |


### PR DESCRIPTION
##### SUMMARY

The unit tests does not need/use the exclude paths, using it will fail the command and avoid running the unit tests.

The change in this PR was included in #532 but removed and merge without it.

Fix #531

##### ISSUE TYPE

- Bug

##### Tests

The check is showing that the unit test is now executed:

Before: https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/12989476933/job/36222569496?pr=532#step:6:1343
After: https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/12993203677/job/36234863727?pr=543#step:6:1437

---

Test-Hint: no-check
