### PR TITLE
Decode creds from secret

### DIFF
--- a/roles/acm_sno/tasks/get-credentials.yml
+++ b/roles/acm_sno/tasks/get-credentials.yml
@@ -19,7 +19,7 @@
 - name: "Set credentials facts"
   set_fact:
     acm_kubeconfig_text: '{{ kubeconfig_secret.resources[0].data["kubeconfig"] | b64decode }}'
-    acm_kubeconfig_user: '{{ kubeconfig_password.resources[0].data["username"] }}'
-    acm_kubeconfig_pass: '{{ kubeconfig_password.resources[0].data["password"] }}'
+    acm_kubeconfig_user: '{{ kubeconfig_password.resources[0].data["username"] | b64decode }}'
+    acm_kubeconfig_pass: '{{ kubeconfig_password.resources[0].data["password"] | b64decode }}'
   no_log: true
 ...


### PR DESCRIPTION
##### SUMMARY

Decode the secret creds obtained for the new cluster.

These credentials when used are stored and consumed in clear text, this is similar to other ways to generate credentials. This change provides consistency on the format of the credentials in other installers.

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestDallasSno: ocp-4.18-spoke-ztp-clusterinstance - https://www.distributed-ci.io/jobs/4b25a85c-977b-4bdd-9bb5-e1e443267937

---

Test-hints: no-check