### PR TITLE
setup_gitea | Mirror the correct branch of the repository

### DIFF
--- a/roles/setup_gitea/tasks/install.yml
+++ b/roles/setup_gitea/tasks/install.yml
@@ -162,7 +162,7 @@
       ansible.builtin.shell:
         cmd: |
           /usr/bin/git remote add mirror http://{{ sg_username }}:{{ sg_password }}@{{ sg_gitea_domain }}/{{ sg_username }}/{{ sg_repository }}.git
-          /usr/bin/git push mirror main
+          /usr/bin/git push mirror {{ sg_repo_mirror_branch }}
         chdir: "{{ _sg_mirror_repo.path }}/mirror"
       changed_when: false
       no_log: true


### PR DESCRIPTION
##### SUMMARY

Right now, we're assuming that we're always pushing the `main` branch to the mirror repository. However, there are some variables that control the branch to use. For the mirroring, it's used `sg_repo_mirror_branch`, so that variable should be used when pushing the changes to the mirrored repo.

##### ISSUE TYPE

- Bug

##### Tests

- [x] ACM hub + ZTP spoke deployment using a PR in the gitops repo - https://www.distributed-ci.io/jobs?limit=20&offset=0&sort=-created_at&where=pipeline_id:4d30330a-fe00-43da-9035-d702e76a2886,state:active

Test-Hints: no-check