### PR TITLE
Add info about organization_id

### DIFF
--- a/roles/chart_verifier/README.md
+++ b/roles/chart_verifier/README.md
@@ -12,12 +12,12 @@ chart_verifier_image               | quay.io/redhat-certification/chart-verifier
 dci_charts                         | undefined                                         | true        | A list of charts and its corresponding parameters to be used during testing. See [How to use with DCI](#how-to-use-with-dci) section for more details
 logs_dir                           | /tmp                                              | false       | Directory to store the tests results.
 github_token_path                  | undefined                                         | true        | GitHub token to be used to push the chart and the results to a repository. Defaults to [openshift-charts/charts](https://github.com/openshift-helm-charts/charts/)
-organization_id                    | undefined                                         | true        | Red Hat PartnerID. Obtained it from https://connect.redhat.com/account/company-profile
+organization_id                    | unknown                                           | false       | Red Hat PartnerID, used to obtain the partner_name. Recommended for tests that will be submitted. Obtained it from https://connect.redhat.com/account/company-profile.
 project_url             | https://catalog.redhat.com/api/containers/v1/vendors/org-id  | true        | API endpoint to query for vendor details.
 partner_email                      | undefined                                         | true        | Email address to be used in the pull request
 sandbox_repository                 | undefined                                         | false       | Target repository to submit the PRs instead of openshift-helm-charts/charts/
 
-Note: The `partner_name` used for merging the chart pull request is retrieved from the organization. This prevents the pull request merge fails during validation. The partner_name represents the Container Registry Namespace or vendor label, and it will be empty for new partners until at least one certification project has been created for their account.
+Note: A valid `partner_name` is required for the chart pull request to be accepted. It is derived from the organization_id. If the `organization_id` is invalid/nonexistent, `partner_name` will be set to "None". The partner_name corresponds to the Container Registry Namespace or vendor label and will remain empty for new partners until they create at least one certification project.
 
 ## Helm charts Certification in a nut shell
 

--- a/roles/chart_verifier/README.md
+++ b/roles/chart_verifier/README.md
@@ -12,12 +12,12 @@ chart_verifier_image               | quay.io/redhat-certification/chart-verifier
 dci_charts                         | undefined                                         | true        | A list of charts and its corresponding parameters to be used during testing. See [How to use with DCI](#how-to-use-with-dci) section for more details
 logs_dir                           | /tmp                                              | false       | Directory to store the tests results.
 github_token_path                  | undefined                                         | true        | GitHub token to be used to push the chart and the results to a repository. Defaults to [openshift-charts/charts](https://github.com/openshift-helm-charts/charts/)
-organization_id                    | undefined                                         | true        | Get Partner name from Organization automatic and to be used in the pull request title
-project_url             | https://catalog.redhat.com/api/containers/v1/vendors/org-id  | true        | Use to get partner name from organization ID
+organization_id                    | undefined                                         | true        | Red Hat PartnerID. Obtained it from https://connect.redhat.com/account/company-profile
+project_url             | https://catalog.redhat.com/api/containers/v1/vendors/org-id  | true        | API endpoint to query for vendor details.
 partner_email                      | undefined                                         | true        | Email address to be used in the pull request
 sandbox_repository                 | undefined                                         | false       | Target repository to submit the PRs instead of openshift-helm-charts/charts/
 
-Note: The partner_name used for merging the PR is now automatically retrieved from the organization, eliminating the need for users to manually define it with a variable. This change is essential to prevent PR merge failures during validation that could arise from user typos. The partner_name represents the Container Registry Namespace or vendor label, and it will be empty for new partners until at least one certification project has been created for their account.
+Note: The `partner_name` used for merging the chart pull request is retrieved from the organization. This prevents the pull request merge fails during validation. The partner_name represents the Container Registry Namespace or vendor label, and it will be empty for new partners until at least one certification project has been created for their account.
 
 ## Helm charts Certification in a nut shell
 

--- a/roles/chart_verifier/defaults/main.yml
+++ b/roles/chart_verifier/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 chart_verifier_image: quay.io/redhat-certification/chart-verifier:main
 project_url: "https://catalog.redhat.com/api/containers/v1/vendors/org-id"
+organization_id: unknown
 ...

--- a/roles/chart_verifier/tasks/get-partner-name.yml
+++ b/roles/chart_verifier/tasks/get-partner-name.yml
@@ -4,17 +4,17 @@
     url: "{{ project_url }}/{{ organization_id }}"
     method: GET
     return_content: true
-    status_code: 200
+    status_code: [200, 404]  # Accept both 200 (success) and 404 (not found)
     timeout: 60
   register: _cv_vendor_partner_name
-  until: not _cv_vendor_partner_name.failed
+  until:
+    - _cv_vendor_partner_name.status == 200
+      or _cv_vendor_partner_name.status == 404
   retries: 3
   delay: 7
 
-- name: Set partner name from the vendor label
+- name: Set partner name with default if not found
   ansible.builtin.set_fact:
-    partner_name: "{{ _cv_vendor_partner_name.json.label }}" # noqa: redhat-ci[no-role-prefix]
-  when:
-    - _cv_vendor_partner_name.json is defined
-    - _cv_vendor_partner_name.json | length > 0
+    partner_name: "{{ _cv_vendor_partner_name.json.label if _cv_vendor_partner_name.status == 200
+                   else 'None' }}" # noqa: redhat-ci[no-role-prefix]
 ...

--- a/roles/chart_verifier/tasks/main.yml
+++ b/roles/chart_verifier/tasks/main.yml
@@ -7,7 +7,6 @@
     - kubeconfig_path
     - ocp_version_full
     - dci_charts
-    - organization_id
 
 - name: "Get partner name"
   ansible.builtin.include_tasks: get-partner-name.yml
@@ -15,12 +14,6 @@
 # Get tools like yq and helm
 - name: "Get tools"
   ansible.builtin.include_tasks: get-tools.yml
-
-## Temporary disabled, failing with images
-## with format like rhscl/mongodb-36-rhel7:1-65
-# - name: "Mirror chart images"
-#   include_tasks: mirror-chart-images.yml
-#   when: dci_disconnected | default(false) | bool
 
 - name: "Set Logs path"
   ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY

Add information about how to get the organization_id from connect
Allow to run tests even if the vendor information is not available in the connect API.

##### ISSUE TYPE

- Documentation

