### PR TITLE
fixed preflight parallel tmpdir due to recently changed from dci ~/tmp

### DIFF
--- a/roles/preflight/tasks/test_preflight_container_parallel.yml
+++ b/roles/preflight/tasks/test_preflight_container_parallel.yml
@@ -76,8 +76,15 @@
     - name: "Copy execution artifacts"
       vars:
         image_name: "{{ item.0.container_image | regex_search('.*/([^@:]+).*$', '\\1') | join('') }}"
-        tmp_prefix: "/tmp/preflight_container_artifacts"
-        file_basename: "{{ item.1.path | regex_replace(tmp_prefix ~ '_[^/]+/(?:([^/]+)/)?([^/]+)$', '\\1_\\2') | replace('__', '') }}"
+        file_basename: >-
+          {{
+            item.1.path
+            | regex_replace(
+            '^(?:' ~ lookup("env", "HOME") ~ ')?/tmp/preflight_container_artifacts_[^/]+/(?:([^/]+)/)?([^/]+)$',
+            '\g<1>_\g<2>'
+            )
+            | regex_replace('^_', '')
+          }}
         preflight_prefix: "preflight_container_{{ image_name }}_{{ file_basename }}"
       ansible.builtin.copy:
         src: "{{ item.1.path }}"
@@ -86,18 +93,22 @@
       loop: "{{ preflight_files_context | subelements('files') }}"
       when: "item.1.path | regex_search('\\.(json|log|xml)$')"
 
-    - name: "Find all temporary directories preflight_container_ in /tmp/ to remove"
+    - name: "Find all temporary directories preflight_container_ in designated temp paths"
       ansible.builtin.find:
-        paths: "/tmp/"
+        paths: "{{ ansible_env.HOME }}/tmp"
         patterns: 'preflight_container_*'
         file_type: directory
-      register: _preflight_tmp_dirs_to_remove
+      register: _preflight_tmp_dirs
 
-    - name: Remove found temporary directories
+    - name: "Aggregate found temporary directories"
+      ansible.builtin.set_fact:
+        preflight_all_tmp_dirs: "{{ _preflight_tmp_dirs.files }}"
+
+    - name: "Remove found temporary directories"
       ansible.builtin.file:
         path: "{{ item.path }}"
         state: absent
-      loop: "{{ _preflight_tmp_dirs_to_remove.files }}"
+      loop: "{{ preflight_all_tmp_dirs }}"
 
     - name: Unset files context contents before starting the next batch of images
       ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY

When we started to use preflight scan with parallel in the latest weeks, it was notice that it failed on Copy execution artifacts. When it worked from the past testings, the tempdir creation like this ["path": "/tmp/preflight_container_artifacts](https://www.distributed-ci.io/jobs/f735ff3e-e526-4c66-b22c-8b0474cd3d3c/jobStates?sort=date&task=0e54dfae-8788-4f86-b0c9-4dc29c1648f2).

Now it failed to copy the artifacts, because the I parsed for multiple preflights logs from those multi-tmpdirs when using parallel is different from single scan. The old code could not extract file_basename due to DCI created /tmp/ dir to DCI user home ~/tmp. Here is the result of new of moving the [/var/lib/dci-openshift-app-agent/tmp/preflight_container_artifacts](https://www.distributed-ci.io/jobs/134cdb45-a0d8-4145-9a76-f3fbf459e60f/jobStates?sort=date&task=624ac4e3-eb0a-499a-a676-311b671e6a8b)

##### ISSUE TYPE

- Bug Fix


##### Tests

- [x] parallel preflight - https://www.distributed-ci.io/jobs/cb1c2bb0-e906-4531-ada9-32d53ee63628/jobStates?sort=date


Test-Hint: no-check

