### PR TITLE
Add delete-ztp-by-reference action

### DIFF
--- a/roles/acm_spoke_mgmt/README.md
+++ b/roles/acm_spoke_mgmt/README.md
@@ -92,7 +92,7 @@ Two resources are deleted by this role.
 Name                         | Type   | Required | Default                                            | Description
 ---------------------------- | ------ | -------- | -------------------------------------------------- | ------------------------------------------------------------
 asm_source_repo              | string | yes      | -                                                  | GitOps repository that was used to deploy the ZTP cluster
-asm_target_revision          | string | yes      | -                                                  | Branch used to to deploy the ZTP cluster
+asm_target_revision          | string | yes      | -                                                  | Branch used to deploy the ZTP cluster
 asm_delete_ztp_resources     | boolean| yes      | true                                               | Deletes the ArgoCD applications and all the related cluster deployments resources
 
 ### Example

--- a/roles/acm_spoke_mgmt/README.md
+++ b/roles/acm_spoke_mgmt/README.md
@@ -10,7 +10,7 @@ The following variable controls the action that can be performed within this rol
 
 Name                         | Type   | Required | Default                                            | Description
 ---------------------------- | ------ | -------- | -------------------------------------------------- | ------------------------------------------------------------
-asm_action                   | string | yes      | -                                                  | Action to be performed. Accepted values are `detach` and `attach`.
+asm_action                   | string | yes      | -                                                  | Action to be performed. Accepted values are `detach`, `attach`, and `delete-ztp-by-ref`.
 
 ## Detach a spoke cluster
 
@@ -73,4 +73,37 @@ asm_cluster_name             | string | yes      | -                            
     asm_action: "attach"
     asm_cluster_kubeconfig_path: "/path/to/spoke/kubeconfig"
     asm_cluster_name: "mycluster"
+
+## Remove ZTP ArgoCD resources
+
+This action allows to remove the ArgoCD resources used to deploy a ZTP cluster. This could remove all the created resources in cascading. The role locates the ArgoCD applications used to create a cluster using the GitOps repository a source branch as references.
+
+Two resources are deleted by this role.
+
+- Application - Cluster
+- Application - Policies
+
+### Requirements
+
+* A `KUBECONFIG` environment variable pointing to the management cluster's kubeconfig file.
+
+### Role Variables
+
+Name                         | Type   | Required | Default                                            | Description
+---------------------------- | ------ | -------- | -------------------------------------------------- | ------------------------------------------------------------
+asm_source_repo              | string | yes      | -                                                  | GitOps repository that was used to deploy the ZTP cluster
+asm_target_revision          | string | yes      | -                                                  | Branch used to to deploy the ZTP cluster
+asm_delete_ztp_resources     | boolean| yes      | true                                               | Deletes the ArgoCD applications and all the related cluster deployments resources
+
+### Example
+
+```yaml
+- name: Remove a ZTP managed cluster from ArgoCD
+  ansible.builtin.include_role:
+    name: redhatci.ocp.acm_spoke_mgmt
+  vars:
+    asm_action: "delete-ztp-by-ref"
+    asm_cluster_kubeconfig_path: "/path/to/spoke/kubeconfig"
+    asm_source_repo: "http://<gitops-repository>/gituser/gitops"
+    asm_target_revision: main
 ```

--- a/roles/acm_spoke_mgmt/defaults/main.yaml
+++ b/roles/acm_spoke_mgmt/defaults/main.yaml
@@ -1,1 +1,3 @@
 ---
+asm_delete_ztp_resources: true
+...

--- a/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
+++ b/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
@@ -1,0 +1,73 @@
+---
+- name: Assert the required variables are defined
+  ansible.builtin.assert:
+    that:
+      - asm_source_repo is defined
+      - asm_source_repo | length > 0
+      - asm_target_revision is defined
+      - asm_target_revision | length > 0
+
+- name: Get all ArgoCD Applications
+  kubernetes.core.k8s_info:
+    api_version: argoproj.io/v1alpha1
+    kind: Application
+    namespace: openshift-gitops
+  register: _asm_all_apps
+  no_log: true
+
+- name: Delete ArgoCD Applications
+  vars:
+    app_sites: "{{ _asm_all_apps.resources | selectattr('spec.source.repoURL', 'equalto', asm_source_repo)
+                | selectattr('spec.source.path', 'equalto', 'sites')
+                | selectattr('spec.source.targetRevision', 'equalto', asm_target_revision)
+                | map(attribute='metadata.name') | list }}"
+    app_policies: "{{ _asm_all_apps.resources | selectattr('spec.source.repoURL', 'equalto', asm_source_repo)
+                | selectattr('spec.source.path', 'equalto', 'policies')
+                | selectattr('spec.source.targetRevision', 'equalto', asm_target_revision)
+                | map(attribute='metadata.name') | list }}"
+    apps_list: "{{ app_sites + app_policies | default([]) }}"
+    app_ns: openshift-gitops
+  when:
+    - apps_list | length > 0
+  block:
+    - name: Patch ArgoCD application finalizers
+      kubernetes.core.k8s:
+        api_version: argoproj.io/v1alpha1
+        kind: Application
+        name: "{{ app }}"
+        namespace: "{{ app_ns }}"
+        definition:
+          metadata:
+            finalizers:
+              - "resources-finalizer.argocd.argoproj.io"
+      loop: "{{ apps_list }}"
+      loop_control:
+        loop_var: app
+      when:
+        - asm_delete_ztp_resources | bool
+
+    - name: Delete Argo Applications
+      kubernetes.core.k8s:
+        state: absent
+        api_version: argoproj.io/v1alpha1
+        kind: Application
+        name: "{{ app }}"
+        namespace: "{{ app_ns }}"
+      loop: "{{ apps_list }}"
+      loop_control:
+        loop_var: app
+
+    - name: Wait for ArgoCD application deletion
+      kubernetes.core.k8s_info:
+        api_version: argoproj.io/v1alpha1
+        kind: Application
+        name: "{{ app }}"
+        namespace: "{{ app_ns }}"
+      register: _asm_app_status
+      until: _asm_app_status.resources | length == 0
+      retries: 120
+      delay: 10
+      loop: "{{ apps_list }}"
+      loop_control:
+        loop_var: app
+...

--- a/roles/acm_spoke_mgmt/tasks/main.yaml
+++ b/roles/acm_spoke_mgmt/tasks/main.yaml
@@ -5,6 +5,7 @@
     asm_actions:
       - detach
       - attach
+      - delete-ztp-by-ref
   ansible.builtin.assert:
     that:
       - asm_action | lower in asm_actions
@@ -20,4 +21,8 @@
   when:
     - asm_action == 'attach'
 
+- name: Delete a ZTP deployment by references
+  ansible.builtin.include_tasks: delete-ztp-by-ref.yaml
+  when:
+    - asm_action == 'delete-ztp-by-ref'
 ...


### PR DESCRIPTION
##### SUMMARY

Allow removing a ZTP cluster managed by ArgoCD using the source repository and branch to identify the target cluster

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

- [x] ocp-4.16-ztp-sno ztp-spoke:ansible_extravars=dci_teardown_on_success:true ztp-spoke:ansible_extravars=dci_teardown_on_failure:true -> https://www.distributed-ci.io/jobs/5535949f-3102-459f-95c3-2cf2e4f03746/jobStates?sort=date

- [x] ocp-4.16-acm-sno openshift-acm-sno:ansible_extravars=dci_teardown_on_success:true openshift-acm-sno:ansible_extravars=dci_teardown_on_failure:true -> https://www.distributed-ci.io/jobs/790a9b7d-0510-4b70-90b5-1b7682b45bc8/jobStates?sort=date

Test-Hint: no-check