### PR TITLE
http_store - Allow pods not manged by systemd and without root

### DIFF
--- a/roles/setup_http_store/README.md
+++ b/roles/setup_http_store/README.md
@@ -11,6 +11,7 @@ Sets up a web host which can be used to distribute ISO's for `boot_iso` role
 | http_dir                  | no       | /opt/http_store                                    |                                                                                                                                      |
 | http_data_dir             | no       | "{{ http_dir }}/data"                              |                                                                                                                                      |
 | container_image           | no       | registry.centos.org/centos/httpd-24-centos7:latest | If you change this to anything other than the same image on a different host you may need to change then environment vars in the task |
+| http_store_ephemeral      | no       | false                                              | If set to true, the HTTP pod will be managed as a systemd service. If false, the pod runs directly using Podman and requires manual management |
 
 ## Dependencies
 

--- a/roles/setup_http_store/README.md
+++ b/roles/setup_http_store/README.md
@@ -11,7 +11,7 @@ Sets up a web host which can be used to distribute ISO's for `boot_iso` role
 | http_dir                  | no       | /opt/http_store                                    |                                                                                                                                      |
 | http_data_dir             | no       | "{{ http_dir }}/data"                              |                                                                                                                                      |
 | container_image           | no       | registry.centos.org/centos/httpd-24-centos7:latest | If you change this to anything other than the same image on a different host you may need to change then environment vars in the task |
-| http_store_ephemeral      | no       | false                                              | If set to true, the HTTP pod will be managed as a systemd service. If false, the pod runs directly using Podman and requires manual management |
+| http_store_ephemeral      | no       | false                                              | By default (false), the pod is managed as a systemd service. If set to true, the pod runs directly using Podman and requires manual management |
 
 ## Dependencies
 

--- a/roles/setup_http_store/defaults/main.yml
+++ b/roles/setup_http_store/defaults/main.yml
@@ -7,3 +7,5 @@ http_port: 80
 container_image: quay.io/fedora/httpd-24:latest
 file_owner: "{{ ansible_env.USER }}"
 file_group: "{{ file_owner }}"
+http_store_ephemeral: false
+...

--- a/roles/setup_http_store/tasks/main.yml
+++ b/roles/setup_http_store/tasks/main.yml
@@ -38,6 +38,7 @@
         publish:
           - "{{ http_port }}:8080"
       register: pod_info
+      become: not http_store_ephemeral | bool
 
     - name: Debug
       ansible.builtin.debug:
@@ -55,6 +56,7 @@
         volumes:
           - "{{ http_data_dir }}:/var/www/html:z"
       register: container_info
+      become: not http_store_ephemeral | bool
 
     - name: Configure HTTP Store systemd service
       when:
@@ -86,13 +88,17 @@
             scope: system
 
         - name: Enable http_store.service
+          environment:
+            XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
           ansible.builtin.systemd:
             name: http_store
             enabled: true
-            scope: system
+            scope: user
 
         - name: Start http_store.service
+          environment:
+            XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
           ansible.builtin.systemd:
             name: http_store
             state: started
-            scope: system
+            scope: user

--- a/roles/setup_http_store/tasks/main.yml
+++ b/roles/setup_http_store/tasks/main.yml
@@ -38,7 +38,7 @@
         publish:
           - "{{ http_port }}:8080"
       register: pod_info
-      become: not http_store_ephemeral | bool
+      become: "{{ not (http_store_ephemeral | bool) }}"
 
     - name: Debug
       ansible.builtin.debug:
@@ -56,7 +56,7 @@
         volumes:
           - "{{ http_data_dir }}:/var/www/html:z"
       register: container_info
-      become: not http_store_ephemeral | bool
+      become: "{{ not (http_store_ephemeral | bool) }}"
 
     - name: Configure HTTP Store systemd service
       when:

--- a/roles/setup_http_store/tasks/main.yml
+++ b/roles/setup_http_store/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 - name: Setup HTTP Store
-  become: true
   block:
     - name: Install podman
-      package:
+      ansible.builtin.package:
         name: podman
         state: present
+      become: true
 
     - name: Open http port, zone internal and public, for firewalld
-      firewalld:
+      ansible.builtin.firewalld:
         port: "{{ http_port }}/tcp"
         permanent: true
         immediate: true
@@ -17,9 +17,10 @@
       loop:
         - internal
         - public
+      become: true
 
     - name: Create directory to hold the registry files
-      file:
+      ansible.builtin.file:
         path: "{{ item }}"
         state: directory
         owner: "{{ file_owner }}"
@@ -29,8 +30,9 @@
       loop:
         - "{{ http_dir }}"
         - "{{ http_data_dir }}"
+      become: true
 
-    - name: Create httpd container
+    - name: Create httpd pod
       containers.podman.podman_pod:
         name: "{{ http_store_pod_name }}"
         publish:
@@ -43,50 +45,54 @@
         verbosity: 1
 
     - name: Create httpd container
+      vars:
+        container_status: "{{ http_store_ephemeral | ternary('started', 'stopped') }}"
       containers.podman.podman_container:
         name: "{{ http_store_container_name }}"
         image: "{{ container_image }}"
         pod: "{{ http_store_pod_name }}"
-        state: stopped
+        state: "{{ container_status }}"
         volumes:
           - "{{ http_data_dir }}:/var/www/html:z"
       register: container_info
 
-    - name: Setting facts about container
-      set_fact:
-        http_store_name: "{{ container_info.container.Name }}"
-        http_store_pidfile: "{{ container_info.container.ConmonPidFile }}"
+    - name: Configure HTTP Store systemd service
+      when:
+        - not http_store_ephemeral | bool
+      become: true
+      block:
+        - name: Copy the systemd service file
+          vars:
+            http_store_pidfile: "{{ container_info.container.ConmonPidFile }}"
+          ansible.builtin.copy:
+            content: |
+              [Unit]
+              Description=Podman http_store.service
+              [Service]
+              Restart=on-failure
+              ExecStart=/usr/bin/podman pod start {{ http_store_pod_name }}
+              ExecStop=/usr/bin/podman pod stop -t 10 {{ http_store_pod_name }}
+              KillMode=none
+              Type=forking
+              PIDFile={{ http_store_pidfile }}
+              [Install]
+              WantedBy=default.target
+            dest: "/etc/systemd/system/http_store.service"
+            mode: "0644"
 
-    - name: Copy the systemd service file
-      copy:
-        content: |
-          [Unit]
-          Description=Podman http_store.service
-          [Service]
-          Restart=on-failure
-          ExecStart=/usr/bin/podman pod start {{ http_store_pod_name }}
-          ExecStop=/usr/bin/podman pod stop -t 10 {{ http_store_pod_name }}
-          KillMode=none
-          Type=forking
-          PIDFile={{ http_store_pidfile }}
-          [Install]
-          WantedBy=default.target
-        dest: "/etc/systemd/system/http_store.service"
-        mode: "0644"
+        - name: Reload systemd service
+          ansible.builtin.systemd:
+            daemon_reexec: true
+            scope: system
 
-    - name: Reload systemd service
-      systemd:
-        daemon_reexec: true
-        scope: system
+        - name: Enable http_store.service
+          ansible.builtin.systemd:
+            name: http_store
+            enabled: true
+            scope: system
 
-    - name: Enable http_store.service
-      systemd:
-        name: http_store
-        enabled: true
-        scope: system
-
-    - name: Start http_store.service
-      systemd:
-        name: http_store
-        state: started
-        scope: system
+        - name: Start http_store.service
+          ansible.builtin.systemd:
+            name: http_store
+            state: started
+            scope: system

--- a/roles/setup_http_store/tasks/main.yml
+++ b/roles/setup_http_store/tasks/main.yml
@@ -88,17 +88,13 @@
             scope: system
 
         - name: Enable http_store.service
-          environment:
-            XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
           ansible.builtin.systemd:
             name: http_store
             enabled: true
-            scope: user
+            scope: system
 
         - name: Start http_store.service
-          environment:
-            XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
           ansible.builtin.systemd:
             name: http_store
             state: started
-            scope: user
+            scope: system


### PR DESCRIPTION
##### SUMMARY

* Allow to create pods not managed by systemd, useful if you to run multiple instances at the same that and managed manually
* Do not run the pod/containers as root
* Use FQCNs  

##### ISSUE TYPE

- Nominal change

##### Tests
- [x] TestBos2: abi - https://www.distributed-ci.io/jobs/66b8540f-4249-416a-8a0b-a8f7e594187e/jobStates

Test-Hint: no-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a configuration option that lets you choose between automatic service management and manual container control for the HTTP service.

- **Documentation**
	- Updated setup guides to include details on the new configuration option and its default behavior.

- **Refactor**
	- Improved privilege escalation handling and task organization for better deployment control and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->