### PR TITLE
Update RHOAI role

### DIFF
--- a/roles/rhoai/README.md
+++ b/roles/rhoai/README.md
@@ -85,18 +85,16 @@ You can include the role like this:
     # apply:
     #   environment:
     #     KUBECONFIG: /path/to/kubeconfig
-    vars:
-     rhoai_operator_map:
-       rhods:
-         channel: stable-2.9  # we want a newer version
-     rhoai_dsc_name: my-dsc
-     rhoai_dsc_spec_components:
-       codeflare: Managed
-       kserve: Removed
-       ray: Managed
-       kueue: Managed
-      ansible.builtin.include_role:
-        name: redhatci.ocp.rhoai
+  vars:
+    rhoai_operator_map:
+      rhods:
+        channel: stable-2.9  # we want a newer version
+    rhoai_dsc_name: my-dsc
+    rhoai_dsc_spec_components:
+      codeflare: Managed
+      kserve: Removed
+      ray: Managed
+      kueue: Managed
      # rhoai_source_catalog: offline-operators  # our own copy of the redhat catalogs
      # rhoai_source_namespace: redhat-offline  # previously mirrored to this location
 ```

--- a/roles/rhoai/README.md
+++ b/roles/rhoai/README.md
@@ -19,6 +19,20 @@ other extra requirements
 | rhoai_dsc_name            | default-dsc           | Name of the DataScienceCluster CRD object to create |
 | rhoai_wait_for_dsc        | true                  | Wait for the DSC deployment to finish |
 
+### DataScienceCluster defaults
+
+The DSC cluster default components state is as below.
+
+| Variable                  | Component                 | Status               |
+|---------------------------|---------------------------|----------------------|
+| rhoai_codeflare           | codeflare                 | Removed              |
+| rhoai_kserve              | kserve                    | Managed              |
+| rhoai_ray                 | ray                       | Removed              |
+| rhoai_kueue               | kueue                     | Removed              |
+| rhoai_workbenches         | workbenches               | Managed              |
+| rhoai_dashboard           | dashboard                 | Managed              |
+| rhoai_modelmeshserving    | modelmeshserving          | Managed              |
+| rhoai_datasciencepipeline | datasciencepipelines      | Managed              |
 
 ### rhoai_operator_map
 
@@ -28,7 +42,7 @@ The default operator map looks something like this:
 servicemesh:
   package: servicemeshoperator
   channel: stable
-namespace: openshift-servicemesh
+namespace: openshift-operators
 serverless:
   package: serverless-operator
   channel: stable-1.32
@@ -71,6 +85,9 @@ You can include the role like this:
        rhods:
          channel: stable-2.9  # we want a newer version
      rhoai_dsc_name: my-dsc
+     rhoai_kserve: Managed
+     rhoai_ray: Removed
+     rhoai_kueue: Removed
      # rhoai_source_catalog: offline-operators  # our own copy of the redhat catalogs
      # rhoai_source_namespace: redhat-offline  # previously mirrored to this location
 ```

--- a/roles/rhoai/README.md
+++ b/roles/rhoai/README.md
@@ -1,11 +1,11 @@
 # rhoai
 
-A role to install the Red Hat OpenShift AI operators
+A role to install the Red Hat OpenShift AI operators and create a DataScience Cluster (DSC)
 
 ## Requirements
 
-This role makes extensive use of the Kubernetes collection, but there are no
-other extra requirements
+- This role makes extensive use of the Kubernetes collection
+- The cluster must have a catalog source that includes the RHOAI operators (servicemeshoperator, serverless-operator, redhat-ods-operator)
 
 ## Role Variables
 
@@ -18,39 +18,44 @@ other extra requirements
 | rhoai_create_dsc          | true                  | Create a DataScienceCluster CRD on `install` action |
 | rhoai_dsc_name            | default-dsc           | Name of the DataScienceCluster CRD object to create |
 | rhoai_wait_for_dsc        | true                  | Wait for the DSC deployment to finish |
+| rhoai_part_of             | rhoai                 | Metadata labels for DCS metadata labels (part-of,created-by) |
+| rhoai_dsc_spec_components | <see defaults>        | DataScienceCluster components status, read more in-depth description below |
 
-### DataScienceCluster defaults
+### DataScienceCluster defaults map
 
-The DSC cluster default components state is as below.
+The DSC cluster's components status can be defined as below.
 
-| Variable                  | Component                 | Status               |
-|---------------------------|---------------------------|----------------------|
-| rhoai_codeflare           | codeflare                 | Removed              |
-| rhoai_kserve              | kserve                    | Managed              |
-| rhoai_ray                 | ray                       | Removed              |
-| rhoai_kueue               | kueue                     | Removed              |
-| rhoai_workbenches         | workbenches               | Managed              |
-| rhoai_dashboard           | dashboard                 | Managed              |
-| rhoai_modelmeshserving    | modelmeshserving          | Managed              |
-| rhoai_datasciencepipeline | datasciencepipelines      | Managed              |
+```yaml
+rhoai_dsc_spec_components:
+  codeflare: Removed
+  kserve: Managed
+  ray: Removed
+  kueue: Removed
+  workbenches: Managed
+  dashboard: Managed
+  modelmeshserving: Managed
+  datasciencepipelines: Managed
+```
+ See role default for initial components status.
 
 ### rhoai_operator_map
 
 The default operator map looks something like this:
 
 ```yaml
-servicemesh:
-  package: servicemeshoperator
-  channel: stable
-namespace: openshift-operators
-serverless:
-  package: serverless-operator
-  channel: stable-1.32
-  namespace: openshift-serverless
-rhods:
-  package: rhods-operator
-  channel: stable-2.8
-  namespace: redhat-ods-operator
+rhoai_operator_map:
+  servicemesh:
+    package: servicemeshoperator
+    channel: stable
+  namespace: openshift-operators
+  serverless:
+    package: serverless-operator
+    channel: stable-1.32
+    namespace: openshift-serverless
+  rhods:
+    package: rhods-operator
+    channel: stable-2.8
+    namespace: redhat-ods-operator
 ```
 
 Defined as follows:
@@ -85,9 +90,13 @@ You can include the role like this:
        rhods:
          channel: stable-2.9  # we want a newer version
      rhoai_dsc_name: my-dsc
-     rhoai_kserve: Managed
-     rhoai_ray: Removed
-     rhoai_kueue: Removed
+     rhoai_dsc_spec_components:
+       codeflare: Managed
+       kserve: Removed
+       ray: Managed
+       kueue: Managed
+      ansible.builtin.include_role:
+        name: redhatci.ocp.rhoai
      # rhoai_source_catalog: offline-operators  # our own copy of the redhat catalogs
      # rhoai_source_namespace: redhat-offline  # previously mirrored to this location
 ```

--- a/roles/rhoai/defaults/main.yml
+++ b/roles/rhoai/defaults/main.yml
@@ -6,4 +6,13 @@ rhoai_source_namespace: openshift-marketplace
 rhoai_create_dsc: true
 rhoai_dsc_name: default-dsc
 rhoai_wait_for_dsc: true
+rhoai_part_of: rhoai
+rhoai_codeflare: Removed
+rhoai_kserve: Managed
+rhoai_ray: Removed
+rhoai_kueue: Removed
+rhoai_workbenches: Managed
+rhoai_dashboard: Managed
+rhoai_modelmeshserving: Managed
+rhoai_datasciencepipelines: Managed
 ...

--- a/roles/rhoai/defaults/main.yml
+++ b/roles/rhoai/defaults/main.yml
@@ -7,12 +7,4 @@ rhoai_create_dsc: true
 rhoai_dsc_name: default-dsc
 rhoai_wait_for_dsc: true
 rhoai_part_of: rhoai
-rhoai_codeflare: Removed
-rhoai_kserve: Managed
-rhoai_ray: Removed
-rhoai_kueue: Removed
-rhoai_workbenches: Managed
-rhoai_dashboard: Managed
-rhoai_modelmeshserving: Managed
-rhoai_datasciencepipelines: Managed
 ...

--- a/roles/rhoai/tasks/create-dsc.yml
+++ b/roles/rhoai/tasks/create-dsc.yml
@@ -1,4 +1,9 @@
 ---
+- name: Merge user-provided and default cluster configurations
+  set_fact:
+    rhoai_merged_dsc_spec_components: "{{ rhoai_default_dsc_spec_components |
+                                      combine(rhoai_dsc_spec_components | default({}), recursive=True) }}"
+
 - name: Create DataScienceCluster
   when: rhoai_create_dsc | bool
   kubernetes.core.k8s:
@@ -18,9 +23,9 @@
       spec:
         components:
           codeflare:
-            managementState: "{{ rhoai_codeflare }}"
+            managementState: "{{ rhoai_merged_dsc_spec_components['codeflare'] }}"
           kserve: >-
-              {{ {'managementState': rhoai_kserve} |
+              {{ {'managementState': rhoai_merged_dsc_spec_components.kserve} |
                   combine({'serving': {
                     'ingressGateway': {
                       'certificate': {
@@ -29,20 +34,20 @@
                     },
                     'managementState': 'Managed',
                     'name': 'knative-serving'
-                  }} if rhoai_kserve == 'Managed' else {})
+                  }} if rhoai_merged_dsc_spec_components['kserve'] == 'Managed' else {})
               }}
           ray:
-            managementState: "{{ rhoai_ray }}"
+            managementState: "{{ rhoai_merged_dsc_spec_components['ray'] }}"
           kueue:
-            managementState: "{{ rhoai_kueue }}"
+            managementState: "{{ rhoai_merged_dsc_spec_components['kueue'] }}"
           workbenches:
-            managementState: "{{ rhoai_workbenches }}"
+            managementState: "{{ rhoai_merged_dsc_spec_components['workbenches'] }}"
           dashboard:
-            managementState: "{{ rhoai_dashboard }}"
+            managementState: "{{ rhoai_merged_dsc_spec_components['dashboard'] }}"
           modelmeshserving:
-            managementState: "{{ rhoai_modelmeshserving }}"
+            managementState: "{{ rhoai_merged_dsc_spec_components['modelmeshserving'] }}"
           datasciencepipelines:
-            managementState: "{{ rhoai_datasciencepipelines }}"
+            managementState: "{{ rhoai_merged_dsc_spec_components['datasciencepipelines'] }}"
 
 - name: Wait up to 30 mins for DataScienceCluster
   kubernetes.core.k8s_info:

--- a/roles/rhoai/tasks/create-dsc.yml
+++ b/roles/rhoai/tasks/create-dsc.yml
@@ -1,0 +1,61 @@
+---
+- name: Create DataScienceCluster
+  when: rhoai_create_dsc | bool
+  kubernetes.core.k8s:
+    state: present
+    wait: "{{ rhoai_wait_for_dsc | bool }}"
+    definition:
+      apiVersion: datasciencecluster.opendatahub.io/v1
+      kind: DataScienceCluster
+      metadata:
+        name: "{{ rhoai_dsc_name }}"
+        labels:
+          app.kubernetes.io/name: datasciencecluster
+          app.kubernetes.io/instance: "{{ rhoai_dsc_name }}"
+          app.kubernetes.io/part-of: "{{ __rhoai_operator_map.rhods.package | default(rhoai_part_of) }}"
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/created-by: "{{ __rhoai_operator_map.rhods.package | default(rhoai_part_of) }}"
+      spec:
+        components:
+          codeflare:
+            managementState: "{{ rhoai_codeflare }}"
+          kserve: >-
+              {{ {'managementState': rhoai_kserve} |
+                  combine({'serving': {
+                    'ingressGateway': {
+                      'certificate': {
+                        'type': 'SelfSigned'
+                      }
+                    },
+                    'managementState': 'Managed',
+                    'name': 'knative-serving'
+                  }} if rhoai_kserve == 'Managed' else {})
+              }}
+          ray:
+            managementState: "{{ rhoai_ray }}"
+          kueue:
+            managementState: "{{ rhoai_kueue }}"
+          workbenches:
+            managementState: "{{ rhoai_workbenches }}"
+          dashboard:
+            managementState: "{{ rhoai_dashboard }}"
+          modelmeshserving:
+            managementState: "{{ rhoai_modelmeshserving }}"
+          datasciencepipelines:
+            managementState: "{{ rhoai_datasciencepipelines }}"
+
+- name: Wait up to 30 mins for DataScienceCluster
+  kubernetes.core.k8s_info:
+    api: datasciencecluster.opendatahub.io/v1
+    kind: DataScienceCluster
+    name: "{{ rhoai_dsc_name }}"
+  register: _rhoai_dsc
+  retries: 60
+  delay: 10
+  until:
+    - _rhoai_dsc.resources is defined
+    - _rhoai_dsc.resources | length == 1
+    - "'status' in _rhoai_dsc.resources[0]"
+    - "'phase' in _rhoai_dsc.resources[0].status"
+    - _rhoai_dsc.resources[0].status.phase == 'Ready'
+...

--- a/roles/rhoai/tasks/create-dsc.yml
+++ b/roles/rhoai/tasks/create-dsc.yml
@@ -1,6 +1,6 @@
 ---
 - name: Merge user-provided and default cluster configurations
-  set_fact:
+  ansible.builtin.set_fact:
     rhoai_merged_dsc_spec_components: "{{ rhoai_default_dsc_spec_components |
                                       combine(rhoai_dsc_spec_components | default({}), recursive=True) }}"
 

--- a/roles/rhoai/tasks/install.yml
+++ b/roles/rhoai/tasks/install.yml
@@ -11,44 +11,6 @@
     - serverless
     - rhods
 
-- name: Create DataScienceCluster
-  when: rhoai_create_dsc | bool
-  kubernetes.core.k8s:
-    state: present
-    wait: "{{ rhoai_wait_for_dsc | bool }}"
-    definition:
-      apiVersion: datasciencecluster.opendatahub.io/v1
-      kind: DataScienceCluster
-      metadata:
-        name: "{{ rhoai_dsc_name }}"
-        labels:
-          app.kubernetes.io/name: datasciencecluster
-          app.kubernetes.io/instance: "{{ rhoai_dsc_name }}"
-          app.kubernetes.io/part-of: "{{ __rhoai_operator_map.rhods.package }}"
-          app.kubernetes.io/managed-by: kustomize
-          app.kubernetes.io/created-by: "{{ __rhoai_operator_map.rhods.package }}"
-      spec:
-        components:
-          codeflare:
-            managementState: Removed
-          kserve:
-            serving:
-              ingressGateway:
-                certificate:
-                  type: SelfSigned
-              managementState: Managed
-              name: knative-serving
-            managementState: Managed
-          ray:
-            managementState: Removed
-          kueue:
-            managementState: Removed
-          workbenches:
-            managementState: Managed
-          dashboard:
-            managementState: Managed
-          modelmeshserving:
-            managementState: Managed
-          datasciencepipelines:
-            managementState: Managed
+- name: Created DataScienceCluster
+  ansible.builtin.include_tasks: create-dsc.yml
 ...

--- a/roles/rhoai/vars/main.yml
+++ b/roles/rhoai/vars/main.yml
@@ -3,7 +3,7 @@ rhoai_default_operator_map:
   servicemesh:
     package: servicemeshoperator
     channel: stable
-    namespace: openshift-servicemesh
+    namespace: openshift-operators
   serverless:
     package: serverless-operator
     channel: stable
@@ -12,4 +12,14 @@ rhoai_default_operator_map:
     package: rhods-operator
     channel: fast
     namespace: redhat-ods-operator
+
+rhoai_default_dsc_spec_components:
+  codeflare: Removed
+  kserve: Managed
+  ray: Removed
+  kueue: Removed
+  workbenches: Managed
+  dashboard: Managed
+  modelmeshserving: Managed
+  datasciencepipelines: Managed
 ...


### PR DESCRIPTION
##### SUMMARY

- Move to a separate play the task to create a DSC
- Service mesh must be installed in the openshift-operators namespace
- Setting the knative-serving as managed only if kserve is managed
- Variables to control the state of the DSC components
- Doc updates

- New or Enhanced Feature

##### Tests

- [x] TestDallas: ocp-4.17-vanilla-core - https://www.distributed-ci.io/jobs/114a3f00-4acb-4df2-bf8f-63ef32c59f5b/jo

Tested in Core cluster.

ocp-4.17-vanilla-core openshift-vanilla:ansible_tags=dci,job,operator-deployment,post-run,success

Gerrit: 33030

Test-Hint: no-check
