### PR TITLE
Set default values in olm_operator role

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -52,7 +52,7 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
-* Tue Feb 10 2025 Tony Garcia <tonyg@redhat.com> - 1.3.EPOCH-VERS
+* Mon Feb 10 2025 Tony Garcia <tonyg@redhat.com> - 1.3.EPOCH-VERS
 - Version bump for olm_operator role updates
 
 * Tue Jan 28 2025 Beto Rdz <josearod@redhat.com> - 1.2.EPOCH-VERS

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        1.2.EPOCH
+Version:        1.3.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -52,6 +52,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Tue Feb 10 2025 Tony Garcia <tonyg@redhat.com> - 1.3.EPOCH-VERS
+- Version bump for olm_operator role updates
+
 * Tue Jan 28 2025 Beto Rdz <josearod@redhat.com> - 1.2.EPOCH-VERS
 - Move vendor Eject task to a separated file
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 1.3.2147483647
-version: 1.2.0
+version: 1.3.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/olm_operator/README.md
+++ b/roles/olm_operator/README.md
@@ -35,6 +35,7 @@ Installing an operator:
     operator_group_spec:
       targetNamespaces:
         - openshift-storage
+    install_approval: Automatic
 ```
 
 Installing an operator's specific version:

--- a/roles/olm_operator/defaults/main.yml
+++ b/roles/olm_operator/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 channel: ""
-source: redhat-operators
-source_ns: openshift-marketplace
-operator_group_name: "{{ operator }}"
+install_approval: "Manual"
 olm_operator_skippable: false
+operator_group_name: "{{ operator }}"
+source_ns: openshift-marketplace
+source: redhat-operators
+starting_csv: ""
 ...

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -91,7 +91,7 @@
         | map(attribute='currentCSV')
         | first
       }}
-    operator_csv: "{{ starting_csv | default(default_csv, true) }}"
+    operator_csv: "{{ starting_csv | length | ternary(starting_csv, default_csv) }}"
   when:
     - olm_operator_found | bool
   block:
@@ -121,6 +121,8 @@
           spec: "{{ operator_group_spec | default(group_spec, true) }}"
 
     - name: Create subscription for OLM operator
+      vars:
+        _oo_approval: "{{ (install_approval == 'Automatic' or (starting_csv | length == 0)) | ternary('Automatic', 'Manual') }}"
       kubernetes.core.k8s:
         definition:
           apiVersion: operators.coreos.com/v1alpha1
@@ -130,7 +132,7 @@
             namespace: "{{ namespace }}"
           spec:
             channel: "{{ desired_channel }}"
-            installPlanApproval: "{{ (starting_csv | default('') | length) | ternary('Manual', 'Automatic') }}"
+            installPlanApproval: "{{ _oo_approval }}"
             config:
               resources: {}
             name: "{{ operator }}"
@@ -167,7 +169,7 @@
       loop_control:
         loop_var: install_plan
       when:
-        - starting_csv | default('') | length > 0
+        - starting_csv | length
 
     - name: Wait for CSV to be ready
       kubernetes.core.k8s_info:


### PR DESCRIPTION
##### SUMMARY

The install_approval and the starting_csv have now explicit default values as documented previously, but the install_approval is now used in the subcription of the operator to install rather than patching the IP later.

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x] TestDallasSno:
ocp-4.16-sno-abi control-plane-example control-plane-example:prev_stages=acm-hub, control-plane-example:ansible_extravars=openshift_app_replicas:1
  - ocp-4.16-sno-abi -  https://www.distributed-ci.io/jobs/82254493-7a69-4b3c-947d-2f1bd83b55c
  - control-plane-example - https://www.distributed-ci.io/jobs/a0a1da64-2204-4ad8-b201-478bffdf31a4

 ---

Test-Hints: no-check