### PR TITLE
Preflight: Expand user on partner creds before using by root

### DIFF
--- a/roles/preflight/tasks/test_run_health_check.yml
+++ b/roles/preflight/tasks/test_run_health_check.yml
@@ -31,15 +31,15 @@
 
 - name: Expanduser partner_creds
   ansible.builtin.set_fact:
-    partner_creds_expanded: "{{ partner_creds | expanduser }}"
+    preflight_partner_creds: "{{ partner_creds | expanduser }}"
   when: partner_creds is defined
 
 - name: Get the image available for the root user
   ansible.builtin.command:
     cmd: >
       podman pull
-      {% if partner_creds_expanded | length %}
-      --authfile {{ partner_creds_expanded }}
+      {% if preflight_partner_creds | length %}
+      --authfile {{ preflight_partner_creds }}
       {% endif %}
       {{ current_operator_image }}
   become: true

--- a/roles/preflight/tasks/test_run_health_check.yml
+++ b/roles/preflight/tasks/test_run_health_check.yml
@@ -29,12 +29,17 @@
     chdir: "{{ preflight_container_artifacts.path }}"
   become: true
 
+- name: Expanduser partner_creds
+  ansible.builtin.set_fact:
+    partner_creds_expanded: "{{ partner_creds | expanduser }}"
+  when: partner_creds is defined
+
 - name: Get the image available for the root user
   ansible.builtin.command:
     cmd: >
       podman pull
-      {% if partner_creds | length %}
-      --authfile {{ partner_creds }}
+      {% if partner_creds_expanded | length %}
+      --authfile {{ partner_creds_expanded }}
       {% endif %}
       {{ current_operator_image }}
   become: true


### PR DESCRIPTION
##### SUMMARY

When partner_creds contains "TILD" in dci-pipeline file, it is interpreted when it is used. Unfortunately it failed when a task uses privilege escalation, "TILD" becomes /root

##### ISSUE TYPE

- Bug

Test-Hint: no-check
