### PR TITLE
Certsuite v5.4.6

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.4.4
+kbpc_version: v5.4.6
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"
@@ -114,6 +114,7 @@ kbpc_feedback:
   operator-pods-no-hugepages: ""
   operator-semantic-versioning: ""
   operator-single-crd-owner: ""
+  operator-single-or-multi-namespaced-allowed-in-tenant-namespaces: ""
   performance-exclusive-cpu-pool: ""
   performance-exclusive-cpu-pool-rt-scheduling-policy: ""
   performance-isolated-cpu-pool-rt-scheduling-policy: ""


### PR DESCRIPTION
**SUMMARY**

Bump certsuite version to v5.4.6 & update the name of the operator tenant namespace test.

**ISSUE TYPE**

Version bump

**Tests**

- [ ] Certsuite submission : https://www.distributed-ci.io/jobs/a61b921a-3c6f-46b1-b3e8-c07a4aaa7ff2/jobStates

Test-Hints: no-check
