### PR TITLE
Add support for root_device_hints

### DIFF
--- a/roles/generate_manifests/README.md
+++ b/roles/generate_manifests/README.md
@@ -36,6 +36,7 @@ All of the variables have sane defaults which you can override to force things, 
     installation_disk_path: /dev/sdb  # this maps to rootDeviceHints.deviceName
     root_device_hints:  # you can also use more specific device hints. This overrides installation_disk_path
       hctl: 0:0:0:1
+      wwn: '0x5000000000'  # remember to quote hex values
   ansible.builtin.include_role:
     name: redhatci.ocp.generate_manifests
 ```

--- a/roles/generate_manifests/README.md
+++ b/roles/generate_manifests/README.md
@@ -1,3 +1,20 @@
-# generate_manifests
+# generate_manifests role
 
 Generates the manifests required for openshift_installer's agent sub-command
+
+## Variables
+
+All of the variables have sane defaults which you can override to force things, but you shouldn't need to
+
+| Variable                      | Default                           | Required  | Description           |
+| ----------------------------- | --------------------------------- | --------- | --------------------- |
+| generated_dir                 | $REPO_ROOT_PATH/generated         | No        | Base path for all generated files |
+| manifests_dir                 | $GENERATED_DIR/$CLUSTER_NAME      | No        | Path to store all rendered manifests |
+| cluster_manifest_dir          | $MANIFESTS_DIR/cluster-manifests  | No        | Path for cluster manifests |
+| extra_manifest_dir            | $MANIFESTS_DIR/openshift          | No        | Path for extra manifests |
+| static_network_config         | {}                                | No        | Static network config for every node |
+| root_device_hints             | {}                                | No        | Device Hints per node |
+| use_local_mirror_registry     | true                              | No        | Use the configured mirror registry |
+| mirror_registry               | $REGISTRY_HOST_FQDN:5000          | No        | Local container image mirror | | ocp_registry_namespace        | ocp4                              | No        | Namespace for image mirror |
+| ocp_registry_image            | openshift4                        | No        | Name for image in the image mirror |
+| single_node_openshift_enabled | false                             | No        | Install OCP in single-node mode |

--- a/roles/generate_manifests/README.md
+++ b/roles/generate_manifests/README.md
@@ -13,8 +13,31 @@ All of the variables have sane defaults which you can override to force things, 
 | cluster_manifest_dir          | $MANIFESTS_DIR/cluster-manifests  | No        | Path for cluster manifests |
 | extra_manifest_dir            | $MANIFESTS_DIR/openshift          | No        | Path for extra manifests |
 | static_network_config         | {}                                | No        | Static network config for every node |
-| root_device_hints             | {}                                | No        | Device Hints per node |
+| installation_disk_path        |                                   | No        | Disk to use for install if you don't want the first found disk |
+| root_device_hints             | {}                                | No        | Install device hints [^1] per node, in case installation_disk_path is not enough |
 | use_local_mirror_registry     | true                              | No        | Use the configured mirror registry |
-| mirror_registry               | $REGISTRY_HOST_FQDN:5000          | No        | Local container image mirror | | ocp_registry_namespace        | ocp4                              | No        | Namespace for image mirror |
+| mirror_registry               | $REGISTRY_HOST_FQDN:5000          | No        | Local container image mirror |
+| ocp_registry_namespace        | ocp4                              | No        | Namespace for image mirror |
 | ocp_registry_image            | openshift4                        | No        | Name for image in the image mirror |
 | single_node_openshift_enabled | false                             | No        | Install OCP in single-node mode |
+
+## Usage Examples
+
+```yaml
+- name: "Generate manifests"
+  vars:
+    static_network_config:  # if you want to specify static configuration
+      mynode-1:
+        mac_interface_map:
+          - logical_nic_name: enp0s0
+            mac_address: DE:AD:BE:EF:00:11
+        network_yaml:
+          # valid nmstate configuration in here
+    installation_disk_path: /dev/sdb  # this maps to rootDeviceHints.deviceName
+    root_device_hints:  # you can also use more specific device hints. This overrides installation_disk_path
+      hctl: 0:0:0:1
+  ansible.builtin.include_role:
+    name: redhatci.ocp.generate_manifests
+```
+
+[^1]: As per the [OCP 4.17 docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/installing_an_on-premise_cluster_with_the_agent-based_installer/index#root-device-hints_preparing-to-install-with-agent-based-installer)

--- a/roles/generate_manifests/defaults/main.yml
+++ b/roles/generate_manifests/defaults/main.yml
@@ -4,6 +4,7 @@ cluster_manifest_dir: "{{ manifests_dir }}/cluster-manifests"
 extra_manifest_dir: "{{ manifests_dir }}/openshift"
 mac_interface_default_mapping: "interfaces[?(name != null && mac != null)].{logical_nic_name: name, mac_address: mac}"
 static_network_config: {}
+root_device_hints: {}
 arch: x86_64
 version_filter: "[?(openshift_version == '{{ openshift_version }}') && (cpu_architecture == '{{ arch }}')]"
 release_image: "{{ (assisted_installer_release_images | json_query(version_filter))[0].url }}"

--- a/roles/generate_manifests/templates/agent-config.yaml.j2
+++ b/roles/generate_manifests/templates/agent-config.yaml.j2
@@ -5,16 +5,24 @@ rendezvousIP: {{ hostvars[agent_based_installer_bootstrap_node][host_ip_keyword]
 additionalNTPSources:
     - {{ hostvars[agent_based_installer_bootstrap_node]['ntp_server'] }}
 hosts:
-{% for hostname, network_config in static_network_config.items() %}
+{% for hostname in groups['masters'] + (groups['workers'] | default([])) | sort %}
   - role: {{ hostvars[hostname]['role'] }}
     hostname: {{ hostname }}
+  {% if hostname in static_network_config %}
     interfaces:
-      - name: {{ network_config.mac_interface_map[0].logical_nic_name }}
-        macAddress: {{ network_config.mac_interface_map[0].mac_address }}
+      - name: {{ static_network_config[hostname].mac_interface_map[0].logical_nic_name }}
+        macAddress: {{ static_network_config[hostname].mac_interface_map[0].mac_address }}
     networkConfig:
-      {{ network_config.network_yaml | indent(6) }}
-  {% if hostvars[hostname]['installation_disk_path'] is defined %}
+      {{ static_network_config[hostname].network_yaml | indent(6) }}
+  {% endif %}
+  {% if hostvars[hostname]['root_device_hints'] | default({}) | length > 0 or hostvars[hostname]['installation_disk_path'] is defined %}
     rootDeviceHints:
+    {% if hostvars[hostname]['installation_disk_path'] is defined %}
       deviceName: {{ hostvars[hostname]['installation_disk_path'] }}
+    {% else %}
+      {% for key, rdh in (hostvars[hostname]['root_device_hints'] | default({})).items() %}
+      {{ key }}: {{ rdh }}
+      {% endfor %}
+    {% endif %}
   {% endif %}
 {% endfor %}

--- a/roles/generate_manifests/templates/agent-config.yaml.j2
+++ b/roles/generate_manifests/templates/agent-config.yaml.j2
@@ -21,7 +21,7 @@ hosts:
       deviceName: {{ hostvars[hostname]['installation_disk_path'] }}
     {% else %}
       {% for key, rdh in (hostvars[hostname]['root_device_hints'] | default({})).items() %}
-      {{ key }}: {{ rdh }}
+      {{ key }}: {{ rdh | to_yaml }}
       {% endfor %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
##### SUMMARY

There is no code path that uses `installation_disk_path` in the OCP agent, adding support for `root_device_hints`

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### Tests

- [x] TestDallas: abi https://www.distributed-ci.io/jobs/24eb136f-8ae5-43f9-8dd1-1145e2572bcb/jobStates?sort=date
- [x] TestBos2Sno: abi-sno https://www.distributed-ci.io/jobs/5043a5e9-4cda-4519-bfb1-08e9db6d5ff8/jobStates?sort=date
- [x] TestDallasSno: ocp-4.16-sno-abi (valid device) - https://www.distributed-ci.io/jobs/44273042-56ed-4990-8538-d24a108140b5
  Despite the failure the sno cluster was installed, the [install info](https://www.distributed-ci.io/files/6ae1e929-0a8e-4085-9b78-8a9a94a6ea7e), shows the rendering of the template is as expected
- [x] TestDallasSno: ocp-4.16-sno-abi (invalid device) - https://www.distributed-ci.io/jobs/0e0b2628-216f-4415-a1f7-96b5944c09da
  This job failed as expected as the device root used does not exist in the server.
- [x] TestDallasSno: ocp-4.16-sno-abi (valid device) - https://www.distributed-ci.io/jobs/e79e4bce-1903-47f1-ad3a-db99cc8ffe97


---

Test-Hints: no-check