### PR TITLE
Catch when no IPMI hosts exist

### DIFF
--- a/roles/conserver/defaults/main.yml
+++ b/roles/conserver/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+conserver_sol_hosts: []
+conserver_socket_hosts: []
+...

--- a/roles/conserver/files/socat_retry.sh
+++ b/roles/conserver/files/socat_retry.sh
@@ -2,6 +2,6 @@
 reconnTimeOut=5
 TERM=vt100
 while /bin/true
-        do /bin/socat $* 2>/dev/null
-        sleep $reconnTimeOut
+    do /bin/socat $* 2>/dev/null
+    sleep $reconnTimeOut
 done

--- a/roles/conserver/tasks/config.yml
+++ b/roles/conserver/tasks/config.yml
@@ -15,27 +15,27 @@
                -p {{ hostvars[item].ipmi_port | default(623) }}
                -I lanplus
                sol info
-  register: ipmi_sol
+  register: _conserver_sol
   ignore_errors: true
+  changed_when: true
   loop: "{{ cluster_nodes }}"
 
 - name: Build list of Serial over IPMI hosts
   ansible.builtin.set_fact:
-    ipmi_sol_hosts: "{{ ipmi_sol_hosts + [item.item] }}"
+    conserver_sol_hosts: "{{ conserver_sol_hosts + [item.item] }}"
   when: item.rc == 0
-  loop: "{{ ipmi_sol.results }}"
+  loop: "{{ _conserver_sol.results | default({}) }}"
 
 - name: Include IPMI console config
   ansible.builtin.include_tasks: config-ipmi.yml
-  when: ipmi_sol_hosts| length>0
+  when: conserver_sol_hosts | length > 0
 
 - name: Build list of Serial over SOCKET hosts (libvirt)
   ansible.builtin.set_fact:
-    socket_hosts: "{{ socket_hosts + [item] }}"
-  when:
-    - hostvars[item].socket_console| default(false)
+    conserver_socket_hosts: "{{ conserver_socket_hosts + [item] }}"
+  when: hostvars[item].socket_console | default(false) | bool
   loop: "{{ cluster_nodes }}"
 
 - name: Include libvirt console config
   ansible.builtin.include_tasks: config-libvirt.yml
-  when: socket_hosts| length>0
+  when: conserver_socket_hosts | length > 0

--- a/roles/conserver/templates/conserver-ipmi.cf
+++ b/roles/conserver/templates/conserver-ipmi.cf
@@ -5,7 +5,7 @@ default {{ cluster }} {
 	master localhost;
 }
 
-{% for host in ipmi_sol_hosts %}
+{% for host in conserver_sol_hosts %}
 console {{ cluster }}-{{ hostvars[host].name }} {
   include {{ cluster }};
   type exec;

--- a/roles/conserver/templates/conserver-libvirt.cf
+++ b/roles/conserver/templates/conserver-libvirt.cf
@@ -8,7 +8,7 @@ default libvirt {
     master localhost;
 }
 
-{% for host in socket_hosts %}
+{% for host in conserver_socket_hosts %}
 console {{ cluster }}-{{ host }} { include libvirt; host {{ host }}.console; }
 {% endfor %}
 

--- a/roles/conserver/vars/main.yml
+++ b/roles/conserver/vars/main.yml
@@ -1,4 +1,0 @@
----
-ipmi_sol_hosts: []
-socket_hosts: []
-...


### PR DESCRIPTION
##### SUMMARY

If no IPMI connection check succeeded, the registered fact is empty, default to {} in that case.
Also a few more linting fixes.

##### ISSUE TYPE

- Bug
- 
##### Tests

Test-Hints: no-check