### PR TITLE
Move GH logout to the proper role

### DIFF
--- a/roles/chart_verifier/tasks/cleanup.yml
+++ b/roles/chart_verifier/tasks/cleanup.yml
@@ -14,12 +14,4 @@
   when:
     - tmp_dir
     - tmp_dir.path is defined
-
-- name: "Delete the one time use key from Github"
-  ansible.builtin.command: "{{ gh_tool_path }} api -X DELETE user/keys/{{ key_id }}"
-  ignore_errors: true
-
-- name: "GH logout"
-  ansible.builtin.command: "{{ gh_tool_path }} auth logout --hostname github.com"
-  failed_when: false
 ...

--- a/roles/create_pr/tasks/main.yml
+++ b/roles/create_pr/tasks/main.yml
@@ -101,4 +101,12 @@
 - name: Create PR for Operator Bundle Certification
   ansible.builtin.include_tasks: bundle_operator.yml
   when: product_type == "operator"
+
+- name: "Delete the one time use key from Github"
+  ansible.builtin.command: "{{ gh_tool_path }} api -X DELETE user/keys/{{ key_id }}"
+  ignore_errors: true
+
+- name: "GH logout"
+  ansible.builtin.command: "{{ gh_tool_path }} auth logout --hostname github.com"
+  failed_when: false
 ...


### PR DESCRIPTION
##### SUMMARY

gh_tool path is own by create_pr, not by chart_verifier, so moving tasks to the proper role

##### ISSUE TYPE
- Bug

##### Tests

Test-Hint: no-check