### PR TITLE
Added setup_ksops role

### DIFF
--- a/roles/acm/setup_ksops/README.md
+++ b/roles/acm/setup_ksops/README.md
@@ -1,0 +1,102 @@
+# setup_ksops
+
+Installs and sets up the KSOPS Kustomize plugin on the OpenShift GitOps Operator.
+
+## Variables
+
+| Variable         | Default | Required | Description
+| ---------------- | ------- | -------- | -----------
+| sk_age_key       |         | yes      | A literal age generated (age-keygen) key. If kept in a version control service, it's recommeneded to vault-encrypt it.
+
+## Example of age key
+
+```
+# created: 2025-04-16T11:28:48Z
+# public key: age1j24rsa89nhv86dstnl696pfhxlngktjl5gcvya6y6ykg8t5jkqgsv0ua36
+AGE-SECRET-KEY-16NSYF9LSS3QZKLXFEYS5K36FPQC62QLZPNA02H7YWV0SFFVXF2PQNRZPNQ
+```
+
+## Usage examples
+
+```
+- name: Setup the KSOPS Kustomize plugin
+  ansible.builtin.include_role:
+    name: redhatci.ocp.acm.setup_ksops
+  vars:
+    sk_age_key: |
+      # created: 2025-04-16T11:28:48Z
+      # public key: age1j24rsa89nhv86dstnl696pfhxlngktjl5gcvya6y6ykg8t5jkqgsv0ua36
+      AGE-SECRET-KEY-16NSYF9LSS3QZKLXFEYS5K36FPQC62QLZPNA02H7YWV0SFFVXF2PQNRZPNQ
+```
+
+## How to encrypt the gitops data
+
+Install first the required binaries (age and [sops](https://github.com/getsops/sops/releases)):
+
+```
+dnf install age
+
+# Download the sops binary
+curl -LO https://github.com/getsops/sops/releases/download/v3.10.2/sops-v3.10.2.linux.amd64
+
+# Move the binary in to your PATH
+mv sops-v3.10.2.linux.amd64 /usr/local/bin/sops
+
+# Make the binary executable
+chmod +x /usr/local/bin/sops
+
+```
+
+Create a working directory:
+
+```
+mkdir sops
+cd sops
+```
+
+Create an age key:
+
+```
+age-keygen -o age.key
+```
+
+Define the SOPS creation rules. The age public key is available in the age.key file:
+
+```
+cat <<EOF > .sops.yaml
+creation_rules:
+  - encrypted_regex: "^(data|stringData)$"
+    age: age1...< your age public key>
+EOF
+```
+
+Encrypt your secret files in your local copy of the GitOps repository:
+
+```
+sops --encrypt --in-place /path/to/gitops/secret.yaml
+```
+
+Add a KSOPS generator to your repository:
+
+```
+cat <<EOF > secret-generator.yaml
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  # Specify a name
+  name: secret-generator
+files:
+  - ./secret.yaml
+EOF
+```
+
+Include the KSOPS generator in your kustomization file:
+
+```
+cat <<EOF > kustomization.yaml
+generators:
+  - ./secret-generator.yaml
+EOF
+```
+
+Add the new files to your git repository and commit the changes.

--- a/roles/acm/setup_ksops/tasks/main.yml
+++ b/roles/acm/setup_ksops/tasks/main.yml
@@ -1,0 +1,58 @@
+- name: Verify SOPS age key is set
+  ansible.builtin.assert:
+    that:
+      - sk_age_key is defined
+
+- name: Load the SOPS age key into the cluster
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: Opaque
+      metadata:
+        name: sops-age
+        namespace: openshift-gitops
+      data:
+        keys.txt: "{{ sk_age_key | b64encode }}"
+
+- name: Patch the OpenShift GitOps ArgoCD resource
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: argoproj.io/v1beta1
+      kind: ArgoCD
+      metadata:
+        name: openshift-gitops
+        namespace: openshift-gitops
+      spec:
+        kustomizeBuildOptions: --enable-alpha-plugins --enable-exec
+        repo:
+          env:
+            - name: XDG_CONFIG_HOME
+              value: /.config
+            - name: SOPS_AGE_KEY_FILE
+              value: /.config/sops/age/keys.txt
+          volumes:
+            - name: custom-tools
+              emptyDir: {}
+            - name: sops-age
+              secret:
+                secretName: sops-age
+          initContainers:
+            - name: install-ksops
+              image: quay.io/viaductoss/ksops:v4.3.3
+              command: ["/bin/sh", "-c"]
+              args:
+                - 'echo "Installing KSOPS..."; cp ksops /custom-tools/; cp $GOPATH/bin/kustomize /custom-tools/; echo "Done.";'
+              volumeMounts:
+                - mountPath: /custom-tools
+                  name: custom-tools
+          volumeMounts:
+            - mountPath: /usr/local/bin/kustomize
+              name: custom-tools
+              subPath: kustomize
+            - mountPath: /.config/kustomize/plugin/viaduct.ai/v1/ksops/ksops
+              name: custom-tools
+              subPath: ksops
+            - mountPath: /.config/sops/age/keys.txt
+              name: sops-age
+              subPath: keys.txt


### PR DESCRIPTION
##### SUMMARY

This change add the role setup_ksops to installs and set up the ksops kustomize plugin in the OpenShift GitOps operator.

With this plugin, the data in the gitops repositories may be encrypted thus allowing to upload secrets (bmh credentials, pull-secret) to shared repositories.

##### ISSUE TYPE

- Enhanced Feature

##### Tests

<!-- Document the tests for this change, if any -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

- [ ] TestBos2Sno: abi-sno - <JobURL>

---

Test-Hints: no-check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added documentation and automation for integrating the KSOPS Kustomize plugin with OpenShift GitOps.
  - Introduced support for managing SOPS age keys and configuring ArgoCD to use KSOPS for secret management.
  - Provided setup instructions and example usage for easier deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->