### PR TITLE
[odf-setup] increase timeout to create ocs-gather daemonset

### DIFF
--- a/roles/odf_setup/tasks/local-storage-operator.yml
+++ b/roles/odf_setup/tasks/local-storage-operator.yml
@@ -22,6 +22,7 @@
     definition: "{{ lookup('template', 'ocs-disk-gatherer.yml.j2') }}"
     state: present
     wait: true
+    wait_timeout: 300
 
 - name: Gathering result from DaemonSet
   ansible.builtin.shell:


### PR DESCRIPTION
##### SUMMARY

in connected environments sometimes it takes over 2 minutes to pull the images for the pods, and this exceeds the default k8s wait time 120s

##### ISSUE TYPE

Bug fix

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/78f8bd30-b106-460e-9480-63dbdffcb8e7/jobStates

Test-Hints: no-check