### PR TITLE
Don't ignore the failure during bootstrap

### DIFF
--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -2,7 +2,6 @@
   ansible.builtin.command:
     cmd: "{{ agent_based_installer_path }} --log-level=debug agent wait-for bootstrap-complete"
     chdir: "{{ manifests_dir }}"
-  failed_when: false
   changed_when: false
 
 - name: Check installation and gather jobs if it fails


### PR DESCRIPTION
##### SUMMARY

Boostrap timeouts after 60 min[1], if the boostrapiong has not passed after this time, don't let the installation continue, is more likely to fail during installation but take more time to fail as the install timeouts after 90 min[2].

[1] https://github.com/openshift/installer/blob/ebe8abe386338ea666827189e5d82b55019de86c/pkg/agent/waitfor.go#L15
[2] https://github.com/openshift/installer/blob/ebe8abe386338ea666827189e5d82b55019de86c/pkg/agent/waitfor.go#L57

##### ISSUE TYPE

- Nominal change


##### Tests

- [ ] TestBos2Sno: abi-sno - 

---

TestBos2Sno: abi-sno
