### PR TITLE
Update Memory limits on OCS deployment

### DIFF
--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -26,8 +26,7 @@
                     memory: "400Mi"
   when:
     - dci_workarounds is defined
-    - '"DFBUGS-1932" in dci_workarounds'            
-    
+    - '"DFBUGS-1932" in dci_workarounds'
     
 - name: Tasks for External OCS/ODF Integration
   when:

--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -5,7 +5,7 @@
   register: intocsresult
   when:
     - ocs_install_type == 'internal'
-    
+
 - name: Patch Deployment to update Memory limits
   kubernetes.core.k8s:
     definition:
@@ -27,7 +27,7 @@
   when:
     - dci_workarounds is defined
     - '"DFBUGS-1932" in dci_workarounds'
-    
+
 - name: Tasks for External OCS/ODF Integration
   when:
     - ocs_install_type == 'external'

--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -5,7 +5,30 @@
   register: intocsresult
   when:
     - ocs_install_type == 'internal'
-
+    
+- name: Patch Deployment to update Memory limits
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: apps/v1
+      namespace: "{{ ocs_storage_namespace }}"
+      kind: Deployment
+      name: ocs-client-operator-controller-manager
+      merge_type: strategic
+      spec:
+        template:
+          spec:
+            containers:
+              - name: manager
+                resources:
+                  requests:
+                    memory: "400Mi"
+                  limits:
+                    memory: "400Mi"
+  when:
+    - dci_workarounds is defined
+    - '"DFBUGS-1932" in dci_workarounds'            
+    
+    
 - name: Tasks for External OCS/ODF Integration
   when:
     - ocs_install_type == 'external'


### PR DESCRIPTION
##### SUMMARY
This change is to apply a work around to update memory requests and limits on container "manager" for ocs-client-operator-controller-manager pod. This container is going to OOMKilled state with current resource limits.

##### ISSUE TYPE

New, Work around


build-depends: https://github.com/dci-labs/bos2-ci-config/pull/320

##### Tests

- [ ] TestBos2: virt-prega-4.19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated memory resource requests and limits for the OCS client operator controller manager when specific conditions are met, improving memory allocation efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->