### PR TITLE
Do not use handlers to remove files

### DIFF
--- a/roles/acm_hypershift/handlers/main.yml
+++ b/roles/acm_hypershift/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: Remove working directory
-  ansible.builtin.file:
-    path: "{{ hs_tmp_dir.path }}"
-    state: absent
-  when: hs_tmp_dir is defined

--- a/roles/acm_hypershift/tasks/create-cluster.yml
+++ b/roles/acm_hypershift/tasks/create-cluster.yml
@@ -19,8 +19,13 @@
       {% if ah_control_plane_availability_policy is defined %}
       --control-plane-availability-policy="{{ ah_control_plane_availability_policy }}"
       {% endif %}
-  notify: Remove working directory
   changed_when: false
+
+- name: Remove working directory
+  ansible.builtin.file:
+    path: "{{ hs_tmp_dir.path }}"
+    state: absent
+  when: hs_tmp_dir is defined
 
 - name: Wait for Hosted Cluster initialization
   ansible.builtin.pause:

--- a/roles/chart_verifier/tasks/cleanup.yml
+++ b/roles/chart_verifier/tasks/cleanup.yml
@@ -3,19 +3,23 @@
   ansible.builtin.file:
     state: absent
     path: "{{ cv_tool_dir.path }}"
+  when:
+    - cv_tool_dir is defined
+    - cv_tool_dir.path is defined
 
 - name: "Delete work_dir directory"
   ansible.builtin.file:
     state: absent
-    path: "{{ work_dir }}"
-  listen: "helm-chart-verifier cleanup"
+    path: "{{ tmp_dir.path }}"
+  when:
+    - tmp_dir
+    - tmp_dir.path is defined
 
 - name: "Delete the one time use key from Github"
   ansible.builtin.command: "{{ gh_tool_path }} api -X DELETE user/keys/{{ key_id }}"
   ignore_errors: true
-  listen: "helm-chart-verifier cleanup"
 
 - name: "GH logout"
   ansible.builtin.command: "{{ gh_tool_path }} auth logout --hostname github.com"
-  listen: "helm-chart-verifier cleanup"
+  ignore_errors: true
 ...

--- a/roles/chart_verifier/tasks/cleanup.yml
+++ b/roles/chart_verifier/tasks/cleanup.yml
@@ -21,5 +21,5 @@
 
 - name: "GH logout"
   ansible.builtin.command: "{{ gh_tool_path }} auth logout --hostname github.com"
-  ignore_errors: true
+  failed_when: false
 ...

--- a/roles/chart_verifier/tasks/main.yml
+++ b/roles/chart_verifier/tasks/main.yml
@@ -41,6 +41,6 @@
     loop_var: chart
     index_var: index
 
-- name: "Run the tests"
+- name: Cleanup tasks
   ansible.builtin.include_tasks: cleanup.yml
 ...

--- a/roles/chart_verifier/tasks/main.yml
+++ b/roles/chart_verifier/tasks/main.yml
@@ -40,4 +40,7 @@
   loop_control:
     loop_var: chart
     index_var: index
+
+- name: "Run the tests"
+  ansible.builtin.include_tasks: cleanup.yml
 ...

--- a/roles/chart_verifier/tasks/mirror-chart-images.yml
+++ b/roles/chart_verifier/tasks/mirror-chart-images.yml
@@ -10,8 +10,6 @@
     loop_var: chart
     label: "{{ chart.chart_file | basename }}"
   register: chart_images
-  notify:
-    - "Delete tmp tool directory"
 
 - name: "Get all images"
   ansible.builtin.set_fact:

--- a/roles/chart_verifier/tasks/tests.yml
+++ b/roles/chart_verifier/tasks/tests.yml
@@ -205,6 +205,4 @@
   when:
     - pr_details is defined
     - pr_details.rc == 0
-  notify:
-    - "helm-chart-verifier cleanup"
 ...

--- a/roles/fbc_catalog/handlers/main.yml
+++ b/roles/fbc_catalog/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: "Delete temp directory"
-  ansible.builtin.file:
-    state: absent
-    path: "{{ fbc_tmp_dir }}"
-...

--- a/roles/fbc_catalog/tasks/main.yml
+++ b/roles/fbc_catalog/tasks/main.yml
@@ -73,8 +73,11 @@
     -t {{ fbc_index_image }}
   args:
     chdir: "{{ fbc_tmp_dir }}"
-  notify:
-    - "Delete temp directory"
+
+- name: "Delete temp directory"
+  ansible.builtin.file:
+    state: absent
+    path: "{{ fbc_tmp_dir }}"
 
 - name: "Display fbc_index_image"
   ansible.builtin.debug:

--- a/roles/mirror_catalog/handlers/main.yml
+++ b/roles/mirror_catalog/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: Delete tmp directory
-  file:
-    path: "{{ mc_tmp.path }}"
-    state: absent
-  when: mc_tmp is defined

--- a/roles/mirror_catalog/tasks/main.yml
+++ b/roles/mirror_catalog/tasks/main.yml
@@ -108,5 +108,10 @@
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
     mode: "0644"
-  notify:
-    - "Delete tmp directory"
+
+- name: Delete tmp directory
+  ansible.builtin.file:
+    path: "{{ mc_tmp.path }}"
+    state: absent
+  when: mc_tmp is defined
+...

--- a/roles/opcap_tool/handlers/main.yml
+++ b/roles/opcap_tool/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: "Remove opcap dir"
-  ansible.builtin.file:
-    path: "{{ opcap_dir.path }}"
-    state: absent
-...

--- a/roles/opcap_tool/tasks/main.yml
+++ b/roles/opcap_tool/tasks/main.yml
@@ -41,6 +41,9 @@
     dest: "{{ opcap_output_dir }}/{{ opcap_target_catalog_source }}_install_report.json"
     mode: "0644"
   when: opcap_check.stdout != ""
-  notify:
-    - "Remove opcap dir"
+
+- name: "Remove opcap dir"
+  ansible.builtin.file:
+    path: "{{ opcap_dir.path }}"
+    state: absent
 ...

--- a/roles/setup_gitea/handlers/main.yml
+++ b/roles/setup_gitea/handlers/main.yml
@@ -1,4 +1,0 @@
-- name: Clear mirror temp dir
-  ansible.builtin.file:
-    path: "{{ _sg_mirror_repo.path }}"
-    state: absent

--- a/roles/setup_gitea/tasks/cleanup.yml
+++ b/roles/setup_gitea/tasks/cleanup.yml
@@ -15,4 +15,9 @@
   retries: 10
   delay: 5
   until: _sg_gitea_namespace.resources | length == 0
+
+- name: Clear mirror temp dir
+  ansible.builtin.file:
+    path: "{{ _sg_mirror_repo.path }}"
+    state: absent
 ...

--- a/roles/setup_gitea/tasks/install.yml
+++ b/roles/setup_gitea/tasks/install.yml
@@ -147,7 +147,6 @@
         state: directory
         prefix: setup_gitea
       register: _sg_mirror_repo
-      notify: Clear mirror temp dir
 
     - name: Clone reference repository
       # Use sshkey file when provided, otherwise omit it in the module


### PR DESCRIPTION
##### SUMMARY

Handlers are executed once the plays are done, some issues non-related to the role may avoid removing some temp files. So, removing temporary files once is not needed by the role.

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Nominal change

##### Tests

- [x] Test at Dallas: ocp-4.16-acm-hypershift   openshift-acm-hypershift:ansible_extravars=ah_force_deploy:true     openshift-acm-hypershift:ansible_extravars=ah_cluster_name:hosted https://www.distributed-ci.io/jobs/b72e80b4-9e24-4db8-b095-2d1a5701d8da/jobStates
- [x] TestDallasWorkload: preflight-green - 
https://www.distributed-ci.io/jobs/37d7de7a-78e2-410f-983c-e2e427307ab6/jobStates
- [x] TestDallasWorkload: tnf-test-cnf-green https://www.distributed-ci.io/jobs/c1e6010b-38b2-4be5-b417-783d761c3d97/jobStates
- [x] TestDallasSno: ocp-4.16-sno-abi -https://www.distributed-ci.io/jobs/4abd49a4-0364-41ce-abc0-302e435e7c8b/jobStates?sort=date
- [x] Test in HelmChart: https://www.distributed-ci.io/jobs/bdcd611e-338c-4026-9250-b2bba2fa63ca/jobStates

Test-Hint: no-check
