### PR TITLE
Fix ansible-lint literal-compare

### DIFF
--- a/roles/destroy_vms/tasks/destroy_networks.yml
+++ b/roles/destroy_vms/tasks/destroy_networks.yml
@@ -22,7 +22,7 @@
     - "{{ vm_bridge_interface }}_{{ vm_bridge_name }}"
   failed_when: false
   become: true
-  when: (DELETE_VM_BRIDGE | default(SETUP_VM_BRIDGE | default(true))) | bool == true
+  when: (DELETE_VM_BRIDGE | default(SETUP_VM_BRIDGE | default(true)))
 
 - name: Delete existing bridges (if any)
   community.general.nmcli:
@@ -31,4 +31,6 @@
     state: absent
   failed_when: false
   become: true
-  when: (DELETE_VM_BRIDGE | default(SETUP_VM_BRIDGE | default(true))) | bool == true and vm_vlan_tag is defined
+  when:
+    - (DELETE_VM_BRIDGE | default(SETUP_VM_BRIDGE | default(true)))
+    - vm_vlan_tag is defined

--- a/roles/insert_dns_records/tasks/configure_firewall.yml
+++ b/roles/insert_dns_records/tasks/configure_firewall.yml
@@ -19,7 +19,7 @@
   loop:
     - internal
     - public
-  when: use_dhcp == true
+  when: use_dhcp | bool
 
 - name: Open port in firewall for proxy DHCP
   ansible.posix.firewalld:
@@ -31,7 +31,7 @@
   loop:
     - internal
     - public
-  when: use_pxe == true
+  when: use_pxe | bool
 
 - name: Open port in firewall for PXE
   ansible.posix.firewalld:
@@ -43,4 +43,4 @@
   loop:
     - internal
     - public
-  when: use_pxe == true
+  when: use_pxe | bool

--- a/roles/installer/tasks/15_disconnected_registry_existing.yml
+++ b/roles/installer/tasks/15_disconnected_registry_existing.yml
@@ -13,7 +13,7 @@
       fail:
         msg:
           - "The disconnected_registry_mirrors_file is defined, but does not exist"
-      when: drm_file.stat.exists != true
+      when: not drm_file.stat.exists
 
     - name: Read the contents of {{ disconnected_registry_mirrors_file }}
       slurp:
@@ -35,7 +35,7 @@
       fail:
         msg:
           - "The disconnected_registry_auths_file is defined, but does not exist"
-      when: dra_file.stat.exists != true
+      when: not dra_file.stat.exists
 
     - name: Read disconnected auths
       slurp:

--- a/roles/installer/tasks/25_create-install-config.yml
+++ b/roles/installer/tasks/25_create-install-config.yml
@@ -9,7 +9,7 @@
   slurp:
     src: "{{ ansible_user_dir }}/.ssh/id_rsa.pub"
   register: sshkey
-  when: sshkeypath.stat.exists == true
+  when: sshkeypath.stat.exists | bool
   tags: installconfig
 
 - name: Set Fact for the ssh key of {{ ansible_user }}

--- a/roles/prereq_facts_check/tasks/main.yml
+++ b/roles/prereq_facts_check/tasks/main.yml
@@ -7,7 +7,7 @@
       - pull_secret | trim != ''
     quiet: true
     msg: "The required 'pull_secret' is not defined or is not valid"
-  when: pull_secret_check | bool == True
+  when: pull_secret_check | bool
 
 - name: Check for ssh_public_key
   assert:
@@ -17,7 +17,7 @@
       - ssh_public_key | trim != ''
     quiet: true
     msg: "The required 'ssh_public_key' is not defined or is not valid"
-  when: ssh_public_check | bool == True
+  when: ssh_public_check | bool
 
 - name: Check for mirror_certificate
   assert:
@@ -27,4 +27,4 @@
       - mirror_certificate | trim != ''
     quiet: true
     msg: "The required 'mirror_certificate' is not defined or is not valid"
-  when: mirror_certificate_check | bool == True
+  when: mirror_certificate_check | bool

--- a/roles/setup_mirror_registry/tasks/prerequisites.yml
+++ b/roles/setup_mirror_registry/tasks/prerequisites.yml
@@ -16,7 +16,7 @@
     - name: "Fail: Certificate not found"
       fail:
         msg: "Cert file {{ registry_dir_cert }}/{{ cert_file_prefix }}.crt missing"
-      when: cert_file.stat.exists | bool == False
+      when: not cert_file.stat.exists
 
 - name: Create config_file_path dir
   file:

--- a/roles/vendors/supermicro/tasks/disk.yml
+++ b/roles/vendors/supermicro/tasks/disk.yml
@@ -36,7 +36,7 @@
             validate_certs: false
             force_basic_auth: true
             return_content: true
-          when: cd1_contents.json.Inserted | bool == True
+          when: cd1_contents.json.Inserted | bool
       rescue:
         - name: Unmount SuperMicro ISO (ISO Config)
           ansible.builtin.uri:


### PR DESCRIPTION
##### SUMMARY

Fix to 17 literal-compare profile:basic tags:idiom Removes the comparison to booleans in when condtitionals.

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/bfd3097b-2041-4571-a71d-4edeff882e41
- [x] TestBos2Sno: abi-sno abi-sno:ansible_extravars=enable_acm: - https://www.distributed-ci.io/jobs/62d6e283-7724-4b69-8de0-5508863eb140

---

Test-hints: no-check