### PR TITLE
updated chartverifier report.yaml validation mandatory failure test cases

### DIFF
--- a/roles/chart_verifier/tasks/tests.yml
+++ b/roles/chart_verifier/tasks/tests.yml
@@ -175,15 +175,15 @@
     remote_src: true
   delegate_to: localhost
 
-- name: "Validate all tests have passed"
+- name: "Validate all mandatory tests have passed"
   ansible.builtin.shell:
     cmd: >
-      grep -c FAIL <( {{ yq_tool_path }} e "..|.outcome? | select(.)" report.yaml )
+      {{ yq_tool_path }} e '[.results[] | select(.outcome == "FAIL" and .type != "Optional")] | length' report.yaml
   register: cv_fail_count
   args:
     chdir: "{{ work_chart_dir }}"
     executable: /bin/bash
-  failed_when: "cv_fail_count.rc not in [ 0, 1 ]"
+  failed_when: cv_fail_count.stdout | int > 0
 
 - name: "Submit CV and create pull request"
   ansible.builtin.include_role:

--- a/roles/preflight/README.md
+++ b/roles/preflight/README.md
@@ -23,6 +23,7 @@ preflight_dci_all_components_are_ga | true                                      
 max_images_per_batch | 1                                             | Optional. This variable allows the user to adjust the number of images processed per batch for running preflight in parallel. By default, it is set to `1`.
 validate_annotations_yaml | true | Optional. Enable or disable validation of operators' annotations.yaml against deprecated API check limitations.
 
+**Note:** When using the preflight to test container images and submitting the results to the backend (for instance, when `cert_project_id` is defined, the `PFLT_LOGLEVEL` will be excluded from the arguments. This means the preflight will only collect logs at the `info` level. The reason for this limitation is that when the preflight tries to submit artifacts, such as the `preflight.log,` with file sizes exceeding 1MB, it will encounter the error `413 Request Entity Too Large` if `PFLT_LOGLEVEL` is set to `trace`. Therefore, the preflight only collects `trace` logs as a preliminary check for container images. Both use cases for sequential and parallel modes are handled automatically.
 
 ## Variables to define for each operator in preflight_operators_to_certify
 


### PR DESCRIPTION
##### SUMMARY
Current validation for chart-verifier report.yaml only check for any FAIL on report, but there is new test case from latest chart-verifier tool like this case. 
```
    - check: v1.0/has-notes
      type: Optional
      outcome: FAIL
      reason: Chart does not contain NOTES.txt
```
##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change

##### Tests

[x] chart-verifier: https://www.distributed-ci.io/jobs/62e37570-f338-46c0-84f2-6b89c11d79b6/jobStates

[x] Test locally and it works as shown in this [DCI Job](https://www.distributed-ci.io/jobs/5b8878ab-0b5f-475e-afe6-4944ea886c41/files)

Test-Hint: no-check

