### PR TITLE
Fix ansible lint key-order

### DIFF
--- a/roles/generate_ssh_key_pair/tasks/main.yml
+++ b/roles/generate_ssh_key_pair/tasks/main.yml
@@ -34,6 +34,7 @@
     - "{{ key_pair_dir }}/{{ public_key_name }}"
 
 - name: Copy SSH Key to bastion
+  delegate_to: bastion
   block:
     - name: Make SSH Key folder
       file:
@@ -49,8 +50,6 @@
       loop:
         - "{{ private_key_name }}"
         - "{{ public_key_name }}"
-
-  delegate_to: bastion
 
 - name: "Remove temporary ssh_keys folder {{ key_pair_dir }}"
   file:

--- a/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -89,6 +89,10 @@
     - create_registry
 
 - name: Create disconnected registry
+  delegate_to: "{{ groups['registry_host'][0] }}"
+  tags:
+    - disconnected
+    - create_registry
   block:
     - name: set cert facts to be easier
       set_fact:
@@ -405,11 +409,6 @@
       file:
         path: "{{ ansible_env.HOME }}/pullsecret.txt"
         state: absent
-
-  delegate_to: "{{ groups['registry_host'][0] }}"
-  tags:
-    - disconnected
-    - create_registry
 
 - name: Set fact to pull oc installer from disconnected registry
   set_fact:

--- a/roles/installer/tasks/15_disconnected_registry_existing.yml
+++ b/roles/installer/tasks/15_disconnected_registry_existing.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Configure to use existing disconnected registry
+  delegate_to: localhost
   block:
 
     - name: Get stats of {{ disconnected_registry_mirrors_file }}
@@ -53,4 +54,3 @@
       set_fact:
         pullsecret: "  {{ new_pullsecret.stdout }}"
       no_log: true
-  delegate_to: localhost

--- a/roles/installer/tasks/23_rhcos_image_paths.yml
+++ b/roles/installer/tasks/23_rhcos_image_paths.yml
@@ -1,5 +1,6 @@
 ---
 - name: RHCOS image path (pre 4.8)
+  when: release_version is ansible.builtin.version('4.7', '<=')
   block:
     - name: Get COMMIT_ID
       shell: |
@@ -34,9 +35,9 @@
         rhcos_uri: "{{ rhcos_json.json | json_query('images.openstack.path') }}"
         rhcos_path: "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-{{ base_version }}/{{ build_id }}/x86_64/"
       tags: rhcospath
-  when: release_version is ansible.builtin.version('4.7', '<=')
 
 - name: RHCOS image path (4.8+)
+  when: release_version is ansible.builtin.version('4.8', '>=')
   block:
     - name: Extract rhcos.json
       shell: |
@@ -61,4 +62,3 @@
         rhcos_qemu_key: 'architectures.x86_64.artifacts.qemu.formats."qcow2.gz".disk.location'
         rhcos_openstack_key: 'architectures.x86_64.artifacts.openstack.formats."qcow2.gz".disk.location'
       tags: rhcospath
-  when: release_version is ansible.builtin.version('4.8', '>=')

--- a/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -191,6 +191,8 @@
   tags: cache
 
 - name: Ensuring container restarts upon reboot
+  tags: cache
+  delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
   block:
     - name: Ensure user specific systemd instance are persistent
       command: |
@@ -243,5 +245,3 @@
         scope: user
       environment:
         DBUS_SESSION_BUS_ADDRESS: "{{ ansible_env.DBUS_SESSION_BUS_ADDRESS|default('unix:path=/run/user/' +  ansible_effective_user_id|string + '/bus') }}"
-  tags: cache
-  delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"

--- a/roles/installer/tasks/50_extramanifests.yml
+++ b/roles/installer/tasks/50_extramanifests.yml
@@ -39,6 +39,8 @@
   tags: extramanifests
 
 - name: Manage chrony configuration
+  when: (clock_servers is defined) and (clock_servers | length > 0)
+  tags: extramanifests
   block:
     - name: Create chrony.conf
       set_fact:
@@ -53,5 +55,3 @@
       with_items:
         - master
         - worker
-  when: (clock_servers is defined) and (clock_servers | length > 0)
-  tags: extramanifests

--- a/roles/installer/tasks/55_customize_filesystem.yml
+++ b/roles/installer/tasks/55_customize_filesystem.yml
@@ -16,6 +16,8 @@
   tags: customfs
 
 - name: Modify Ignition Configs
+  when: (filesFound | json_query('results[*].matched') | sum) > 0
+  tags: customfs
   block:
 
     - name: Create OpenShift Ignition Configs
@@ -68,6 +70,3 @@
       with_items:
         - "master"
         - "worker"
-
-  when: (filesFound | json_query('results[*].matched') | sum) > 0
-  tags: customfs

--- a/roles/installer/tasks/60_deploy_ocp.yml
+++ b/roles/installer/tasks/60_deploy_ocp.yml
@@ -20,6 +20,8 @@
   tags: install
 
 - name: Deploy OpenShift Cluster with extended timeouts
+  when: increase_bootstrap_timeout is defined or increase_install_timeout is defined
+  tags: install
   block:
     - name: Run OpenShift Cluster install as async task
       shell: |
@@ -50,5 +52,3 @@
       until: wait_for_install_result is succeeded
       retries: "{{ increase_install_timeout|default(1)|int }}"
       delay: 1
-  when: increase_bootstrap_timeout is defined or increase_install_timeout is defined
-  tags: install

--- a/roles/node_prep/tasks/10_validation.yml
+++ b/roles/node_prep/tasks/10_validation.yml
@@ -238,7 +238,15 @@
     - drm_set
     - webserver_url|length == 0
 
-- block:
+- name: Python crypto libraries
+  tags:
+    - create_registry
+    - validation
+  when:
+    - not dra_set
+    - not drm_set
+    - registry_host_exists
+  block:
     - name: Check if Python cryptography libraries are installed
       python_requirements_info:
         dependencies:
@@ -258,13 +266,6 @@
         msg: "Required cryptography libraries are missing cryptography OR PyOpenSSL"
       when: (_py_crypto.not_found != []) and
             (_py_pyopenssl.not_found != [] )
-  tags:
-    - create_registry
-    - validation
-  when:
-    - not dra_set
-    - not drm_set
-    - registry_host_exists
 
 - name: Get Release.txt File
   uri:
@@ -483,6 +484,7 @@
   tags: validation
 
 - name: Adding hosts to to their dynamic Dell inventory group
+  tags: validation
   block:
     - name: Add all the hosts that are Dell to a group with iDRAC firmware higher than 4.20.20.20
       add_host:
@@ -503,9 +505,9 @@
     - name: Attempt to add all hosts that are part of the Dell group failed
       debug:
         msg: 'Adding hosts to dynamic Dell group failed or redfish_inspection was set to false. All inventory systems will use IPMI.'
-  tags: validation
 
 - name: Adding hosts to to their dynamic HP inventory group
+  tags: validation
   block:
     - name: Add all the hosts that are HP to a group
       add_host:
@@ -523,7 +525,6 @@
     - name: Attempt to add all hosts that are part of the HP group failed
       debug:
         msg: 'Adding hosts to dynamic HP group failed or redfish_inspection was set to false. All inventory systems will use IPMI.'
-  tags: validation
 
 - name: Fail when provisioningHostIP and bootstrapProvisioningIP are not set when virtualmedia option is enabled
   fail:

--- a/roles/node_prep/tasks/30_req_packages.yml
+++ b/roles/node_prep/tasks/30_req_packages.yml
@@ -1,5 +1,6 @@
 ---
 - name: Install packages
+  tags: packages
   block:
   - name: Create list of packages to be installed
     set_fact:
@@ -13,4 +14,3 @@
       update_cache: true
       disable_gpg_check: true
     become: true
-  tags: packages

--- a/roles/node_prep/tasks/40_bridge.yml
+++ b/roles/node_prep/tasks/40_bridge.yml
@@ -1,5 +1,7 @@
 ---
 - name: Setup Bridge Creation
+  become: true
+  tags: network
   block:
     - name: Get the provision connection name
       shell: |
@@ -162,5 +164,3 @@
         - "{{ prov_nic }}"
       when:
         - not enable_virtualmedia|bool
-  become: true
-  tags: network

--- a/roles/node_prep/tasks/70_enabled_fw_services.yml
+++ b/roles/node_prep/tasks/70_enabled_fw_services.yml
@@ -1,5 +1,7 @@
 ---
 - name: Configure firewalld
+  when: firewall != "iptables"
+  tags: firewall
   block:
     - name: Enable HTTP for firewalld
       firewalld:
@@ -18,10 +20,10 @@
         immediate: true
       become: true
       when: cache_enabled|bool
-  when: firewall != "iptables"
-  tags: firewall
 
 - name: Configure iptables
+  when: firewall == "iptables"
+  tags: firewall
   block:
     - name: Enable HTTP for iptables
       iptables:
@@ -51,5 +53,3 @@
       shell: |
         /usr/sbin/iptables-save > /etc/sysconfig/iptables
       become: true
-  when: firewall == "iptables"
-  tags: firewall

--- a/roles/node_prep/tasks/80_libvirt_pool.yml
+++ b/roles/node_prep/tasks/80_libvirt_pool.yml
@@ -1,5 +1,7 @@
 ---
 - name: Define, Start, Autostart Storage Pool
+  become: true
+  tags: storagepool
   block:
     - name: Define Storage Pool for default
       virt_pool:
@@ -16,5 +18,3 @@
       virt_pool:
         autostart: true
         name: default
-  become: true
-  tags: storagepool

--- a/roles/node_prep/tasks/90_create_config_install_dirs.yml
+++ b/roles/node_prep/tasks/90_create_config_install_dirs.yml
@@ -1,5 +1,6 @@
 ---
 - name: Setup clusterconfigs dir
+  tags: clusterconfigs
   block:
     - name: Clear config dir (if any, in case this is a re-run)
       file:
@@ -17,4 +18,3 @@
         mode: '0755'
       with_items:
         - "{{ dir }}"
-  tags: clusterconfigs

--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -56,6 +56,8 @@
 # release.txt, among others)
 - name: Extract artifacts from release image
   become: true
+  when:
+    - not downloaded_artifacts.stat.exists
   block:
     # we need to temporarily download ocp stable binary to extract the artifacts
     - name: Create tmp directory for oc stable client
@@ -84,8 +86,6 @@
       file:
         path: "{{ oc_tmp_dir.path }}"
         state: absent
-  when:
-    - not downloaded_artifacts.stat.exists
 
 - name: Setup Version/Image facts
   block:
@@ -110,6 +110,9 @@
     binaries_tool_path: "{{ binaries_tmp_dir.path }}"
 
 - name: Install oc
+  tags:
+    - create_registry
+    - fetch_oc
   block:
     - name: Check if oc binary has been extracted
       stat:
@@ -168,11 +171,10 @@
         - kubectl
         - oc
 
+- name: Install opm
   tags:
     - create_registry
-    - fetch_oc
-
-- name: Install opm
+    - fetch_opm
   block:
     - name: Check if opm tarball has been previously downloaded
       stat:
@@ -217,6 +219,3 @@
     - name: Check opm installed
       command:  
         cmd: "{{ binaries_tool_path }}/opm version"
-  tags:
-    - create_registry
-    - fetch_opm

--- a/roles/setup_mirror_registry/tasks/setup_registry.yml
+++ b/roles/setup_mirror_registry/tasks/setup_registry.yml
@@ -102,6 +102,7 @@
     container_registry_pidfile: "{{ registry_container_info.container.ConmonPidFile }}"
 
 - name: Setup registry service
+  become: true
   block:
     - name: Copy the systemd service file
       copy:
@@ -136,4 +137,3 @@
       systemd:
         name: container-registry
         state: started
-  become: true


### PR DESCRIPTION
##### SUMMARY

Reorders keys in blocks.  Fixes 22 key-order[task]

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt -  https://www.distributed-ci.io/jobs/2f2190ad-3628-45f0-b301-b5accbce584d
- [x] TestBos2Sno: abi-sno abi-sno:ansible_extravars=enable_acm: - https://www.distributed-ci.io/jobs/ca8928bc-7112-4424-a11d-f19aeef8307c

---

Test-hints: no-check
