### PR TITLE
Update openshift doc links

### DIFF
--- a/roles/configure_ztp_gitops_apps/tasks/main.yaml
+++ b/roles/configure_ztp_gitops_apps/tasks/main.yaml
@@ -52,7 +52,7 @@
         mode: "0644"
 
     # Please see:
-    # https://docs.openshift.com/container-platform/4.12/scalability_and_performance/ztp_far_edge/ztp-manual-install.html
+    # https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/edge_computing/ztp-manual-install#ztp-generating-install-and-config-crs-manually_ztp-manual-install
     - name: Download ZTP cluster and policies applications from ztp site generator
       ansible.builtin.shell: |
         set -o pipefail

--- a/roles/metallb_setup/README.md
+++ b/roles/metallb_setup/README.md
@@ -118,7 +118,7 @@ To confirm that the BGP routing is working properly:
 
 ## Troubleshooting
 
-See [Troubleshooting MetalLB](https://docs.openshift.com/container-platform/4.13/networking/metallb/metallb-troubleshoot-support.html)
+See [Troubleshooting MetalLB](https://docs.redhat.com/documentation/openshift_container_platform/4.17/html/networking/load-balancing-with-metallb#nw-metallb-setting-metalb-logging-levels_metallb-troubleshoot-support)
 
 1. Confirm that all the pods in the `metallb-system` namespace are running.
     ```ShellSession
@@ -142,4 +142,4 @@ See [Troubleshooting MetalLB](https://docs.openshift.com/container-platform/4.13
 
 ## References
 
-* [MetalLB Operator documentation](https://docs.openshift.com/container-platform/4.13/networking/metallb/about-metallb.html)
+* [MetalLB Operator documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/networking/load-balancing-with-metallb)

--- a/roles/mirror_catalog/README.md
+++ b/roles/mirror_catalog/README.md
@@ -23,7 +23,7 @@ mc_max_components          | No       | int     | 3       | The maximum number o
 The following applications must be already present in the system.
 
 - [skopeo](https://github.com/containers/skopeo/blob/main/install.md)
-- [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html)
+- [oc](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc)
 
 ## Outputs
 

--- a/roles/ocp_logging/README.md
+++ b/roles/ocp_logging/README.md
@@ -26,7 +26,7 @@ This role only works on OCP 4.10 and newer and with a S3 compatible storage back
 | ol_bucket                              | undefined                     | Yes         | Object Storage bucket name                    |
 | ol_endpoint                            | undefined                     | Yes         | Object Storage endpoint                       |
 | ol_region                              | undefined                     | Yes         | Object Storage region                         |
-| ol_loki_size                           | undefined                     | Yes         | Loki Deployment Size. See [Sizing](https://docs.openshift.com/container-platform/4.13/logging/cluster-logging-loki.html#deployment-sizing_cluster-logging-loki) for more details |
+| ol_loki_size                           | undefined                     | Yes         | Loki Deployment Size. See [Sizing](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/logging/log-storage-3#loki-deployment-sizing_installing-log-storage) for more details |
 | ol_storage_class                       | undefined                     | Yes         | Cluster Storage class for Loki components     |
 | ol_event_router_image                  | registry.redhat.io/openshift-logging/eventrouter-rhel8:v5.2.1-1 | No   | Event Router image |
 | ol_action                              | install                       | No          | Controls the action performed by the role: Install or cleanup|
@@ -103,7 +103,7 @@ The following are some recommended actions in case there are issues during the d
 
 # References
 
-* [Cluster Logging Loki documentation](https://docs.openshift.com/container-platform/4.13/logging/cluster-logging-loki.html)
+* [Cluster Logging Loki documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/logging/cluster-logging-deploying#logging-loki-cli-install_cluster-logging-deploying)
 * [olm_operator](../olm_operator/README.md): A role that installs OLM based operators.
 * [dci-openshfit-agent](https://github.com/redhat-cip/dci-openshift-agent/): An agent that allows the deployment of OCP clusters, it is integrated with DCI (Red Hat Distributed CI).
 * [dci-openshfit-app-agent](https://github.com/redhat-cip/dci-openshift-app-agent/): An agent that allows the deployment of workloads and certification testing on top OCP clusters, it is integrated with DCI (Red Hat Distributed CI).

--- a/roles/prune_catalog/README.md
+++ b/roles/prune_catalog/README.md
@@ -21,7 +21,7 @@ The following application must be already present on the system.
 
 - [Podman](https://podman.io/docs/installation)
 - [skopeo](https://github.com/containers/skopeo/blob/main/install.md)
-- [jq](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html)
+- [jq](https://github.com/jqlang/jq)
 
 ## Example of usage
 

--- a/roles/rhoai/tasks/uninstall.yml
+++ b/roles/rhoai/tasks/uninstall.yml
@@ -51,7 +51,7 @@
     - servicemesh
 
 # Have to clean up additional resources according to
-# https://docs.openshift.com/container-platform/4.14/service_mesh/v1x/removing-ossm.html
+# https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/service_mesh/service-mesh-2-x#ossm-control-plane-remove_removing-ossm
 - name: Remove istio DaemonSet
   kubernetes.core.k8s:
     state: absent

--- a/roles/setup_netobserv_stack/README.md
+++ b/roles/setup_netobserv_stack/README.md
@@ -36,7 +36,7 @@ setup_netobserv_stack_access_key_secret            | minioadmin                 
 setup_netobserv_stack_bucket                       | network                         | No          | Bucket for the Network Observability
 setup_netobserv_stack_endpoint                     | http://minio-service.minio:9000 | No          | Object Storage Endpoint. It must exist and be reachable
 setup_netobserv_stack_region                       | us-east-1                       | No          | Object Storage region
-setup_netobserv_stack_loki_size                    | 1x.extra-small                  | No          | Loki Stack size See [Sizing](https://docs.openshift.com/container-platform/4.14/logging/log_storage/installing-log-storage.html)
+setup_netobserv_stack_loki_size                    | 1x.extra-small                  | No          | Loki Stack size See [Sizing](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/logging/log-storage-3#loki-deployment-sizing_installing-log-storage)
 setup_netobserv_stack_storage_class                | managed-nfs-storage             | No          | Storage class for the Loki Stack
 
 ## Role requirements
@@ -118,7 +118,7 @@ The following are some recommended actions in case there are issues during the d
 
 # References
 
-* [Network Observability Operator documentation](https://docs.openshift.com/container-platform/4.14/network_observability/configuring-operator.html)
+* [Network Observability Operator documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/network_observability/configuring-network-observability-operators)
 * [olm_operator](../olm_operator/README.md): A role that installs OLM based operators.
 * [dci-openshfit-agent](https://github.com/redhat-cip/dci-openshift-agent/): An agent that allows the deployment of OCP clusters, it is integrated with DCI (Red Hat Distributed CI).
 * [dci-openshfit-app-agent](https://github.com/redhat-cip/dci-openshift-app-agent/): An agent that allows the deployment of workloads and certification testing on top OCP clusters, it is integrated with DCI (Red Hat Distributed CI).

--- a/roles/storage_tester/README.md
+++ b/roles/storage_tester/README.md
@@ -5,7 +5,7 @@
 * the provisioner associated with the storage class must implement the CSI `CLONE_VOLUME` [capability](https://kubernetes-csi.github.io/docs/developing.html).
 * A running OpenShift cluster with the proper credentials is required, credentials must be passed as by setting the KUBECONFIG environment.
 
-For more information on storage classes, see [the OCP documentation](https://docs.openshift.com/container-platform/4.11/post_installation_configuration/storage-configuration.html#defining-storage-classes_post-install-storage-configuration).
+For more information on storage classes, see [the OCP documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/storage/dynamic-provisioning#basic-storage-class-definition_dynamic-provisioning).
 
 ### Three scenarios of tests
 It can be enabled by setting the boolean `storage_upgrade_tester` to **true**, when the dci-openshift-agent is running an upgrade.


### PR DESCRIPTION
##### SUMMARY

The openshift docs are being decommissioned, migrating the links to the latest available in docs.redhat.com

##### ISSUE TYPE

- Docs

##### Tests

Test-Hint: no-check
