### PR TITLE
Remove workaround for namespace PSA

### DIFF
--- a/roles/preflight/tasks/tests_preflight_check_operator.yml
+++ b/roles/preflight/tasks/tests_preflight_check_operator.yml
@@ -36,21 +36,6 @@
           pod-security.kubernetes.io/enforce: "baseline"
           pod-security.kubernetes.io/warn: "baseline"
 
-- name: "Create namespace for {{ operator.name }}"
-  kubernetes.core.k8s:
-    definition:
-      apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: "{{ operator.name }}"
-        labels:
-          security.openshift.io/scc.podSecurityLabelSync: "false"
-          pod-security.kubernetes.io/enforce: privileged
-          pod-security.kubernetes.io/enforce-version: latest
-    wait: true
-  when:
-    - '"github-867" in dci_workarounds|default([])'
-
 - name: "Run preflight check operator on {{ operator.name }}"
   environment:
     OPENSHIFT_AUTH: "{{ partner_creds }}"


### PR DESCRIPTION
##### SUMMARY

It is expected that a baseline policy in the namespace works for preflight, removing the explicit change of policy that was used as a workaround.

The related issue is: https://github.com/redhat-openshift-ecosystem/openshift-preflight/issues/867

##### ISSUE TYPE

- Tech debt

##### Tests

- [x] TestDallasWorkload: preflight-green - https://www.distributed-ci.io/jobs/c9a5c610-faa0-4635-90a6-e3dc722c2998/jobStates

---

Test-Hints: no-check
