### PR TITLE
Fix regex for extra plugins/roles

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -202,7 +202,7 @@ jobs:
                [[ ! -r "plugins/modules/${rp}.py" ]]; then
               echo "- Extra role/plugin found in README: ${role}" | tee -a ${GITHUB_STEP_SUMMARY}
             fi
-          done < <(grep '^\[' README.md | grep -Po 'redhatci\.ocp\.[^\]a-z]+' )
+          done < <(grep -Po '^\[redhatci\.ocp\.[^\]]+' README.md | tr -d '[')
           if grep -qP "^- (Missing:|Extra)" ${GITHUB_STEP_SUMMARY}; then
             exit 1
           fi


### PR DESCRIPTION
##### SUMMARY

The previous regex did not matched any plugin/role


##### ISSUE TYPE

- Bug

##### Tests

Previous regex did not matched any plugin/role:

```Shell
❯ grep '^\[' README.md | grep -cPo 'redhatci\.ocp\.[^\]a-z]+'
0
```

The new regex:

```Shell
❯ grep -cPo '^\[redhatci\.ocp\.[^\]]+' README.md | tr -d '['
111

❯ grep -Po '^\[redhatci\.ocp\.[^\]]+' README.md | tr -d '[' | tail -5
redhatci.ocp.junit2obj
redhatci.ocp.ocp_compatibility
redhatci.ocp.regex_diff
redhatci.ocp.get_compatible_rhocp_repo
redhatci.ocp.nmcli
```

Test-Hint: no-check
