### PR TITLE
Wait for StorageCluster to be ready

### DIFF
--- a/roles/ocp_on_libvirt/templates/hosts.j2
+++ b/roles/ocp_on_libvirt/templates/hosts.j2
@@ -34,7 +34,7 @@ ssh_extra_keys_paths={{ ssh_extra_keys_paths | to_json }}
 
 {% if enable_lso | default(false) | bool %}
 ocs_install_type=internal
-local_storage_devices=["scsi0-0-0-1"]
+local_storage_devices=["scsi-0QEMU_QEMU_HARDDISK_drive-scsi0-0-0-1"]
 
 [ocs_nodes:children]
 workers

--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -80,4 +80,20 @@
         name: "{{ ocs_default_storage_class }}"
         annotations:
           "{{ default_storageclass_annotation }}"
+
+- name: Wait up to 20 mins Storage Cluster to be ready
+  kubernetes.core.k8s_info:
+    api_version: ocs.openshift.io/v1
+    kind: StorageCluster
+    name: "{{ ocs_storagecluster_name }}"
+    namespace: "{{ ocs_storage_namespace }}"
+  register: _os_sc
+  retries: 40
+  delay: 30
+  until:
+    - _of_sc.resources is defined
+    - _of_sc.resources | length == 1
+    - _of_sc.resources[0].status is defined
+    - _of_sc.resources[0].status.phase is defined
+    - _of_sc.resources[0].status.phase == "Ready"
 ...

--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -91,9 +91,9 @@
   retries: 40
   delay: 30
   until:
-    - _of_sc.resources is defined
-    - _of_sc.resources | length == 1
-    - _of_sc.resources[0].status is defined
-    - _of_sc.resources[0].status.phase is defined
-    - _of_sc.resources[0].status.phase == "Ready"
+    - _os_sc.resources is defined
+    - _os_sc.resources | length == 1
+    - _os_sc.resources[0].status is defined
+    - _os_sc.resources[0].status.phase is defined
+    - _os_sc.resources[0].status.phase == "Ready"
 ...


### PR DESCRIPTION
##### SUMMARY

- StorageCluster takes around 10 minutes to reconcile
- Use full device ID in the hosts template

##### ISSUE TYPE

-  Nominal change

##### Tests

- [ ] TestBos2: virt libvirt:components=ocp?tags%3abuild%3aga - https://www.distributed-ci.io/jobs/fe8b712c-a59e-4d35-bde6-e9e402e39aaf


Test-hints: no-check