### PR TITLE
Return a dict on junit2obj filter

### DIFF
--- a/plugins/filter/junit2obj.py
+++ b/plugins/filter/junit2obj.py
@@ -30,11 +30,6 @@ DOCUMENTATION = r"""
       description: The junit report xml text data
       type: str
       required: true
-    object:
-      description: return JSON object (not the string)
-      type: bool
-      default: false
-      required: false
 """
 
 
@@ -141,8 +136,8 @@ EXAMPLES = r"""
 RETURN = r"""
   _value:
     description:
-      - JSON text representation (escaped string) of the report or JSON data if `object` is `True`
-    type: str or dict
+      - JSON data
+    type: dict
 """
 
 
@@ -159,7 +154,7 @@ class FilterModule(object):
             "junit2obj": self.junit2obj,
         }
 
-    def junit2obj(self, xml_report_text: str, object: bool = False) -> str | dict:
+    def junit2obj(self, xml_report_text: str) -> dict:
         """
         Convert junit XML Report into JSON.
         """
@@ -271,7 +266,4 @@ class FilterModule(object):
             curr_suite = _process_test_suite(tstsuite)
             report["test_suites"].append(curr_suite)
 
-        if object is True:
-            return report
-        result_text: str = json.dumps(dict(report), indent=4) + "\n"
-        return result_text
+        return report

--- a/roles/junit2json/tasks/convert.yml
+++ b/roles/junit2json/tasks/convert.yml
@@ -31,6 +31,14 @@
 
 - name: Write the json data to file
   ansible.builtin.copy:
-    content: "{{ junit2_result_data | redhatci.ocp.junit2obj(object=not (junit2_out_str)) | to_nice_json }}"
+    content: "{{ junit2_result_data | redhatci.ocp.junit2obj | to_nice_json }}"
     dest: "{{ junit2_output_report_path }}"
     mode: '0644'
+  when: not junit2_out_str | bool
+
+- name: Write the json string to file
+  ansible.builtin.copy:
+    content: "{{ junit2_result_data | redhatci.ocp.junit2obj }}"
+    dest: "{{ junit2_output_report_path }}"
+    mode: '0644'
+  when: junit2_out_str | bool


### PR DESCRIPTION
##### SUMMARY

Returning more than one type is not supported in py3.6, keeping compatibility through the role by allowing to return string or dict through it.

Fixes: #635

##### ISSUE TYPE

- Bug

##### Tests

- [ ] TestDallasWorkload: preflight-green - 
- [ ] TestDallasWorkload: tnf-test-cnf-green tnf-test-cnf-green:ansible_extravars=kbpc_version:HEAD - 
- [ ] TestBos2Sno: abi-sno control-plane control-plane:ansible_extravars=openshift_app_replicas:1

---

TestDallasWorkload: preflight-green 
TestBos2Sno: abi-sno control-plane control-plane:ansible_extravars=openshift_app_replicas:1

