### PR TITLE
Increase version for certsuite role v5.4.7

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.4.6
+kbpc_version: v5.4.7
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"
@@ -123,6 +123,7 @@ kbpc_feedback:
   performance-shared-cpu-pool-non-rt-scheduling-policy: ""
   platform-alteration-base-image: ""
   platform-alteration-boot-params: ""
+  platform-alteration-cluster-operator-health: ""
   platform-alteration-hugepages-1g-only: ""
   platform-alteration-hugepages-2m-only: ""
   platform-alteration-hugepages-config: ""


### PR DESCRIPTION
##### SUMMARY

Bump the default version to v5.4.7 and include new test under platform-alteration

https://github.com/redhat-best-practices-for-k8s/certsuite/releases/tag/v5.4.7

##### ISSUE TYPE

- Nominal change

##### Tests

- [ ] TestDallasWorkload: tnf-test-cnf tnf-test-cnf:ansible_extravars=tests_to_verify:[] - https://www.distributed-ci.io/jobs/53dad110-8aa6-4209-9f87-6306419a1b3f

---

Test-Hints: no-check