### PR TITLE
Fix ansible lint command-instead-of-shell

### DIFF
--- a/roles/apply_nmstate/tasks/main.yml
+++ b/roles/apply_nmstate/tasks/main.yml
@@ -19,10 +19,11 @@
         file: check_if_vm_host_is_bastion.yml
 
     - name: Apply nmstate
-      ansible.builtin.shell:
+      ansible.builtin.command:
         cmd: "nmstatectl apply --no-commit --timeout 120 {{ vm_nmstate_config_path }}"
       async: 60
       poll: 5
+      changed_when: false
 
     - name: Check network connection when vm_host and bastion are the same
       when: vm_host_is_bastion | bool
@@ -36,14 +37,16 @@
               This should be and IP external to the bastion and vm_host.
 
         - name: "Check for connection wider network"
-          ansible.builtin.shell:
+          ansible.builtin.command:
             cmd: "ping -c 4 -W 1 {{ vm_network_test_ip }}"
           when: vm_host_is_bastion | bool
           register: connection_test_result
           until: connection_test_result is succeeded
           retries: 60
           delay: 5
+          changed_when: false
 
     - name: Commit changes
-      ansible.builtin.shell:
+      ansible.builtin.command:
         cmd: "nmstatectl commit"
+      changed_when: false

--- a/roles/create_vms/tasks/provision_vms.yml
+++ b/roles/create_vms/tasks/provision_vms.yml
@@ -27,7 +27,8 @@
       loop: "{{ kvm_nodes }}"
 
     - name: Run vm creation_scripts
-      shell: 
+      ansible.builtin.command:
         cmd: "/bin/bash {{ vm_create_scripts_dir }}/{{ item.name }}_setup_vm.sh"
+      changed_when: false
       
       loop: "{{ kvm_nodes }}"

--- a/roles/extract_openshift_installer/tasks/main.yml
+++ b/roles/extract_openshift_installer/tasks/main.yml
@@ -23,10 +23,11 @@
       --to={{ extract_dest_path }}
 
 - name: Check extracted installer has agent subcommand
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: "{{ openshift_installer_path }} agent --help"
   register: res
   failed_when: false
+  changed_when: false
 
 - name: Check agent sub-commmand output
   ansible.builtin.fail:

--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -1,8 +1,9 @@
 - name: Wait for bootstrap complete
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: "{{ agent_based_installer_path }} --log-level=debug agent wait-for bootstrap-complete"
     chdir: "{{ manifests_dir }}"
-  failed_when: false # Timeout is fixed and some bare metal clusters complete bootstrap just after the timeout
+  failed_when: false
+  changed_when: false
 
 - name: Check installation and gather jobs if it fails
   block:
@@ -30,11 +31,10 @@
   rescue:
     # Using master-0 IP address to reach the bootstrap VM
     # Placing the logs in repo_root_path
-    # Trying several times in case there are SSH connectivity issues
     - name: Gather logs from installation
       vars:
         rendezvous_ip_address: "{{ hostvars[agent_based_installer_bootstrap_node][host_ip_keyword] }}"
-      ansible.builtin.shell:
+      ansible.builtin.command:
         cmd: "{{ agent_based_installer_path }} --log-level=debug gather bootstrap --bootstrap {{ rendezvous_ip_address }}"
         chdir: "{{ repo_root_path }}"
       register: command_result
@@ -42,6 +42,7 @@
       retries: 6
       delay: 20
       failed_when: false
+      changed_when: false
 
     - name: Fail properly because installation was not completed
       fail:

--- a/roles/mount_discovery_iso_for_pxe/tasks/main.yml
+++ b/roles/mount_discovery_iso_for_pxe/tasks/main.yml
@@ -22,10 +22,11 @@
         state: directory
         mode: '0755'
 
-    - name: mount the efiboot image
-      shell: 
-        cmd: "mount -o loop,ro {{ mount_images_directory }}/efiboot.img {{ mount_efiboot_directory }}" # noqa command-instead-of-module
- 
+    - name: Mount the efiboot image
+      ansible.builtin.command:
+        cmd: "mount -o loop,ro {{ mount_images_directory }}/efiboot.img {{ mount_efiboot_directory }}"  # noqa command-instead-of-module
+      changed_when: false
+
     - name: Create grub Configuration File
       template:
         src: "./grub.cfg.j2"

--- a/roles/validate_dns_records/tasks/check.yml
+++ b/roles/validate_dns_records/tasks/check.yml
@@ -1,5 +1,5 @@
 - name: Check required domain {item} exists
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: "{{ required_binary }} {{ item.value }} A {{ item.value }} AAAA +short"
   register: res
   changed_when: false

--- a/roles/validate_dns_records/tasks/main.yml
+++ b/roles/validate_dns_records/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Check if the required binary for testing exists
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: "which {{ required_binary }}"
   register: required_binary_check
   failed_when: false


### PR DESCRIPTION
##### SUMMARY

Replace shell by command where a shell is not required. Fixes 10 command-instead-of-shell profile:basic tags:command-shell,idiom

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/53d8e8cb-e6a0-4405-a086-ac3ceeb8e58b
- [x] TestBos2Sno: abi-sno - https://www.distributed-ci.io/jobs/4da5334d-3907-48e3-8b84-8674be3e3763

---

Test-hints: no-check
