### PR TITLE
Fixing linting converting mode values to string from octals.

### DIFF
--- a/roles/apply_nmstate/tasks/main.yml
+++ b/roles/apply_nmstate/tasks/main.yml
@@ -11,7 +11,7 @@
       ansible.builtin.copy:
         content: "{{ rendered_nmstate_yml }}"
         dest: "{{ vm_nmstate_config_path }}"
-        mode: 0644
+        mode: "0644"
       # No commit is done to revert the changes if they cause the host to be come unreachable
 
     - name: Check if vm_host is bastion

--- a/roles/create_cluster/tasks/main.yml
+++ b/roles/create_cluster/tasks/main.yml
@@ -117,7 +117,7 @@
   copy:
     content: "{{ cluster_id }}"
     dest: "{{ fetched_dest }}/{{ cluster_id_filename }}"
-    mode: 0644
+    mode: "0644"
   delegate_to: localhost
   become: false
   when: create | bool == True

--- a/roles/create_day2_cluster/tasks/main.yml
+++ b/roles/create_day2_cluster/tasks/main.yml
@@ -39,7 +39,7 @@
   copy:
     content: "{{ add_host_cluster_id }}"
     dest: "{{ fetched_dest }}/{{ day2_cluster_id_filename }}"
-    mode: 0644
+    mode: "0644"
   delegate_to: localhost
   become: false
 

--- a/roles/create_vms/tasks/provision_vms.yml
+++ b/roles/create_vms/tasks/provision_vms.yml
@@ -6,7 +6,7 @@
       template:
         src: rng_device.xml.j2
         dest: "/tmp/{{ cluster_name }}_rng_device.xml"
-        mode: 0664
+        mode: "0664"
 
     - name: Create vm create scripts dir
       file:
@@ -23,7 +23,7 @@
         src: create_vm.sh.j2
         dest: "{{ vm_create_scripts_dir }}/{{ item.name }}_setup_vm.sh"
         lstrip_blocks: true
-        mode: 0774
+        mode: "0774"
       loop: "{{ kvm_nodes }}"
 
     - name: Run vm creation_scripts

--- a/roles/extract_openshift_installer/tasks/main.yml
+++ b/roles/extract_openshift_installer/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     path: "{{ extract_dest_path }}"
     state: directory
-    mode: 0755
+    mode: "0755"
     recurse: true
 
 - name: Create pull_secret_file

--- a/roles/generate_discovery_iso/tasks/main.yml
+++ b/roles/generate_discovery_iso/tasks/main.yml
@@ -107,7 +107,7 @@
   copy:
     content: "{{ infra_env_id }}"
     dest: "{{ fetched_dest }}/infra_env_id.txt"
-    mode: 0644
+    mode: "0644"
   delegate_to: localhost
 
 - name: Get discovery ignition file
@@ -123,7 +123,7 @@
   copy:
     content: "{{ discovery_ign_reply.content }}"
     dest: "{{ fetched_dest }}/discovery.ign"
-    mode: 0644
+    mode: "0644"
   delegate_to: localhost
 
 - name: Patch discovery user password
@@ -160,7 +160,7 @@
       copy:
         content: "{{ infra_env_patch_reply.content }}"
         dest: "{{ fetched_dest }}/patched_discovery.ign"
-        mode: 0644
+        mode: "0644"
       delegate_to: localhost
 
 - name: Put discovery iso in http store

--- a/roles/generate_manifests/tasks/main.yml
+++ b/roles/generate_manifests/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Make cluster-manifests dir
   ansible.builtin.file:
     name: "{{ cluster_manifest_dir }}"
-    mode: 0775
+    mode: "0775"
     recurse: true
     state: directory
 
@@ -31,7 +31,7 @@
   ansible.builtin.template:
     src: "{{ item }}"
     dest: "{{ manifests_dir }}/{{ item.rsplit('.', 1)[0] }}"
-    mode: 0644
+    mode: "0644"
     trim_blocks: true
     lstrip_blocks: true
   loop:
@@ -52,7 +52,7 @@
 - name: Create extra_manifest_dir dir
   ansible.builtin.file:
     name: "{{ extra_manifest_dir }}"
-    mode: 0775
+    mode: "0775"
     recurse: true
     state: directory
   when:

--- a/roles/generate_manifests/tasks/manifest.yml
+++ b/roles/generate_manifests/tasks/manifest.yml
@@ -23,4 +23,4 @@
   ansible.builtin.copy:
     content: "{{ manifest_content }}"
     dest: "{{ extra_manifest_dir }}/{{ manifest_name }}"
-    mode: 0644
+    mode: "0644"

--- a/roles/generate_ssh_key_pair/tasks/main.yml
+++ b/roles/generate_ssh_key_pair/tasks/main.yml
@@ -15,13 +15,13 @@
 - name: Make key dir
   file:
     path: "{{ key_pair_dir }}"
-    mode: 0775
+    mode: "0775"
     state: directory
 
 - name: Generate an OpenSSH rsa keypair
   community.crypto.openssh_keypair:
     path: "{{ key_pair_dir }}/{{ private_key_name }}"
-    mode: 0600
+    mode: "0600"
   args: "{{ openssh_keypair_args | default({}) }}"
 
 - name: Fetch SSH Key
@@ -38,7 +38,7 @@
     - name: Make SSH Key folder
       file:
         path: "{{ ssh_key_dest_dir }}"
-        mode: 0775
+        mode: "0775"
         state: directory
 
     - name: Copy SSH Key files to bastion

--- a/roles/get_image_hash/tasks/main.yml
+++ b/roles/get_image_hash/tasks/main.yml
@@ -71,7 +71,7 @@
   copy:
     content: "{{ image_hashes | to_nice_yaml }}"
     dest: "{{ image_hashes_path }}"
-    mode: 0660
+    mode: "0660"
   delegate_to: localhost
 
 - name: Update release_images with hashes

--- a/roles/insert_dns_records/tasks/dnsmasq.yml
+++ b/roles/insert_dns_records/tasks/dnsmasq.yml
@@ -3,7 +3,7 @@
   ansible.builtin.template:
     src: openshift-cluster.conf.j2
     dest: "/etc/dnsmasq.d/{{ dns_entries_file_name }}"
-    mode: 0644
+    mode: "0644"
   notify: restart_service
 
 - name: Start dnsmasq

--- a/roles/insert_dns_records/tasks/network-manager.yml
+++ b/roles/insert_dns_records/tasks/network-manager.yml
@@ -3,13 +3,13 @@
   ansible.builtin.copy:
     src: nm-dnsmasq.conf
     dest: /etc/NetworkManager/conf.d/dnsmasq.conf
-    mode: 0644
+    mode: "0644"
 
 - name: Create dnsmasq openshift-cluster config file
   ansible.builtin.template:
     src: openshift-cluster.conf.j2
     dest: "/etc/NetworkManager/dnsmasq.d/{{ dns_entries_file_name }}"
-    mode: 0644
+    mode: "0644"
   notify: restart_service
 
 - name: Start NetworkManager

--- a/roles/installer/tasks/10_get_oc.yml
+++ b/roles/installer/tasks/10_get_oc.yml
@@ -123,7 +123,7 @@
     dest: "{{ tempdir }}/{{ installer_oc_installer_prefix }}-{{ release_version }}.tar.gz"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: 0755
+    mode: "0755"
   become: true
   when: registry_creation|bool
   tags:

--- a/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -56,7 +56,7 @@
     dest: "/usr/local/bin/oc"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: 0755
+    mode: "0755"
   become: true
   when: groups['registry_host'][0] != groups['provisioner'][0]
   delegate_to: "{{ groups['registry_host'][0] }}"
@@ -260,7 +260,7 @@
         remote_src: true
         group: "{{ ansible_user }}"
         owner: "{{ ansible_user }}"
-        mode: 0644
+        mode: "0644"
         force: true
         backup: true
       become: true
@@ -432,7 +432,7 @@
     dest: "/etc/pki/ca-trust/source/anchors/{{ groups['registry_host'][0] }}-domain.crt"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: 0644
+    mode: "0644"
   become: true
   tags:
     - create_registry

--- a/roles/installer/tasks/20_extract_installer.yml
+++ b/roles/installer/tasks/20_extract_installer.yml
@@ -42,7 +42,7 @@
     dest: "{{ dir }}/pull-secret.txt"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: 0755
+    mode: "0755"
   become: true
   when:
     - registry_creation|bool
@@ -144,7 +144,7 @@
     dest: "/usr/local/bin/{{ installer_cmd }}"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: 0755
+    mode: "0755"
   become: true
   when:
     - registry_creation|bool

--- a/roles/installer/tasks/50_extramanifests.yml
+++ b/roles/installer/tasks/50_extramanifests.yml
@@ -7,7 +7,7 @@
   copy:
     src: ipv6-dual-stack-no-upgrade.yml
     dest: "{{ extramanifestsopenshift_path }}/"
-    mode: 0644
+    mode: "0644"
   when:
     - ipv6_enabled|bool
     - dualstack_baremetal

--- a/roles/patch_cluster/tasks/main.yml
+++ b/roles/patch_cluster/tasks/main.yml
@@ -23,7 +23,7 @@
   copy:
     content: "{{ install_config.json }}"
     dest: "{{ fetched_dest }}/install-config.txt"
-    mode: 0644
+    mode: "0644"
   delegate_to: localhost
   become: false
 
@@ -77,7 +77,7 @@
   copy:
     content: "{{ install_config.json }}"
     dest: "{{ fetched_dest }}/{{ patch_set_prefix }}patched-config.txt"
-    mode: 0644
+    mode: "0644"
   delegate_to: localhost
   become: false
 

--- a/roles/populate_mirror_registry/tasks/populate_registry.yml
+++ b/roles/populate_mirror_registry/tasks/populate_registry.yml
@@ -14,13 +14,13 @@
       file:
         path: "{{ config_file_path }}/containers/"
         state: directory
-        mode: 0755
+        mode: "0755"
 
     - name: Copy pull_secrets file.
       copy:
         src: "{{ config_file_path }}/{{ pull_secret_file_name }}"
         dest: "{{ config_file_path }}/containers/auth.json"
-        mode: 0644
+        mode: "0644"
         remote_src: true
 
     - name: Podman login to remote registry

--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -30,7 +30,7 @@
   copy:
     src: "{{ local_pull_secret_path }}"
     dest: "{{ config_file_path }}/{{ pull_secret_file_name }}"
-    mode: 0644
+    mode: "0644"
   when:
     - not copied_pull_secret.stat.exists
 
@@ -39,7 +39,7 @@
     path: "{{ item }}"
     owner: "{{ file_owner }}"
     group: "{{ file_group }}"
-    mode: 0755
+    mode: "0755"
     state: directory
   loop:
     - "{{ downloads_path }}"
@@ -68,7 +68,7 @@
       unarchive:
         src: "{{ stable_release_url }}/{{ stable_oc_tar }}"
         dest: "{{ oc_tmp_dir.path }}"
-        mode: 0755
+        mode: "0755"
         remote_src: true
 
     - name: Extract artifacts from release image (x86_64)
@@ -133,7 +133,7 @@
         dest: "{{ binaries_tool_path }}/{{ item }}"
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"
-        mode: 0775
+        mode: "0775"
         remote_src: true
       become: true
       with_items:
@@ -154,7 +154,7 @@
         dest: "/usr/local/bin/{{ item }}"
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"
-        mode: 0775
+        mode: "0775"
         remote_src: true
       become: true
       with_items:
@@ -184,7 +184,7 @@
       get_url:
         url: "{{ stable_release_url }}/{{ stable_opm_tar }}"
         dest: "{{ downloads_path }}/{{ openshift_full_version }}/"
-        mode: 0664
+        mode: "0664"
       when:
         - not downloaded_opm_tar.stat.exists
 
@@ -210,7 +210,7 @@
         dest: "{{ binaries_tool_path }}/opm"
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"
-        mode: 0775
+        mode: "0775"
         remote_src: true
       become: true
 

--- a/roles/setup_assisted_installer/tasks/main.yml
+++ b/roles/setup_assisted_installer/tasks/main.yml
@@ -21,7 +21,7 @@
           copy:
             content: "{{ mirror_certificate }}"
             dest: /etc/pki/ca-trust/source/anchors/ai_registry.crt
-            mode: 0660
+            mode: "0660"
             force: true
             backup: true
 
@@ -34,13 +34,13 @@
             path: "{{ config_file_path }}/containers/"
             state: directory
             recurse: true
-            mode: 0755
+            mode: "0755"
 
         - name: Copy pull_secrets file.
           copy:
             content: "{{ pull_secret }}"
             dest: "{{ config_file_path }}/containers/auth.json"
-            mode: 0644
+            mode: "0644"
             remote_src: true
   
       when: use_local_mirror_registry  | bool
@@ -69,7 +69,7 @@
     - name: Create directories for assisted-installer
       ansible.builtin.file:
         path: "{{ item }}"
-        mode: 0775
+        mode: "0775"
         state: directory
       with_items:
         - "{{ assisted_installer_dir }}"
@@ -78,14 +78,14 @@
     - name: Create directory for assisted-installer database
       file:
         path: "{{ assisted_installer_data_dir }}/postgresql"
-        mode: 0775
+        mode: "0775"
         state: directory
         recurse: true
     
     - name: Create directory for assisted-installer images 
       file:
         path: "{{ assisted_installer_data_dir }}/image_service"
-        mode: 0775
+        mode: "0775"
         state: directory
         recurse: true
 
@@ -93,7 +93,7 @@
       template:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
-        mode: 0644
+        mode: "0644"
         trim_blocks: true
         lstrip_blocks: true
       loop:
@@ -165,7 +165,7 @@
           [Install]
           WantedBy=default.target
         dest: "/etc/systemd/system/assisted_installer.service"
-        mode: 0644
+        mode: "0644"
 
     - name: Reload systemd service
       systemd:

--- a/roles/setup_http_store/tasks/main.yml
+++ b/roles/setup_http_store/tasks/main.yml
@@ -24,7 +24,7 @@
         state: directory
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"
-        mode: 0775
+        mode: "0775"
         recurse: true
       loop:
         - "{{ http_dir }}"
@@ -72,7 +72,7 @@
           [Install]
           WantedBy=default.target
         dest: "/etc/systemd/system/http_store.service"
-        mode: 0644
+        mode: "0644"
 
     - name: Reload systemd service
       systemd:

--- a/roles/setup_mirror_registry/tasks/prerequisites.yml
+++ b/roles/setup_mirror_registry/tasks/prerequisites.yml
@@ -23,11 +23,11 @@
     path: "{{ config_file_path }}"
     owner: "{{ file_owner }}"
     group: "{{ file_group }}"
-    mode: 0775
+    mode: "0775"
     state: directory
 
 - name: Copy pull_secret
   copy:
     src: "{{ local_pull_secret_path }}"
     dest: "{{ config_file_path }}/{{ pull_secret_file_name }}"
-    mode: 0644
+    mode: "0644"

--- a/roles/setup_mirror_registry/tasks/setup_registry.yml
+++ b/roles/setup_mirror_registry/tasks/setup_registry.yml
@@ -23,7 +23,7 @@
         path: "{{ item }}"
         owner:  "{{ file_owner }}"
         group:  "{{ file_group }}"
-        mode: 0775
+        mode: "0775"
         state: directory
         recurse: true
       loop:
@@ -42,7 +42,7 @@
     dest: "{{ registry_dir_auth }}/htpasswd"
     owner:  "{{ file_owner }}"
     group:  "{{ file_group }}"
-    mode: 0660
+    mode: "0660"
     backup: true
     force: true
   become: true
@@ -66,7 +66,7 @@
   copy:
     content: "{{ pull_secret | to_json }}"
     dest: "{{ config_file_path }}/{{ pull_secret_file_name }}"
-    mode: 0644
+    mode: "0644"
 
 - name: Update bastion
   set_fact:
@@ -118,7 +118,7 @@
           [Install]
           WantedBy=default.target
         dest: "/etc/systemd/system/container-registry.service"
-        mode: 0644
+        mode: "0644"
 
     - name: Reload demon to pick up changes in container-registry.service
       ansible.builtin.systemd:

--- a/roles/setup_ntp/tasks/main.yml
+++ b/roles/setup_ntp/tasks/main.yml
@@ -13,7 +13,7 @@
         dest: /etc/chrony.conf
         owner: root
         group: root
-        mode: 0644
+        mode: "0644"
       notify: Restart chronyd
 
     - name: Start chrony

--- a/roles/setup_selfsigned_cert/tasks/main.yml
+++ b/roles/setup_selfsigned_cert/tasks/main.yml
@@ -25,7 +25,7 @@
     path: "{{ cert_dir }}"
     owner: "{{ file_owner }}"
     group: "{{ file_group }}"
-    mode: 0770
+    mode: "0770"
     state: directory
     recurse: true
   become: true
@@ -74,7 +74,7 @@
         remote_src: true
         owner: "{{ file_owner }}"
         group: "{{ file_group }}"
-        mode: 0660
+        mode: "0660"
         force: true
         backup: true
 

--- a/roles/setup_sushy_tools/tasks/main.yml
+++ b/roles/setup_sushy_tools/tasks/main.yml
@@ -13,7 +13,7 @@
       file:
         path: "{{ item }}"
         state: directory
-        mode: 0755
+        mode: "0755"
       loop:
         - "{{ sushy_dir }}"
         - "{{ sushy_auth_dir }}"
@@ -66,7 +66,7 @@
             dest: "{{ sushy_auth_file }}"
             owner: "{{ file_owner }}"
             group: "{{ file_group }}"
-            mode: 0660
+            mode: "0660"
             backup: true
             force: true
           become: true
@@ -86,13 +86,13 @@
       template:
         src: sushy-emulator.conf.j2
         dest: "{{ sushy_dir }}/sushy-emulator.conf"
-        mode: 0664
+        mode: "0664"
 
     - name: Create sushy-tools service
       template:
         src: sushy-tools.service.j2
         dest: /etc/systemd/system/sushy-tools.service
-        mode: 0664
+        mode: "0664"
 
     - name: Reload systemd service
       systemd:

--- a/roles/validate_http_store/tasks/main.yml
+++ b/roles/validate_http_store/tasks/main.yml
@@ -11,7 +11,7 @@
   copy:
     content: "{{ contents }}"
     dest: "{{ http_store_dir }}/{{ vhs_test_file_name }}"
-    mode: 0644
+    mode: "0644"
     setype: httpd_sys_content_t
   become: true
   delegate_to: http_store


### PR DESCRIPTION
##### SUMMARY

This change fixes:
62 yaml profile:basic tags:formatting,yaml -
yaml[octal-values]: Forbidden implicit octal value

##### ISSUE TYPE

- Tech Debt

##### Tests

- [x] TestDallasSno: ocp-4.16-sno-abi sno-abi:ansible_extravars=enable_acm: - https://www.distributed-ci.io/jobs/68e0b92e-fa39-453b-9834-ffa0a138c5b6
- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/f8ea71b7-271b-4666-9bd1-1c256eda99a7
- [x] TestBos2Sno: abi-sno abi-sno:ansible_extravars=enable_acm: - https://www.distributed-ci.io/jobs/d68fa1dd-3157-4ca7-ab0d-e1d031e5906a

---

Test-hints: no-check
