### PR TITLE
Disabe IPv6 on boot

### DIFF
--- a/roles/ocp_on_libvirt/templates/libvirt_node.xml.j2
+++ b/roles/ocp_on_libvirt/templates/libvirt_node.xml.j2
@@ -16,6 +16,9 @@
 {% if enable_conserver %}
     <bios useserial='yes' rebootTimeout='0'/>
 {% endif %}
+{% if disable_ipv6 %}
+    <cmdline>ipv6.disable=1</cmdline>
+{% endif %}
   </os>
   <features>
     <acpi/>


### PR DESCRIPTION
##### SUMMARY
Allow to disable IPv6 on boot for IPI VMs

##### ISSUE TYPE
- New or Enhanced Feature

##### Tests

- [ ] TestBos2: virt - <JobURL>

Test-Hint: no-check
