### PR TITLE
Extract rhcos.json only for >= 4.8

### DIFF
--- a/roles/mirror_ocp_release/tasks/artifacts.yml
+++ b/roles/mirror_ocp_release/tasks/artifacts.yml
@@ -23,14 +23,21 @@
         --registry-config {{ mor_auths_file }}
         --tools
         --from {{ mor_pull_url }}
-        --to "{{ mor_cache_dir }}/{{ mor_version }}";
-        {{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }} coreos print-stream-json >
-        {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json'
+        --to "{{ mor_cache_dir }}/{{ mor_version }}"'
       register: _mor_extract_res
       retries: 9
       delay: 10
       until: _mor_extract_res is not failed
       changed_when: false
+
+    - name: "Extract rhcos.json if version >= 4.8"
+      when:
+        - mor_version is version("4.8", ">=")
+      ansible.builtin.shell: >
+        flock -x "{{ mor_cache_dir }}/{{ mor_version }}/release_extract.lock" -c '{
+        "{{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }}" coreos print-stream-json >
+        "{{ mor_cache_dir }}/{{ mor_version }}/rhcos.json";
+        }'
 
     - name: "Download rhcos.json (< 4.8)"
       when:
@@ -73,7 +80,8 @@
         mode: "0755"
         setype: "httpd_sys_content_t"
 
-    - name: "Remove lock file"
+  always:
+    - name: "Ensure lock file is removed"
       ansible.builtin.file:
         path: "{{ mor_cache_dir }}/{{ mor_version }}/release_extract.lock"
         state: absent

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -1,4 +1,14 @@
 ---
+- name: "Get content of release.txt"
+  ansible.builtin.slurp:
+    src: "{{ mor_cache_dir }}/{{ mor_version }}/release.txt"
+  register: _mor_release_content
+  no_log: true
+
+- name: "Read release_image from release content"
+  ansible.builtin.set_fact:
+    mor_release_image: "{{ _mor_release_content.content | b64decode | regex_search('(?<=^Pull From: )(.*)$', multiline=true) }}"
+
 - name: "Read the contents of rhcos.json"
   ansible.builtin.command: "cat {{ mor_cache_dir }}/{{ mor_version }}/rhcos.json"
   register: rhcos
@@ -6,7 +16,7 @@
 - name: "Set image facts"
   ansible.builtin.set_fact:
     ocp_release_data:
-      container_image: "{{ mor_pull_url }}"
+      container_image: "{{ mor_release_image }}"
       rhcos_version: "{{ rhcos.stdout | from_json | json_query('architectures.x86_64.artifacts.metal.release') }}"
       rhcos_images: "{{ ocp_release_data['rhcos_images'] | default({}) | combine({item.key: (rhcos.stdout | from_json | json_query('architectures.x86_64.artifacts.' + item.path))}) }}"
   with_items:


### PR DESCRIPTION
##### SUMMARY

coreos command is only available in 4.18 and above

Always remove the lock file

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### Tests

- [x] TestDallas: ocp-4.16-sno-abi sno-abi:ansible_tags=dci,job,pre-run,success - Release in the cache - https://www.distributed-ci.io/jobs/4a450bc5-4219-41f0-aa73-ac65c68c8b8d/jobStates
- [x] TestDallas:  ocp-4.16-sno-abi sno-abi:ansible_tags=dci,job,pre-run,success - Release not cached - https://www.distributed-ci.io/jobs/3105dd15-5a5c-4810-8d8c-764ffe50930c/jobStates?sort=date
- [x] TestDallas: ocp-4.7-vcp openshift-vcp:ansible_tags=dci,job,pre-run,success - Release in the cache - https://www.distributed-ci.io/jobs/e1e7acf1-8d25-4df6-a6e6-6c7ca3bceeb2/jobStates
- [x] TestDallas: ocp-4.7-vcp openshift-vcp:ansible_tags=dci,job,pre-run,success - Release not cached - https://www.distributed-ci.io/jobs/6d1491ce-e79f-43dc-8925-7dd2cbcbcaac/jobStates
- [x] TestBos2:  virt libvirt - Full job - https://www.distributed-ci.io/jobs/e6d87376-5aa3-49f8-92c2-666425cb3f8f/jobStates
- [x] TestBos2:   abi abi:ansible_tags=dci,job,pre-run,success - Release already cached - https://www.distributed-ci.io/jobs/d08d2744-6628-446f-918a-1d1b982dd10a/jobStates
- [x] TestBos2:   abi abi:ansible_tags=dci,job,pre-run,success - Release not cached - https://www.distributed-ci.io/jobs/2a91f3d1-0150-4cdc-a387-cc661ad5454b/jobStates


Test-hints: no-check
