### PR TITLE
gai: add generic gai_http_delegate_host variable for delete_to option

### DIFF
--- a/roles/generate_agent_iso/defaults/main.yml
+++ b/roles/generate_agent_iso/defaults/main.yml
@@ -3,3 +3,5 @@ gai_generated_dir: "{{ gai_repo_root_path }}/generated"
 gai_manifests_dir: "{{ gai_generated_dir }}/{{ gai_cluster_name }}"
 gai_iso_download_dest_path: "/opt/http_store/data"
 gai_arch: x86_64
+gai_remote_http_src: false
+gai_http_delegate_host: http_store

--- a/roles/generate_agent_iso/tasks/main.yml
+++ b/roles/generate_agent_iso/tasks/main.yml
@@ -48,7 +48,7 @@
     - _gai_gen_iso.rc == 0
 
 - name: Put discovery iso in http store
-  delegate_to: http_store
+  delegate_to: "{{ gai_http_delegate_host }}"
   become: true
   block:
     - name: Create discovery directory
@@ -62,3 +62,4 @@
         src: "{{ gai_manifests_dir }}/agent.{{ gai_arch }}.iso"
         dest: "{{ gai_iso_download_dest_path }}/{{ gai_discovery_iso_name }}"
         mode: '0644'
+        remote_src: "{{ gai_remote_http_src }}"


### PR DESCRIPTION
Added the gai_http_delegate_host variable to make the role more generic

##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->
Added the gai_http_delegate_host variable to make the role more generic. 
Please note that the default role behavior is not affected by this change.
<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change
- New or Enhanced Feature

##### Tests

- [x] TestBos2Sno: abi-sno - https://www.distributed-ci.io/jobs/0468db71-bc03-4079-993d-aa52f33204e1/jobStates

Test-Hints: no-check