### PR TITLE
[odf_setup] allow to define the number of devicesets for OCS

### DIFF
--- a/roles/odf_setup/README.md
+++ b/roles/odf_setup/README.md
@@ -31,6 +31,7 @@ Role Variables
 | ocs_default_storage_class        | storagecluster-cephfs         | String       | No          | Default storage class name                                               |
 | gatherer_image                   | registry.access.redhat.com/ubi8/ubi | String | No          | Image for disk-gatherer deployment                                       |
 | odf_setup_oc_tool_path                   | '/usr/local/bin/oc` | String | No          | Path to the OpenShift Command Line Interface binary.
+| ocs_total_deviceset              | length of local_storage_devices | Int | No          | (Optional) number of device sets for OCS |
 
 
 Inventory Groups and Variables

--- a/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
+++ b/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
@@ -16,7 +16,7 @@ spec:
   manageNodes: false
   monDataDirHostPath: /var/lib/rook
   storageDeviceSets:
-  - count: {{ local_storage_devices | length }}
+  - count: {{ ocs_total_deviceset | default(local_storage_devices | length) }}
     dataPVCTemplate:
       spec:
         accessModes:


### PR DESCRIPTION
##### SUMMARY

allow to define the number of devicesets for OCS

##### ISSUE TYPE

Minor enhancement in ODF setup

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/187b7b77-6baa-43c9-9c01-7d0c0da71c1f/jobStates
- [ ] TestBaremetal - in progress


TestBos2: virt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional configuration parameter to explicitly define the number of storage device sets for OpenShift Container Storage.
	- Updated the configuration logic to prioritize this parameter when set, while still defaulting to the previous automatic count otherwise, offering greater flexibility during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->