### PR TITLE
[DNM] stop install just before bootstrap to troubleshoot

### DIFF
--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: "DNM troubleshooting ABI install failures"
+  ansible.builtin.fail:
+    msg: "Stop here to run the install manually and troubleshoot: {{ manifests_dir }} - {{ agent_based_installer_path }} --log-level=debug agent wait-for bootstrap-complete"
+
 - name: Wait for bootstrap complete
   ansible.builtin.shell:
     cmd: "{{ agent_based_installer_path }} --log-level=debug agent wait-for bootstrap-complete"


### PR DESCRIPTION
##### SUMMARY

Please do not review/merge, this is just a PR to stop the automation before ABI installation is triggered, then I manually run and troubleshoot the deployment

##### Tests

TestBos2: abi