### PR TITLE
Add flag to skip operators_validation

### DIFF
--- a/roles/olm_operator/README.md
+++ b/roles/olm_operator/README.md
@@ -18,7 +18,7 @@ source_ns                   | No        | openshift-marketplace  | Namespace whe
 starting_csv                | No        | \<latest\>             | Operator version to install different than the latest published in the catalog.
 olm_operator_skippable      | No        | false                  | When set to `true`, avoids failing if the `operator` is not present in the `source`
 subscription_name           | No        | {{ operator }}         | Name to be given to the Subscription. If none is defined, the operator name will be used
-validate_installation       | No        | true                   | Validates that the CSV an operator's pods are Ready
+olm_operator_validate_install | No      | true                   | Validates that the CSV an operator's pods are Ready
 
 ## Examples of usage
 

--- a/roles/olm_operator/README.md
+++ b/roles/olm_operator/README.md
@@ -16,8 +16,9 @@ operator_group_spec         | No        | {}                     | The operator 
 source                      | No        | redhat-operators       | CatalogSource where to pull operator from
 source_ns                   | No        | openshift-marketplace  | Namespace where the CatalogSource is (default: )
 starting_csv                | No        | \<latest\>             | Operator version to install different than the latest published in the catalog.
-olm_operator_skippable      | No        | false                  | When set to `true`, avoids failing if the `operator` is not present in the `source`.
-subscription_name           | No        | {{ operator }}         | Name to be given to the Subscription. If none is defined, the operator name will be used.
+olm_operator_skippable      | No        | false                  | When set to `true`, avoids failing if the `operator` is not present in the `source`
+subscription_name           | No        | {{ operator }}         | Name to be given to the Subscription. If none is defined, the operator name will be used
+validate_installation       | No        | true                   | Validates that the CSV an operator's pods are Ready
 
 ## Examples of usage
 

--- a/roles/olm_operator/defaults/main.yml
+++ b/roles/olm_operator/defaults/main.yml
@@ -6,5 +6,5 @@ operator_group_name: "{{ operator }}"
 source_ns: openshift-marketplace
 source: redhat-operators
 starting_csv: ""
-validate_installation: true
+olm_operator_validate_install: true
 ...

--- a/roles/olm_operator/defaults/main.yml
+++ b/roles/olm_operator/defaults/main.yml
@@ -6,4 +6,5 @@ operator_group_name: "{{ operator }}"
 source_ns: openshift-marketplace
 source: redhat-operators
 starting_csv: ""
+validate_installation: true
 ...

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -170,34 +170,38 @@
       when:
         - starting_csv | length
 
-    - name: Wait for CSV to be ready
-      kubernetes.core.k8s_info:
-        api: operators.coreos.com/v1alpha1
-        namespace: "{{ namespace }}"
-        kind: ClusterServiceVersion
-        name: "{{ operator_csv }}"
-      register: csv
-      retries: 20
-      delay: 30
-      until:
-        - csv.resources is defined
-        - csv.resources | length == 1
-        - "'status' in csv.resources[0]"
-        - "'phase' in csv.resources[0].status"
-        - csv.resources[0].status.phase == 'Succeeded' or
-          csv.resources[0].status.phase == 'Present'
-      no_log: true
+    - name: Validate operator installation
+      when:
+        - validate_installation | bool
+      block:
+        - name: Wait for CSV to be ready
+          kubernetes.core.k8s_info:
+            api: operators.coreos.com/v1alpha1
+            namespace: "{{ namespace }}"
+            kind: ClusterServiceVersion
+            name: "{{ operator_csv }}"
+          register: _oo_csv
+          retries: 20
+          delay: 30
+          until:
+            - _oo_csv.resources is defined
+            - _oo_csv.resources | length == 1
+            - "'status' in _oo_csv.resources[0]"
+            - "'phase' in _oo_csv.resources[0].status"
+            - _oo_csv.resources[0].status.phase == 'Succeeded' or
+              _oo_csv.resources[0].status.phase == 'Present'
+          no_log: true
 
-    - name: Fail if not all pods reach a successful state
-      kubernetes.core.k8s_info:
-        kind: Pod
-        namespace: "{{ namespace }}"
-      register: olm_pod
-      retries: 30
-      delay: 20
-      until:
-        olm_pod.resources | map(attribute='status.phase') | difference(['Succeeded', 'Running']) | length == 0
-      no_log: true
+        - name: Fail if not all pods reach a successful state
+          kubernetes.core.k8s_info:
+            kind: Pod
+            namespace: "{{ namespace }}"
+          register: _oo_olm_pod
+          retries: 30
+          delay: 20
+          until:
+            _oo_olm_pod.resources | map(attribute='status.phase') | difference(['Succeeded', 'Running']) | length == 0
+          no_log: true
 
     - name: Patch subscription according to install_approval
       kubernetes.core.k8s:

--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -172,7 +172,7 @@
 
     - name: Validate operator installation
       when:
-        - validate_installation | bool
+        - olm_operator_validate_install | bool
       block:
         - name: Wait for CSV to be ready
           kubernetes.core.k8s_info:


### PR DESCRIPTION
##### SUMMARY

Define a flag to skip operators' validation during installation

##### ISSUE TYPE

- Nominal change

##### Tests


- [x] TestBos2: virt-prega-4.19 - https://www.distributed-ci.io/jobs/e6e4651c-bcb9-4bf2-9b65-c6e091449234

Test-hints: no-check
