### PR TITLE
setup_gitea mirror mismatched repo branches

### DIFF
--- a/roles/setup_gitea/tasks/install.yml
+++ b/roles/setup_gitea/tasks/install.yml
@@ -161,8 +161,7 @@
     - name: Mirror the repository # noqa command-instead-of-module
       ansible.builtin.shell:
         cmd: |
-          /usr/bin/git remote add mirror http://{{ sg_username }}:{{ sg_password }}@{{ sg_gitea_domain }}/{{ sg_username }}/{{ sg_repository }}.git
-          /usr/bin/git push mirror {{ sg_repo_mirror_branch }}
+          /usr/bin/git push http://{{ sg_username }}:{{ sg_password }}@{{ sg_gitea_domain }}/{{ sg_username }}/{{ sg_repository }}.git {{ sg_repo_mirror_branch }}:{{ sg_repo_branch }}
         chdir: "{{ _sg_mirror_repo.path }}/mirror"
       changed_when: false
       no_log: true


### PR DESCRIPTION
##### SUMMARY

Currently, the setup_gitea role only allows mirroring the repository from and to the same branch name.

This change allows mirroring between different branch names, as the role was intended from the beginning.

##### ISSUE TYPE

- Bug fix

##### Tests


- [x] TestDallasSno: ocp-4.18-hub-abi-sno - https://www.distributed-ci.io/jobs/33b6816b-f09c-49ca-b05e-2c3005581b55
- [x]  TestDallasSno: ocp-4.18-hub-abi-sno sno-abi:ansible_extravars=sg_repo_mirror_branch:ztp-flat-dirs sno-abi:ansible_extravars=sg_repo_branch:non-main - https://www.distributed-ci.io/jobs/d584cc1e-6994-4323-a4f8-d5006af7b9ce

---

Test-hints: no-check