### PR TITLE
odf_setup: make the task names compatible with dcijunit

### DIFF
--- a/roles/odf_setup/tasks/tests.yml
+++ b/roles/odf_setup/tasks/tests.yml
@@ -1,5 +1,5 @@
 ---
-- name: Test CephRBD PVC
+- name: Test_ CephRBD PVC
   kubernetes.core.k8s:
     definition:
       apiVersion: v1
@@ -15,7 +15,7 @@
             storage: 1Gi
         storageClassName: "{{ ocs_sc_rbd_name }}"
 
-- name: Get CephRBD PVC status
+- name: Validate_ CephRBD PVC status
   kubernetes.core.k8s_info:
     kind: PersistentVolumeClaim
     namespace: default
@@ -28,7 +28,7 @@
     - cephrbd_pvc_status.resources != []
     - cephrbd_pvc_status.resources[0].status.phase == "Bound"
 
-- name: Test CephFS PVC
+- name: Test_ CephFS PVC
   kubernetes.core.k8s:
     definition:
       apiVersion: v1
@@ -44,7 +44,7 @@
             storage: 1Gi
         storageClassName: "{{ ocs_sc_cephfs_name }}"
 
-- name: Get CephFS PVC status
+- name: Validate_ CephFS PVC status
   kubernetes.core.k8s_info:
     kind: PersistentVolumeClaim
     namespace: default


### PR DESCRIPTION
##### SUMMARY

Make sure the tests from odf_setup appear as Junit in DCI.

##### ISSUE TYPE

- Enhanced Feature

##### Tests

<!-- Document the tests for this change, if any -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

<!-- Examples:
- [ ] TestDallas: ocp-4.17-vanilla - <JobURL>
- [ ] TestDallasHybrid: ocp-4.17-vanilla-hybrid - <JobURL>
- [ ] TestDallasWorkload: preflight-green - <JobURL>
- [ ] TestBos2: virt - <JobURL>
- [ ] TestBos2Sno: sno - <JobURL>
- [ ] TestBos2SnoBaremetal: sno - <JobURL>
-->

---

<!-- Include the test and dependencies for this change -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->


<!-- Examples:

Test-Hint: no-check
Depends-on: https://path/to/depending/change

-->
