### PR TITLE
Extract rhcos.json only for >= 4.8

### DIFF
--- a/roles/mirror_ocp_release/tasks/artifacts.yml
+++ b/roles/mirror_ocp_release/tasks/artifacts.yml
@@ -23,14 +23,20 @@
         --registry-config {{ mor_auths_file }}
         --tools
         --from {{ mor_pull_url }}
-        --to "{{ mor_cache_dir }}/{{ mor_version }}";
-        {{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }} coreos print-stream-json >
-        {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json'
+        --to "{{ mor_cache_dir }}/{{ mor_version }}"'
       register: _mor_extract_res
       retries: 9
       delay: 10
       until: _mor_extract_res is not failed
       changed_when: false
+
+    - name: "Extract rhcos.json if version >= 4.8"
+      when:
+        - mor_version is version("4.8", ">=")
+      ansible.builtin.shell: >
+        flock -x {{ mor_cache_dir }}/{{ mor_version }}/release_extract.lock -c '
+          {{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }} coreos print-stream-json >
+          {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json;'
 
     - name: "Download rhcos.json (< 4.8)"
       when:

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -1,4 +1,13 @@
 ---
+- name: "Get content of release.txt"
+  ansible.builtin.slurp:
+    src: "{{ mor_cache_dir }}/{{ mor_version }}/release.txt"
+  register: _mor_release_content
+
+- name: "Read release_image from release content"
+  ansible.builtin.set_fact:
+    mor_release_image: "{{ _mor_release_content.content | b64decode | regex_search('(?<=^Pull From: )(.*)$', multiline=true) }}"
+
 - name: "Read the contents of rhcos.json"
   ansible.builtin.command: "cat {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json"
   register: rhcos
@@ -6,7 +15,7 @@
 - name: "Set image facts"
   ansible.builtin.set_fact:
     ocp_release_data:
-      container_image: "{{ mor_pull_url }}"
+      container_image: "{{ mor_release_image }}"
       rhcos_version: "{{ rhcos.stdout | from_json | json_query('architectures.x86_64.artifacts.metal.release') }}"
       rhcos_images: "{{ ocp_release_data['rhcos_images'] | default({}) | combine({item.key: (rhcos.stdout | from_json | json_query('architectures.x86_64.artifacts.' + item.path))}) }}"
   with_items:


### PR DESCRIPTION
##### SUMMARY

coreos command is only available in 4.18 and above. 

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change

##### Tests
- [x] TestDallas: ocp-4.7-vcp https://www.distributed-ci.io/jobs/d1326cba-25ff-4626-bc8e-2d3a6dc9a1a2/jobStates?sort=date&task=ff6cf407-66b8-4d35-bd6a-b4531b4137b4

Test-Hint: no-check

