### PR TITLE
up step Check roles are documented in main README

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -186,20 +186,23 @@ jobs:
       - name: Check roles are documented in main README
         run: |
           echo "# Missing roles in README" > ${GITHUB_STEP_SUMMARY}
-          for role in $(ls roles); do
-            if ! grep -q "^\[redhatci\.ocp\.${role}" README.md; then
+          while read -r role_readme; do
+            role="${role_readme%/*}"  # strip last file `/README.md``
+            role="${role#*/}"         # strip left `roles/`
+            role="${role/\//.}"       # replace `/` with `.`
+            if ! grep -q "^\[redhatci\.ocp\.${role}\]" README.md; then
               echo "- Missing: ${role}" | tee -a ${GITHUB_STEP_SUMMARY}
             fi
-          done
+          done < <(find roles -name README.md)
           echo "# Additional roles/plugins in README" > ${GITHUB_STEP_SUMMARY}
-          for role in $(grep '^\[' README.md | grep -Po 'redhatci\.ocp\.[^\]]+'); do
+          while read -r role; do
             rp="${role/redhatci.ocp./}"
             if [[ ! -d "roles/${rp/./\/}" ]] &&
                [[ ! -r "plugins/filter/${rp}.py" ]] &&
                [[ ! -r "plugins/modules/${rp}.py" ]]; then
               echo "- Extra role/plugin found in README: ${role}" | tee -a ${GITHUB_STEP_SUMMARY}
             fi
-          done
+          done < <(grep '^\[' README.md | grep -Po 'redhatci\.ocp\.[^\]a-z]+' )
           if grep -qP "^- (Missing:|Extra)" ${GITHUB_STEP_SUMMARY}; then
             exit 1
           fi


### PR DESCRIPTION
- in `pr.yml` more careful grep to not fail on special character '`' in "Check roles are documented in main README"

Fixes: #604

##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->
make  `grep` calls more fine tuned to avoid catching more special chars
<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug


##### Tests

<!-- Document the tests for this change, if any -->
`old.sh` code:
```bash
#!/usr/bin/env bash
DOC="${DOC:-"README.md"}"
REPORT="${GITHUB_STEP_SUMMARY:-"report.txt"}"
echo "# Missing roles in README" > "${REPORT}"
for role in $(ls roles); do
  if ! ggrep -q "^\[redhatci\.ocp\.${role}" "${DOC}"; then
    echo "- Missing: ${role}" | tee -a "${REPORT}"
  fi
done
echo "# Additional roles/plugins in README" > "${REPORT}"
for role in $(ggrep '^\[' "${DOC}" | ggrep -Po 'redhatci\.ocp\.[^\]]+'); do
  rp="${role/redhatci.ocp./}"
  if [[ ! -d "roles/${rp/./\/}" ]] &&
     [[ ! -r "plugins/filter/${rp}.py" ]] &&
     [[ ! -r "plugins/modules/${rp}.py" ]]; then
    echo "- Extra role/plugin found in README: ${role}" | tee -a "${REPORT}"
  fi
done
if ggrep -qP "^- (Missing:|Extra)" "${REPORT}"; then
  exit 1
fi
```
running in `main`, using old `README.md`:
  - no output
  - rc = `0`
 
 in branch `mvk/role_junit2json`:
 ```
 ./old.sh
- Extra role/plugin found in README: redhatci.ocp.junit2dict`)
 echo $?
 1
 ```
`new.sh` code:
```bash
#!/usr/bin/env bash
DOC="${DOC:-"README.md"}"
REPORT="${GITHUB_STEP_SUMMARY:-"report.txt"}"
echo "# Missing roles in README" > "${REPORT}"
while read -r role_readme; do
  role="${role_readme%/*}" # strip `/README.md`
  role="${role#*/}" # strip `roles/`
  role="${role/\//.}" # replace `/` with `.`
  # echo "role: ${role}"
  if ! grep -q "^\[redhatci\.ocp\.${role}\]" "${DOC}"; then
    echo "- Missing: ${role}" | tee -a "${REPORT}"
  fi
done < <(find roles -name README.md)
echo "# Additional roles/plugins in README" > "${REPORT}"
while read -r role; do
  rp="${role/redhatci.ocp./}"
  if [[ ! -d "roles/${rp/./\/}" ]] &&
     [[ ! -r "plugins/filter/${rp}.py" ]] &&
     [[ ! -r "plugins/modules/${rp}.py" ]]; then
    echo "- Extra role/plugin found in README: ${role}" | tee -a "${REPORT}"
  fi
done < <(ggrep '^\[' "${DOC}" | ggrep -Po 'redhatci\.ocp\.[^\]a-z]+')
if ggrep -qP "^- (Missing:|Extra)" "${REPORT}"; then
  exit 1
fi
```
in branch `main`:
```
./new.sh
echo $?
0
```
in branch `mvk/role_junit2json`:
```
./new.sh
echo $?
0
```
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

<!-- Examples:
- [ ] TestDallas: ocp-4.17-vanilla - <JobURL>
- [ ] TestDallasHybrid: ocp-4.17-vanilla-hybrid - <JobURL>
- [ ] TestDallasWorkload: preflight-green - <JobURL>
- [ ] TestBos2: virt - <JobURL>
- [ ] TestBos2Sno: sno - <JobURL>
- [ ] TestBos2SnoBaremetal: sno - <JobURL>
-->

---

<!-- Include the test and dependencies for this change -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->


<!-- Examples:

Test-Hint: no-check
Depends-on: https://path/to/depending/change

-->
