### PR TITLE
[acm_setup] update MCH phase validation

### DIFF
--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -105,7 +105,7 @@
     - mch.resources | length == 1
     - "'status' in mch.resources[0]"
     - "'phase' in mch.resources[0].status"
-    - mch.resources[0].status.phase == 'Running'
+    - mch.resources[0].status.phase == 'Running' or mch.resources[0].status.phase == 'Available'
 
 - name: "Disable ClusterImageSets and AppSubs when disconnected"
   when:


### PR DESCRIPTION
##### SUMMARY

Currently only the Running phase is considered
but newer versions show Available when ready.

##### ISSUE TYPE

Bug fix

##### Tests

- [ ] TestBos2: virt-prega-4.18 libvirt:ansible_extravars=dci_pre_ga_catalog:quay.io/prega/prega-operator-index:v4.18-20250126T200308 - Pending


TestBos2: virt-prega-4.18 libvirt:ansible_extravars=dci_pre_ga_catalog:quay.io/prega/prega-operator-index:v4.18-20250126T200308