### PR TITLE
Bump certsuite to v5.5.1

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.0
+kbpc_version: v5.5.1
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
##### SUMMARY

Bump certsuite to v5.5.1

##### ISSUE TYPE

- Bump version

##### Tests

- [x] Passing job: https://www.distributed-ci.io/jobs/05aa986f-662a-477e-8a5a-77482f8e7b6b/jobStates

Test-Hints: no-check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default version of the Kubernetes Best Practices Certsuite to v5.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->