### PR TITLE
Monitor ABI installation - force failure if no events logged from the Agent Rest API

### DIFF
--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -20,7 +20,10 @@
       register: _mabi_install_output
       retries: 10
       delay: 60
-      until: "'Attempted to gather ClusterOperator status after wait failure: Listing ClusterOperator objects' not in _mabi_install_output.stderr"
+      until:
+        "'Attempted to gather ClusterOperator status after wait failure: Listing ClusterOperator objects' not in _mabi_install_output.stderr
+        or
+        'No events logged from the Agent Rest API' in _mabi_install_output.stderr"
   rescue:
     # Using master-0 IP address to reach the bootstrap VM
     # Placing the logs in repo_root_path


### PR DESCRIPTION
##### SUMMARY

This tries to unblock jobs like [this one](https://www.distributed-ci.io/jobs/dfe90943-0d17-4439-bacc-f36c2a4cc3a2/jobStates), where we kept repeating the ABI monitoring task all the times because we were hitting the ClusterOperator error message, but in this case, the issue was different: openshift-install really waited till the timeout and finally declared that no events were logged from the Agent REST API. In case of finding that message, we have to stop doing retries and continue with the job (in that case, the job will fail because rc will be different than 0).

##### ISSUE TYPE

- Bug

##### Tests

- [x] ABI installation passed - https://www.distributed-ci.io/jobs/4d7e1c0c-a694-478c-ad0a-6fc1a6103366/jobStates?sort=date&task=cb9f8742-f8e2-454d-90d6-d9d04605a649

Test-Hints: no-check