### PR TITLE
make sure nmstate is installed for abi jobs

### DIFF
--- a/roles/generate_agent_iso/README.md
+++ b/roles/generate_agent_iso/README.md
@@ -32,3 +32,6 @@ You can call this role in the following way, as an example of usage:
   ansible.builtin.include_role:
     name: redhatci.ocp.generate_agent_iso
 ```
+
+> [!NOTE]
+> This role makes use of nmstatectl command provided by nmstate to render the network configuration.

--- a/roles/generate_agent_iso/tasks/main.yml
+++ b/roles/generate_agent_iso/tasks/main.yml
@@ -27,11 +27,11 @@
     mode: "0644"
     remote_src: true
 
-- name: Fail if required nmstatectl is not installed
-  ansible.builtin.command: type nmstatectl
-  register: _gai_nmstatectl_check
-  failed_when: _gai_nmstatectl_check.rc != 0
-  changed_when: _gai_nmstatectl_check.rc != 0
+- name: Making sure nmstate is installed
+  become: true
+  ansible.builtin.package:
+    name: nmstate
+    state: installed
 
 - name: Generate agent ISO
   ansible.builtin.command:


### PR DESCRIPTION
##### SUMMARY

ABI installations require nmstate to generate the
network configuration, nmstatectl will be use to
render and validate the configuration, when the
command is missing the deployment fails to generate the config.

##### ISSUE TYPE

Enhance role

##### Tests

- [x] TestBos2: abi - https://www.distributed-ci.io/jobs/2a86a07a-6c21-484e-91a8-5bf54fe95d8f/jobStates
---

TestHints: no-check