### PR TITLE
olm_operator: added subscription_name optional variable

### DIFF
--- a/roles/olm_operator/README.md
+++ b/roles/olm_operator/README.md
@@ -17,6 +17,7 @@ source                      | No        | redhat-operators       | CatalogSource
 source_ns                   | No        | openshift-marketplace  | Namespace where the CatalogSource is (default: )
 starting_csv                | No        | \<latest\>             | Operator version to install different than the latest published in the catalog.
 olm_operator_skippable      | No        | false                  | When set to `true`, avoids failing if the `operator` is not present in the `source`.
+subscription_name           | No        | {{ operator }}         | Name to be given to the Subscription. If none is defined, the operator name will be used.
 
 ## Examples of usage
 

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Initialize operator found fact
   ansible.builtin.set_fact:
     olm_operator_found: true
@@ -128,7 +127,7 @@
           apiVersion: operators.coreos.com/v1alpha1
           kind: Subscription
           metadata:
-            name: "{{ operator }}"
+            name: "{{ subscription_name | default(operator) }}"
             namespace: "{{ namespace }}"
           spec:
             channel: "{{ desired_channel }}"
@@ -206,7 +205,7 @@
           apiVersion: operators.coreos.com/v1alpha1
           kind: Subscription
           metadata:
-            name: "{{ operator }}"
+            name: "{{ subscription_name | default(operator) }}"
             namespace: "{{ namespace }}"
           spec:
             installPlanApproval: "{{ install_approval | default('Manual') }}"


### PR DESCRIPTION
##### SUMMARY

Added subscription_name optional variable

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/145c6224-c8e8-4901-88fa-c52ce357f72a/jobStates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved flexibility in Subscription resource naming during operator installation, allowing the use of a custom subscription name if defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->