### PR TITLE
Certsuite | Provide Hydra API parameters as flags rather than in the config file

### DIFF
--- a/roles/k8s_best_practices_certsuite/tasks/tests.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/tests.yml
@@ -58,6 +58,10 @@
           --preflight-dockerconfig=/usr/certsuite/config/config.json \
           --allow-preflight-insecure={{ kbpc_allow_preflight_insecure }} \
           {% endif %}
+          {% if kbpc_version == 'HEAD' and kbpc_cwe_apikey is defined and kbpc_cwe_project_id is defined %}
+          --connect-api-key={{ kbpc_cwe_apikey }} \
+          --connect-project-id={{ kbpc_cwe_project_id }} \
+          {% endif %}
           --output-dir=/usr/certsuite/results \
           --offline-db=/usr/offline-db \
           --config-file=/usr/certsuite/config/certsuite_config.yml \

--- a/roles/k8s_best_practices_certsuite/templates/certsuite_config.yml.j2
+++ b/roles/k8s_best_practices_certsuite/templates/certsuite_config.yml.j2
@@ -51,14 +51,17 @@ servicesignorelist:
 {% endfor %}
 
 {% if kbpc_version is version('v5.4.2', '>=') or kbpc_version == 'HEAD' %}
-{% if kbpc_cwe_apikey is defined and kbpc_cwe_project_id is defined %}
 connectAPIConfig:
   baseURL: "https://access.redhat.com/hydra/cwe/rest/v1.0"
+{% if kbpc_version is version('v5.4.2', '>=') and kbpc_cwe_apikey is defined and kbpc_cwe_project_id is defined %}
   apiKey: {{ kbpc_cwe_apikey }}
   projectID: {{ kbpc_cwe_project_id }}
+{% else %}
+  apiKey: ""
+  projectID: ""
+{% endif %}
   proxyURL: ""
   proxyPort: ""
-{% endif %}
 {% endif %}
 
 ## fields below are not currently used, leaving placeholder in case they were needed in the future


### PR DESCRIPTION
##### SUMMARY

This continues https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/540

Its purpose is mainly to avoid publishing the API key, which should be a private value. If using flags in the certsuite invocation, since it's running under a `no_log: true` clause, the API key will not be printed in that case

This requires https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2739 and https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2741 to work, so consequently, this feature is only enabled when using certsuite HEAD, else we'll keep using the config file.

##### ISSUE TYPE

- Enhanced feature

##### Tests

- [x] Certsuite submission where API key is not revealed: https://www.distributed-ci.io/jobs/87330a72-b570-4c28-8a68-7e1f33dacec7/jobStates

Test-Hints: no-check