### PR TITLE
Update jq command to skip iteration over null

### DIFF
--- a/roles/example_cnf_deploy/tasks/deploy.yml
+++ b/roles/example_cnf_deploy/tasks/deploy.yml
@@ -5,7 +5,7 @@
       set -e -o pipefail;
       {{ ecd_opm_path }} render
       {{ ecd_catalog_image }} |
-      jq -r '.relatedImages[].image'
+      jq -rn 'inputs | select(.schema == "olm.bundle").relatedImages[].image'
   args:
     executable: /bin/bash
   register: _ecd_catalog_data_cmd


### PR DESCRIPTION
##### SUMMARY

Update jq command to skip iteration over null, to prevent "jq: error Cannot iterate over null" 

##### ISSUE TYPE
Nominal change

Test-Hint: no-check

https://www.distributed-ci.io/jobs/040c3eb2-dd05-4a36-956b-35198e423dc0/jobStates

