### PR TITLE
Allow ACM to patch MCE IPs if needed

### DIFF
--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -91,6 +91,34 @@
   delay: 15
   no_log: true
 
+- name: Get InstallPlans for MCE
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    namespace: multicluster-engine
+  register: _as_mce_ips
+  no_log: true
+
+- name: Patch pending InstallPlans for MCE
+  kubernetes.core.k8s_json_patch:
+    api_version: operators.coreos.com/v1alpha1
+    kind: InstallPlan
+    name: "{{ ip.metadata.name }}"
+    namespace: "{{ ip.metadata.namespace }}"
+    patch:
+      - op: replace
+        path: /spec/approved
+        value: true
+  loop: "{{ _as_mce_ips.resources }}"
+  loop_control:
+    loop_var: ip
+    label: "{{ ip.metadata.name }}"
+  when:
+    - _as_mce_ips.resources | length
+    - ip.spec.approval == 'Manual'
+    - not ip.spec.approved | bool
+  no_log: true
+
 - name: "Wait up to 30 mins for MCH to be ready"
   kubernetes.core.k8s_info:
     api: operator.open-cluster-management.io/v1


### PR DESCRIPTION
##### SUMMARY

Some deployments of the MulticlusterEngineHub for ACM require its InstallPlans to be patched manually whenever a previous operator was installed and changed its IP to manual.

This change finds any pending InstallPlan in the multicluster-engine namespace and approves them so MulticlusterHub can continue to install.


##### ISSUE TYPE

- Bug Fix

##### Tests


- [ ] TestDallasSno: sno-abi control-plane-example control-plane-example:prev_stages=acm-hub, control-plane-example:ansible_extravars=openshift_app_replicas:1

---

TestDallasSno: ocp-4.16-sno-abi control-plane-example control-plane-example:prev_stages=acm-hub, control-plane-example:ansible_extravars=openshift_app_replicas:1
