### PR TITLE
example-cnf | Add support for grout-operator

### DIFF
--- a/roles/example_cnf_deploy/defaults/main.yml
+++ b/roles/example_cnf_deploy/defaults/main.yml
@@ -18,39 +18,61 @@ ecd_opm_path: /usr/local/bin/opm
 # Logs folder
 ecd_job_logs_path: /tmp
 
+# CNFApp to select
+ecd_cnfapp_name: grout
+
 # Operators/apps to enable
 ecd_enable_mac_fetch: true
-ecd_enable_testpmd: true
+ecd_enable_testpmd: false
+ecd_enable_grout: true
 ecd_enable_trex: true
 ecd_enable_trex_app: true
 
 # Operator installation
 ecd_testpmd_channel: alpha
+ecd_grout_channel: alpha
 ecd_trex_channel: alpha
 
-# Static MAC addresses used by the deployed workloads
+# Network configuration
+
+## (Required for Grout deployment) Path to the network configuration file to be used to set the IP and MAC addresses for
+## each interface of both CNFApp and TRex
+ecd_network_config_file: ""
+
+## Default static MAC addresses used by the deployed workloads (if providing `ecd_network_config_file`, they are updated)
 ecd_trex_mac_list:
   - "20:04:0f:f1:89:01"
   - "20:04:0f:f1:89:02"
-ecd_testpmd_app_mac_list:
+ecd_cnfapp_mac_list:
   - "80:04:0f:f1:89:01"
   - "80:04:0f:f1:89:02"
 
-# Run all testpmd and trex deployment automation. If different than 1, the automation will only create the pods and prepare the scripts
-# to launch testpmd and trex manually afterwards
-ecd_run_deployment: 1
+## No default static IP addresses are provided for the deployed workloads. To update them, they must be provided on
+## `ecd_network_config_file` (just required when using Grout, optional for TestPMD since it is launched on MAC forwarding mode)
+ecd_trex_ip_list:
+  - ""
+  - ""
+ecd_cnfapp_ip_list:
+  - ""
+  - ""
 
-# Variables for gathering the network info from the scenario
-## SRIOV networks used in the connection between TRex and CNF Application, together with the number of interfaces to be used per network
+## Variables for gathering the network info from the scenario
+### SRIOV networks used in the connection between TRex and CNF Application, together with the number of interfaces to be used per network
 ecd_sriov_networks: []
-## Networks for the CNF, including the hardcoded MAC addresses
-ecd_networks_testpmd_app: []
+### Networks for CNFApp, including MAC addresses and (if provided) IP addresses
+ecd_networks_cnfapp: []
+### Networks for TRex, including MAC addresses and (if provided) IP addresses
+ecd_networks_trex: []
+
+# Run all deployment automation. If different than 1, the automation will only create the pods and prepare the scripts
+# to launch testpmd/grout and trex manually afterwards
+ecd_run_deployment: 1
 
 # RuntimeClass that should be used for running DPDK application,
 # if the var is empty, the annotation irq-load-balancing.crio.io: "disable" is not applied
 # ecd_high_perf_runtime: "performance-blueprint-profile"
 
-# Testpmd related variables
+# TestPMD related variables
 
 ## Termination grace period for testpmd
 ecd_termination_grace_period_seconds: 30

--- a/roles/example_cnf_deploy/scripts/get-example-cnf-status.sh
+++ b/roles/example_cnf_deploy/scripts/get-example-cnf-status.sh
@@ -42,7 +42,7 @@ done
 
 echo
 echo "--- CR status ---"
-CRS="cnfappmac testpmd trexconfig trexapp"
+CRS="cnfappmac $CNFAPP_NAME trexconfig trexapp"
 for CR in $CRS; do 
    echo "> Status of $CR"
    $OC_BINARY get "$CR" -n "$APP_NAMESPACE"

--- a/roles/example_cnf_deploy/tasks/deploy.yml
+++ b/roles/example_cnf_deploy/tasks/deploy.yml
@@ -1,4 +1,11 @@
 ---
+- name: "Fail if no network configuration is provided when using Grout as CNFApp"
+  ansible.builtin.fail:
+    msg: "If using Grout as CNFApp, network configuration file must be provided"
+  when:
+    - ecd_cnfapp_name == "grout"
+    - ecd_network_config_file|length == 0
+
 - name: "Find versions from the catalog"
   ansible.builtin.shell:
     cmd: >

--- a/roles/example_cnf_deploy/tasks/deploy/app.yml
+++ b/roles/example_cnf_deploy/tasks/deploy/app.yml
@@ -38,56 +38,59 @@
   when:
     - "ecd_sriov_networks|length == 0"
 
-# In this case, include hardcoded MAC addresses
-- name: "Create network list for cnfapp with hardcoded macs"
+- name: "Apply network configuration (if provided)"
+  ansible.builtin.include_tasks: deploy/net-config.yml
+  when: ecd_network_config_file|length > 0
+
+- name: "Create network list for CNFApp"
   ansible.builtin.set_fact:
-    ecd_networks_testpmd_app: "{{ ecd_networks_testpmd_app + [item | combine({'mac': ecd_testpmd_app_mac_list[idx:idx+item.count]})] }}"
+    ecd_networks_cnfapp: "{{ ecd_networks_cnfapp + [item | combine({'mac': ecd_cnfapp_mac_list[idx:idx+item.count], 'ip': ecd_cnfapp_ip_list[idx:idx+item.count]})] }}"
   loop: "{{ ecd_sriov_networks }}"
   loop_control:
     index_var: idx
 
-- name: "Create cr for cnf application"
+- name: "Create CR for CNF application"
   kubernetes.core.k8s:
-    definition: "{{ lookup('template', 'testpmd-cr.yaml.j2') }}"
+    definition: "{{ lookup('template', ecd_cnfapp_name + '-cr.yaml.j2') }}"
 
-- name: "Check testpmd pod count to be greater than 0"
+- name: "Check CNFApp pod count to be greater than 0"
   kubernetes.core.k8s_info:
     namespace: "{{ ecd_cnf_namespace }}"
     kind: Pod
     label_selectors:
       - example-cnf-type=cnf-app
-  register: _ecd_testpmd_pods
+  register: _ecd_cnfapp_pods
   retries: 60
   delay: 5
   until:
-    - _ecd_testpmd_pods.resources|length > 0
+    - _ecd_cnfapp_pods.resources|length > 0
 
-# At least confirm that the first testpmd pod is up and running
-- name: "Check testpmd pod status to be running"
+# At least confirm that the first CNFApp pod is up and running, if using more than one
+- name: "Check CNFApp pod status to be running"
   kubernetes.core.k8s_info:
     namespace: "{{ ecd_cnf_namespace }}"
     kind: Pod
     label_selectors:
       - example-cnf-type=cnf-app
-  register: _ecd_testpmd_pods
+  register: _ecd_cnfapp_pods
   vars:
-    ecd_container_state_running_query: "resources[0].status.containerStatuses[?name=='testpmd'].state.running"
-    ecd_container_started_query: "resources[0].status.containerStatuses[?name=='testpmd'].started"
-    ecd_container_ready_query: "resources[0].status.containerStatuses[?name=='testpmd'].ready"
-    ecd_container_state_running: "{{ _ecd_testpmd_pods | json_query(ecd_container_state_running_query) }}"
-    ecd_container_started: "{{ _ecd_testpmd_pods | json_query(ecd_container_started_query) }}"
-    ecd_container_ready: "{{ _ecd_testpmd_pods | json_query(ecd_container_ready_query) }}"
+    ecd_container_state_running_query: "resources[0].status.containerStatuses[?name=='{{ ecd_cnfapp_name }}'].state.running"
+    ecd_container_started_query: "resources[0].status.containerStatuses[?name=='{{ ecd_cnfapp_name }}'].started"
+    ecd_container_ready_query: "resources[0].status.containerStatuses[?name=='{{ ecd_cnfapp_name }}'].ready"
+    ecd_container_state_running: "{{ _ecd_cnfapp_pods | json_query(ecd_container_state_running_query) }}"
+    ecd_container_started: "{{ _ecd_cnfapp_pods | json_query(ecd_container_started_query) }}"
+    ecd_container_ready: "{{ _ecd_cnfapp_pods | json_query(ecd_container_ready_query) }}"
   retries: 60
   delay: 5
   until:
-    - _ecd_testpmd_pods.resources[0].status.phase == 'Running'
+    - _ecd_cnfapp_pods.resources[0].status.phase == 'Running'
     - ecd_container_state_running | length > 0
     - ecd_container_started | length > 0
     - ecd_container_started[0] | bool
     - ecd_container_ready | length > 0
     - ecd_container_ready[0] | bool
 
-- name: "Check cnfappmac resource (created by testpmd app) count to be greater than 0"
+- name: "Check CNFAppMac resource count to be greater than 0"
   kubernetes.core.k8s_info:
     namespace: "{{ ecd_cnf_namespace }}"
     kind: CNFAppMac
@@ -98,13 +101,13 @@
     - _ecd_cnfappmac.resources is defined
     - _ecd_cnfappmac.resources|length > 0
 
-# CNFAppMac and testpmd pods share the same name, so we can use it for doing
+# CNFAppMac and CNFApp pods share the same name, so we can use it for doing
 # some extra checks
-- name: "Check that at least the cnfappmac resource for the first testpmd pod has the required data"
+- name: "Check that at least the cnfappmac resource for the first CNFApp pod has the required data"
   kubernetes.core.k8s_info:
     namespace: "{{ ecd_cnf_namespace }}"
     kind: CNFAppMac
-    name: "{{ _ecd_testpmd_pods.resources[0].metadata.name }}"
+    name: "{{ _ecd_cnfapp_pods.resources[0].metadata.name }}"
   register: _ecd_first_cnfappmac
   retries: 120
   delay: 5
@@ -122,13 +125,13 @@
     ecd_trex_tests_skip_failures: true
   when: ecd_run_deployment != 1
 
-- name: "Trex cr block"
+- name: "TRex CR block"
   ansible.builtin.include_tasks: trex/retry-trex.yml
   when: ecd_enable_trex|bool
 
 # We need to check ecd_trex_continuous_mode here to avoid running extra tests, where we would have two or
 # more possible TRex jobs that are running in continuous burst mode.
-- name: "Trex additional tests"
+- name: "TRex additional tests"
   ansible.builtin.include_tasks: trex/tests.yml
   when:
     - ecd_enable_trex_app|bool

--- a/roles/example_cnf_deploy/tasks/deploy/net-config.yml
+++ b/roles/example_cnf_deploy/tasks/deploy/net-config.yml
@@ -1,0 +1,54 @@
+---
+- name: Check network config file
+  ansible.builtin.stat:
+    path: "{{ ecd_network_config_file }}"
+  register: _ecd_network_config_file_stat
+
+- name: Fail if network config file is not found
+  ansible.builtin.fail:
+    msg: "Network config file {{ ecd_network_config_file }} not found"
+  when: not _ecd_network_config_file_stat.stat.exists
+
+- name: Fail if network config file is empty
+  ansible.builtin.fail:
+    msg: "Network config file {{ _ecd_network_config_file_stat }} is empty"
+  when: _ecd_network_config_file_stat.stat.size == 0
+
+- name: Load network config file
+  ansible.builtin.include_vars:
+    file: "{{ ecd_network_config_file }}"
+  when: _ecd_network_config_file_stat.stat.exists
+
+- name: Check structure of the network config file
+  ansible.builtin.assert:
+    that:
+      - ecd_network_config is defined
+      - ecd_network_config.cnfapp is defined
+      - ecd_network_config.cnfapp.net1 is defined
+      - ecd_network_config.cnfapp.net1.mac is defined
+      - ecd_network_config.cnfapp.net1.ip is defined
+      - ecd_network_config.cnfapp.net2 is defined
+      - ecd_network_config.cnfapp.net2.mac is defined
+      - ecd_network_config.cnfapp.net2.ip is defined
+      - ecd_network_config.trex is defined
+      - ecd_network_config.trex.net1 is defined
+      - ecd_network_config.trex.net1.mac is defined
+      - ecd_network_config.trex.net1.ip is defined
+      - ecd_network_config.trex.net2 is defined
+      - ecd_network_config.trex.net2.mac is defined
+      - ecd_network_config.trex.net2.ip is defined
+
+- name: Redefine network-related variables
+  ansible.builtin.set_fact:
+    ecd_cnfapp_mac_list:
+      - "{{ ecd_network_config.cnfapp.net1.mac }}"
+      - "{{ ecd_network_config.cnfapp.net2.mac }}"
+    ecd_cnfapp_ip_list:
+      - "{{ ecd_network_config.cnfapp.net1.ip }}"
+      - "{{ ecd_network_config.cnfapp.net2.ip }}"
+    ecd_trex_mac_list:
+      - "{{ ecd_network_config.trex.net1.mac }}"
+      - "{{ ecd_network_config.trex.net2.mac }}"
+    ecd_trex_ip_list:
+      - "{{ ecd_network_config.trex.net1.ip }}"
+      - "{{ ecd_network_config.trex.net2.ip }}"

--- a/roles/example_cnf_deploy/tasks/deploy/sub.yml
+++ b/roles/example_cnf_deploy/tasks/deploy/sub.yml
@@ -1,4 +1,9 @@
 ---
+- name: "Set CNFApp-related operator to be installed"
+  ansible.builtin.set_fact:
+    ecd_enable_testpmd: "{{ ecd_cnfapp_name == 'testpmd' }}"
+    ecd_enable_grout: "{{ ecd_cnfapp_name == 'grout' }}"
+
 - name: "Set list of example-cnf operators to be installed"
   ansible.builtin.set_fact:
     ecd_operators:
@@ -6,17 +11,22 @@
         namespace: "{{ ecd_cnf_namespace }}"
         channel: "{{ ecd_testpmd_channel }}"
         source: "{{ ecd_catalog_name }}"
-        enable: "{{ ecd_enable_mac_fetch | bool}}"
+        enable: "{{ ecd_enable_mac_fetch | bool }}"
       - name: testpmd-operator
         namespace: "{{ ecd_cnf_namespace }}"
         channel: "{{ ecd_testpmd_channel }}"
         source: "{{ ecd_catalog_name }}"
-        enable: "{{ ecd_enable_testpmd | bool}}"
+        enable: "{{ ecd_enable_testpmd | bool }}"
+      - name: grout-operator
+        namespace: "{{ ecd_cnf_namespace }}"
+        channel: "{{ ecd_grout_channel }}"
+        source: "{{ ecd_catalog_name }}"
+        enable: "{{ ecd_enable_grout | bool }}"
       - name: trex-operator
         namespace: "{{ ecd_cnf_namespace }}"
         channel: "{{ ecd_trex_channel }}"
         source: "{{ ecd_catalog_name }}"
-        enable: "{{ ecd_enable_trex | bool}}"
+        enable: "{{ ecd_enable_trex | bool }}"
 
 - name: "Install enabled operators"
   vars:

--- a/roles/example_cnf_deploy/tasks/deploy_extra_trex.yml
+++ b/roles/example_cnf_deploy/tasks/deploy_extra_trex.yml
@@ -1,4 +1,8 @@
 ---
+- name: "CNFApp must be TestPMD"
+  ansible.builtin.assert:
+    that: ecd_cnfapp_name == 'testpmd'
+
 # Directly call to retry-trex.yml playbook
 - name: "Deploy an extra TRex job"
   ansible.builtin.include_tasks: trex/retry-trex.yml

--- a/roles/example_cnf_deploy/tasks/draining.yml
+++ b/roles/example_cnf_deploy/tasks/draining.yml
@@ -1,4 +1,7 @@
 ---
+- name: "CNFApp must be TestPMD"
+  ansible.builtin.assert:
+    that: ecd_cnfapp_name == 'testpmd'
 
 - name: Gather facts
   ansible.builtin.include_tasks: draining/gather-facts.yml

--- a/roles/example_cnf_deploy/tasks/main.yml
+++ b/roles/example_cnf_deploy/tasks/main.yml
@@ -1,9 +1,29 @@
 ---
-- name: "Requirements validation for example-cnf actions"
+- name: "Requirements validation for example-cnf actions and CNFApp alternatives"
   ansible.builtin.assert:
     that:
       - ecd_action is defined
       - ecd_action in ['catalog', 'deploy', 'validate', 'deploy_extra_trex', 'draining']
+      - ecd_cnfapp_name in ['grout', 'testpmd']
+
+- name: "Get cluster version"
+  kubernetes.core.k8s_info:
+    api: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+  register: _ecd_cluster_version
+
+- name: "Set OCP name and version facts"
+  vars:
+    ecd_current_ver_query: "history[?state=='Completed'] | [0].version"
+    ecd_full_ver: "{{ _ecd_cluster_version.resources[0].status | json_query(ecd_current_ver_query) }}"
+  ansible.builtin.set_fact:
+    ecd_ocp_version_full: "{{ ecd_full_ver }}"
+
+- name: "Fail if OCP version is lower than 4.14"
+  ansible.builtin.fail:
+    msg: OCP version is lower than 4.14. This is required to use and manipulate pod network annotations
+  when: ecd_ocp_version_full is ansible.builtin.version('4.14', '<')
 
 - name: "Deploy Example CNF catalog"
   ansible.builtin.include_tasks: catalog.yml

--- a/roles/example_cnf_deploy/tasks/trex/app.yml
+++ b/roles/example_cnf_deploy/tasks/trex/app.yml
@@ -11,15 +11,10 @@
 - name: Create and check TRexServer CR
   when: _ecd_trexconfig_cr.resources|length == 0
   block:
-    - name: Set local fact for trex pod networks
-      ansible.builtin.set_fact:
-        ecd_networks_trex: []
-        ecd_packet_gen_net: "{{ ecd_sriov_networks }}"
-
     - name: Create network list for trex with hardcoded macs
       ansible.builtin.set_fact:
-        ecd_networks_trex: "{{ ecd_networks_trex + [ item | combine({'mac': ecd_trex_mac_list[idx:idx+item.count]})] }}"
-      loop: "{{ ecd_packet_gen_net }}"
+        ecd_networks_trex: "{{ ecd_networks_trex + [ item | combine({'mac': ecd_trex_mac_list[idx:idx+item.count], 'ip': ecd_trex_ip_list[idx:idx+item.count]})] }}"
+      loop: "{{ ecd_sriov_networks }}"
       loop_control:
         index_var: idx
 
@@ -132,6 +127,7 @@
         OC_BINARY: "{{ ecd_oc_path }}"
         APP_NAMESPACE: "{{ ecd_cnf_namespace }}"
         SRIOV_NAMESPACE: openshift-sriov-network-operator
+        CNFAPP_NAME: "{{ ecd_cnfapp_name }}"
       ansible.builtin.script:
         cmd: >
           ../../scripts/get-example-cnf-status.sh > example-cnf-post-job-status.log

--- a/roles/example_cnf_deploy/tasks/validate/migrate.yml
+++ b/roles/example_cnf_deploy/tasks/validate/migrate.yml
@@ -1,15 +1,17 @@
 ---
 
-- name: "Get TestPMD CR info"
+- name: "Get CNFApp CR info"
+  vars:
+    ecd_cnfapp_cr_kind: "{{ (ecd_cnfapp_name == 'grout') | ternary('Grout', 'TestPMD') }}"
   kubernetes.core.k8s_info:
     namespace: "{{ ecd_cnf_namespace }}"
-    kind: TestPMD
-  register: _ecd_testpmd_list
+    kind: "{{ ecd_cnfapp_cr_kind }}"
+  register: _ecd_cnfapp_list
 
-- name: "Validate number of TestPMD CRs"
+- name: "Validate number of CNFApp CRs"
   ansible.builtin.fail:
-    msg: "TestPMD CRs count ({{ _ecd_testpmd_list.resources | length }}) is invalid"
-  when: "_ecd_testpmd_list.resources|length != 1"
+    msg: "CNFApp CR count ({{ _ecd_cnfapp_list.resources | length }}) is invalid"
+  when: "_ecd_cnfapp_list.resources|length != 1"
 
 # This means that the TRex job may have failed, so we don't want to run the migration
 # tests in that case

--- a/roles/example_cnf_deploy/tasks/validate/pod-delete.yml
+++ b/roles/example_cnf_deploy/tasks/validate/pod-delete.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Get cnf app pod"
+- name: "Get CNFApp pod"
   kubernetes.core.k8s_info:
     kind: Pod
     namespace: "{{ ecd_cnf_namespace }}"
@@ -15,18 +15,18 @@
 
 - name: "Set cnf app pod's node name"
   ansible.builtin.set_fact:
-    ecd_cnf_existing_node: "{{ _ecd_cnf_pod.resources[0].spec.nodeName }}"
+    ecd_cnfapp_existing_node: "{{ _ecd_cnf_pod.resources[0].spec.nodeName }}"
     ecd_cnf_existing_pod_name: "{{ _ecd_cnf_pod.resources[0].metadata.name }}"
     ecd_cnf_app_count: "{{ _ecd_cnf_pod.resources|length }}"
     ecd_cnf_app_list: "{{ _ecd_cnf_pod | json_query('resources[*].metadata.name') }}"
 
-- name: "Show current node of testpmd"
+- name: "Show current node of CNFApp"
   ansible.builtin.debug:
-    msg: "CNF App is running on node {{ ecd_cnf_existing_node }}"
+    msg: "CNF App is running on node {{ ecd_cnfapp_existing_node }}"
 
 - name: "Cordon the node"
   ansible.builtin.shell: |
-    {{ ecd_oc_path }} adm cordon {{ ecd_cnf_existing_node }}
+    {{ ecd_oc_path }} adm cordon {{ ecd_cnfapp_existing_node }}
 
 - name: Delete the cnf app pod
   kubernetes.core.k8s:
@@ -51,9 +51,9 @@
   until:
     - "_ecd_cnf_new_pods.resources|length == ecd_cnf_app_count|int"
 
-- name: "Set new testpmd node name"
+- name: "Set new CNFApp node name"
   ansible.builtin.set_fact:
-    ecd_testpmd_new_node: "{{ pod.spec.nodeName }}"
+    ecd_cnfapp_new_node: "{{ pod.spec.nodeName }}"
   loop: "{{ _ecd_cnf_new_pods.resources }}"
   loop_control:
     loop_var: pod
@@ -61,13 +61,13 @@
 
 - name: "Uncordon the node"
   ansible.builtin.shell: |
-    {{ ecd_oc_path }} adm uncordon {{ ecd_cnf_existing_node }}
+    {{ ecd_oc_path }} adm uncordon {{ ecd_cnfapp_existing_node }}
 
-- name: "Fail if TestPMD pod is not migrated"
+- name: "Fail if CNFApp pod is not migrated"
   ansible.builtin.fail:
-    msg: "TestPMD pod is not migrated"
-  when: ecd_testpmd_new_node == ecd_cnf_existing_node
+    msg: "CNFApp pod is not migrated"
+  when: ecd_cnfapp_new_node == ecd_cnfapp_existing_node
 
-- name: "Debug new TestPMD pod"
+- name: "Debug new CNFApp pod"
   ansible.builtin.debug:
-    msg: "TestPMD pod is migrated from {{ ecd_cnf_existing_node }} to {{ ecd_testpmd_new_node }}"
+    msg: "CNFApp pod is migrated from {{ ecd_cnfapp_existing_node }} to {{ ecd_cnfapp_new_node }}"

--- a/roles/example_cnf_deploy/templates/grout-cr.yaml.j2
+++ b/roles/example_cnf_deploy/templates/grout-cr.yaml.j2
@@ -1,16 +1,13 @@
 apiVersion: examplecnf.openshift.io/v1
-kind: TestPMD
+kind: Grout
 metadata:
-  name: testpmd
+  name: grout
   namespace: {{ ecd_cnf_namespace }}
 spec:
   privileged: false
   imagePullPolicy: {{ ecd_image_pull_policy }}
-  ethpeerMaclist: {{ ecd_trex_mac_list }}
   size: 1  
   networks: {{ ecd_networks_cnfapp }}
-  terminationGracePeriodSeconds: {{ ecd_termination_grace_period_seconds }}
-  reducedMode: {{ ecd_testpmd_reduced_mode }}
   runDeployment: {{ ecd_run_deployment }}
 {% if ecd_high_perf_runtime is defined and ecd_high_perf_runtime|length %}
   runtime_class_name: "{{ ecd_high_perf_runtime }}"

--- a/roles/example_cnf_deploy/templates/trex-app-cr.yaml.j2
+++ b/roles/example_cnf_deploy/templates/trex-app-cr.yaml.j2
@@ -16,6 +16,9 @@ spec:
 {% if ecd_packet_size|default('') %}
   packetSize: {{ ecd_packet_size }}
 {% endif %}
+  trexIps: {{ ecd_trex_ip_list }}
+  cnfappIps: {{ ecd_cnfapp_ip_list }}
+  arpResolution: {{ (ecd_cnfapp_name == 'grout') | ternary('1','0') }}
   registry: {{ ecd_registry_url }}
   org: {{ ecd_repo_name }}
   version: {{ ecd_trex_app_version }}

--- a/roles/example_cnf_deploy/templates/trex-app-job.yaml.j2
+++ b/roles/example_cnf_deploy/templates/trex-app-job.yaml.j2
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: trex-app-account
       containers:
       - name: trex-app
-        image: "{{ ecd:image_app }}"
+        image: "{{ ecd_image_app }}"
         imagePullPolicy: "{{ ecd_image_pull_policy }}"
         volumeMounts:
         - name: varlog
@@ -54,8 +54,14 @@ spec:
         - name: PACKET_RATE
           value: "{{ ecd_packet_rate }}"
 {% endif %}
+        - name: trex_ip_list
+          value: "{{ ecd_trex_ip_list[0] }},{{ ecd_trex_ip_list[1] }},"
+        - name: cnfapp_ip_list
+          value: "{{ ecd_cnfapp_ip_list[0] }},{{ ecd_cnfapp_ip_list[1] }},"
         - name: run_deployment
           value: "{{ ecd_run_deployment }}"
+        - name: arp_resolution
+          value: "{{ (ecd_cnfapp_name == 'grout') | ternary('1','0') }}"
         lifecycle:
           postStart:
             exec:

--- a/roles/sriov_config/templates/sriov-network.yml.j2
+++ b/roles/sriov_config/templates/sriov-network.yml.j2
@@ -8,7 +8,7 @@ spec:
   capabilities: {{ sriov.network.capabilities | to_json }}
 {% endif %}
 {% if sriov.network.ipam is defined %}
-  ipam: "{{ sriov.network.ipam }}"
+  ipam: {{ sriov.network.ipam | to_json }}
 {% endif %}
 {% if sriov.network.link_state is defined %}
   linkState: "{{ sriov.network.link_state }}"


### PR DESCRIPTION
##### SUMMARY

- Restructure example_cnf_deploy role to be able to launch grout as CNFApp. We can also select testpmd, but grout will be the default one
- Main improvement is the inclusion of L3 configuration for the workloads under test. This is mandatory for Grout as it uses L3 forwarding, but optional for TestPMD (it can work regardless of the IP addressing).
- sriov_config role needs an update for correctly handling the `ipam` config in the SriovNetwork template. All documentation regarding SriovNetwork mentions that `ipam` block is defined in JSON format. Example [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/hardware-networks#nw-sriov-network-attachment_configuring-sriov-net-attach). If not using it, we may find issues like [this one](https://www.distributed-ci.io/jobs/8ee1c266-fe47-42be-9945-c5cab01f47f1/jobStates), where templating fails because of not expecting the correct format.

##### ISSUE TYPE

- Enhanced feature

##### Tests

Summary of tests that have been executed:

- [x] Troubleshooting mode with Grout (verified manually) - https://www.distributed-ci.io/jobs/81e00827-d455-4c94-a04f-a7b16d38355b/jobStates?sort=date
- [x] Troubleshooting mode with TestPMD - L3 (verified manually) - https://www.distributed-ci.io/jobs/fccf4827-43d9-4c2a-838b-01b87a55d707/jobStates?sort=date
- [x] Automated deployment with Grout - https://www.distributed-ci.io/jobs/7978319b-b984-4cb9-8716-f69075ef5f20/jobStates?sort=date
- [x] Automated deployment with TestPMD - L3 - https://www.distributed-ci.io/jobs/fcd7002f-7b01-4d5f-aec4-4f5065e3d334/jobStates?sort=date
- [x] Automated deployment with TestPMD - L2 - https://www.distributed-ci.io/jobs/3b1a815c-29a2-4e0c-b1d3-3e3b9e661cb2/jobStates?sort=date
- [x] Automated deployment with Grout + all certification suites - 1) with empty tests_to_verify to confirm the results: https://www.distributed-ci.io/jobs/22dc5106-d62c-4b8d-925e-12023b02fd14/jobStates?sort=date, 2) with completed tests_to_verify to verify the results are fine: https://www.distributed-ci.io/jobs/ad611c02-f158-461a-a1b9-0a899f2e2bae/jobStates?sort=date
-  [x] Automated deployment with TestPMD - L3 + certsuite (preflight exec does not depend on the CNFApp) - https://www.distributed-ci.io/jobs/fc774a55-9e37-4dd0-9427-aedf213eabc2/jobStates?sort=date
-  [x] Automated deployment with TestPMD - L2 + certsuite (preflight exec does not depend on the CNFApp) - https://www.distributed-ci.io/jobs/1d7b3e80-3251-411c-9793-ddd73bfd1745/jobStates?sort=date

Test-Hints: no-check

## Summary by CodeRabbit

- **New Features**
  - Added support for deploying both TestPMD and Grout DPDK workloads, with Grout as the default.
  - Introduced a configurable network configuration file for advanced network setups, required for Grout deployments.
  - Enhanced network configuration options, including support for specifying MAC and IP addresses for CNFApp and TRex.
  - Added new custom resource template for Grout workload and dynamic deployment templates based on workload choice.

- **Improvements**
  - Updated documentation to reflect new variables, configuration options, and OpenShift version requirements (now >=4.14).
  - Streamlined variable naming and deployment logic for flexibility and clarity.
  - Improved error handling and validation for missing or incorrect configurations.
  - Extended operator installation to include Grout operator with conditional enablement.
  - Enhanced log retrieval and status scripts to dynamically handle workload names.
  - Added OpenShift version check to enforce minimum version requirements.

- **Bug Fixes**
  - Corrected template and script references to ensure consistent deployment and status reporting for both CNF applications.