### PR TITLE
Allow explicit partner_name with precedence over  org_id

### DIFF
--- a/roles/chart_verifier/README.md
+++ b/roles/chart_verifier/README.md
@@ -14,10 +14,11 @@ logs_dir                           | /tmp                                       
 github_token_path                  | undefined                                         | true        | GitHub token to be used to push the chart and the results to a repository. Defaults to [openshift-charts/charts](https://github.com/openshift-helm-charts/charts/)
 organization_id                    | unknown                                           | false       | Red Hat PartnerID, used to obtain the partner_name. Recommended for tests that will be submitted. Obtained it from https://connect.redhat.com/account/company-profile.
 project_url             | https://catalog.redhat.com/api/containers/v1/vendors/org-id  | true        | API endpoint to query for vendor details.
+partner_name                       | None                                              | false       | Name of the partner to be used in the pull request
 partner_email                      | undefined                                         | true        | Email address to be used in the pull request
 sandbox_repository                 | undefined                                         | false       | Target repository to submit the PRs instead of openshift-helm-charts/charts/
 
-Note: A valid `partner_name` is required for the chart pull request to be accepted. It is derived from the organization_id. If the `organization_id` is invalid/nonexistent, `partner_name` will be set to "None". The partner_name corresponds to the Container Registry Namespace or vendor label and will remain empty for new partners until they create at least one certification project.
+Note: A `partner_name` is required for the chart pull request to be accepted. This can be set explicitly or obtained from the RH catalog using the organization_id. If the `organization_id` is invalid/nonexistent, `partner_name` will be set to "None". The partner_name corresponds to the Container Registry Namespace or vendor label and will remain empty for new partners until they create at least one certification project.
 
 ## Helm charts Certification in a nut shell
 

--- a/roles/chart_verifier/tasks/get-partner-name.yml
+++ b/roles/chart_verifier/tasks/get-partner-name.yml
@@ -4,7 +4,7 @@
     url: "{{ project_url }}/{{ organization_id }}"
     method: GET
     return_content: true
-    status_code: [200, 404]  # Accept both 200 (success) and 404 (not found)
+    status_code: [200, 404]
     timeout: 60
   register: _cv_vendor_partner_name
   until:

--- a/roles/chart_verifier/tasks/main.yml
+++ b/roles/chart_verifier/tasks/main.yml
@@ -10,6 +10,8 @@
 
 - name: "Get partner name"
   ansible.builtin.include_tasks: get-partner-name.yml
+  when:
+    - partner_name is undefined
 
 # Get tools like yq and helm
 - name: "Get tools"


### PR DESCRIPTION
##### SUMMARY

Allow to set a partner_name that takes priority over the org_id

##### ISSUE TYPE
- nominal change

##### Tests

chart-verifier chart-verifier:ansible_extravars=partner_name:beto -  https://www.distributed-ci.io/jobs/95c7caa3-dcf7-4523-95dc-46b0da274b37/jobStates
chart-verifier chart-verifier:ansible_extravars=organization_id:15451045 - https://www.distributed-ci.io/jobs/78809402-c85d-451a-9b88-723787691ff4/jobStates

Test-Hint: no-check
