### PR TITLE
[monitor_abi] make sure api is ready before monitoring bootstrap

### DIFF
--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -4,10 +4,10 @@
     url: 'https://api.{{ cluster }}.{{ base_dns_domain }}:6443/readyz'
     validate_certs: false
     return_content: true
-  register: mabi_api_ready
+  register: _mabi_api_ready
   until:
-    - "'ok' in mabi_api_ready.content"
-    - mabi_api_ready.status == 200
+    - "'ok' in _mabi_api_ready.content"
+    - _mabi_api_ready.status == 200
   retries: 180
   delay: 10
 

--- a/roles/monitor_agent_based_installer/tasks/main.yml
+++ b/roles/monitor_agent_based_installer/tasks/main.yml
@@ -1,3 +1,16 @@
+---
+- name: Wait for API to be available
+  ansible.builtin.uri:
+    url: 'https://api.{{ cluster }}.{{ base_dns_domain }}:6443/readyz'
+    validate_certs: false
+    return_content: true
+  register: mabi_api_ready
+  until:
+    - "'ok' in mabi_api_ready.content"
+    - mabi_api_ready.status == 200
+  retries: 180
+  delay: 10
+
 - name: Wait for bootstrap complete
   ansible.builtin.command:
     cmd: "{{ agent_based_installer_path }} --log-level=debug agent wait-for bootstrap-complete"


### PR DESCRIPTION
##### SUMMARY

make sure api is ready before monitoring bootstrap

##### ISSUE TYPE

Workaround for OCPBUGS-53222

##### Tests

- [x] TestBos2: abi (baremetal) https://www.distributed-ci.io/jobs/3a467407-6e40-49e1-b98d-f13a656d60f7/jobStates
- [x] TestBos2: abi (virtual) https://www.distributed-ci.io/jobs/68f64ab6-f40c-411a-a356-d4aa89999474/jobStates

TestHints: no-check