### PR TITLE
Bump certsuite to v5.4.9

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.4.8
+kbpc_version: v5.4.9
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
##### SUMMARY

Bump to certsuite v5.4.9

##### ISSUE TYPE

- Bump version

##### Tests

- [x] Working deployment - https://www.distributed-ci.io/jobs/26b2ea8f-450d-405a-b05f-1bc903a8fa2b/jobStates?sort=date

Test-Hints: no-check