### PR TITLE
updating certsuite tests to call binary in $PATH

### DIFF
--- a/roles/k8s_best_practices_certsuite/tasks/tests.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/tests.yml
@@ -50,7 +50,7 @@
         kbpc_partner_repo: "{{ (kbpc_registry | length) | ternary(kbpc_registry, 'quay.io') }}/{{ kbpc_repo_org_name }}"
         kbpc_support_image: "{{ kbpc_support_image_name }}:{{ kbpc_support_image_version }}"
         kbpc_container_command: |
-          ./certsuite run \
+          certsuite run \
           {% if kbpc_test_labels | length > 0 %}
           --label-filter='{{ kbpc_test_labels }}' \
           {% endif %}


### PR DESCRIPTION
##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->
Updating the certsuite tests to call the binary in `$PATH`. The binary is in two places in the container, but to provide more clarity the one in `$PATH` should be used.

Below shows that the binary is available at `$PATH` location.
```
❯ podman run --rm -it quay.io/redhat-best-practices-for-k8s/certsuite:latest certsuite -h
A CLI tool for the Red Hat Best Practices Test Suite for Kubernetes.

Usage:
  certsuite [command]
```

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change

##### Tests

- [x] TestDallasWorkload:  tnf-test-cnf-green tnf-test-cnf-green:ansible_extravars=kbpc_version:HEAD - https://www.distributed-ci.io/jobs/01c18d60-d113-4e1c-a862-fbab9f799b73/jobStates
- [x] Check launched from https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2903 - https://www.distributed-ci.io/jobs/9125b352-b9b2-4b5c-a08a-93e62210aaf9/jobStates?sort=date

---

Test-Hints: no-check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the way the certsuite test suite is executed within the container to improve compatibility with the environment. No changes to test options or other task behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->