### PR TITLE
monitor_abi | Check if certificate issue appears while monitoring installation

### DIFF
--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -23,7 +23,10 @@
       until:
         "'Attempted to gather ClusterOperator status after wait failure: Listing ClusterOperator objects' not in _mabi_install_output.stderr
         or
-        'No events logged from the Agent Rest API' in _mabi_install_output.stderr"
+        'No events logged from the Agent Rest API' in _mabi_install_output.stderr
+        or
+        'x509: certificate has expired or is not yet valid' in _mabi_install_output.stderr"
+
   rescue:
     # Using master-0 IP address to reach the bootstrap VM
     # Placing the logs in repo_root_path


### PR DESCRIPTION
##### SUMMARY

Right now, we're hitting daily ABI issues like [this one](https://www.distributed-ci.io/jobs/6bf7bef5-ea29-4933-a1d8-69b0896d7f81/jobStates?sort=date&task=eb684fd4-b630-4a4c-a2b2-500e5c462ca7), where we're repeating the ABI monitoring check because we're not meeting the conditions to stop checking, but we should stop because we have a recurrent certificate issue, but each retry lasts 1-2h, so the job lasts >10h

Adding this certificate issue to the conditions to stop waiting. Checked manually, it works.

##### ISSUE TYPE

Bug

##### Tests

- [x] TestBos2: abi - https://www.distributed-ci.io/jobs/f5200ad3-a184-48f7-8932-2a22387d95c6/jobStates

Test-Hints: no-check