### PR TITLE
Increase wait time to check nfs-client-provisioner pod

### DIFF
--- a/roles/nfs_external_storage/tasks/main.yml
+++ b/roles/nfs_external_storage/tasks/main.yml
@@ -205,7 +205,7 @@
                   server: "{{ nes_nfs_server }}"
                   path: "{{ nes_nfs_path }}"
 
-- name: "Wait for nfs-client-provisioner pod to be Running"
+- name: "Wait for 10 min for nfs-client-provisioner pod to be Running"
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Pod
@@ -213,7 +213,7 @@
     label_selectors:
       - app=nfs-client-provisioner
   register: nfs_pod
-  retries: 40
+  retries: 60
   delay: 10
   until:
     - nfs_pod.resources is defined


### PR DESCRIPTION
SUMMARY
This change is to allow more retries to check nfs-client-provisioner container to become ready/Running state.

ISSUE TYPE
Nominal change

Tests
TestBos2Sno: sno

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Extended the waiting period to 10 minutes and increased retry attempts for a key system check, ensuring smoother and more reliable service initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->