### PR TITLE
[odf_setup] allow cluster-wide disk encryption without kms

### DIFF
--- a/roles/odf_setup/README.md
+++ b/roles/odf_setup/README.md
@@ -32,6 +32,8 @@ Role Variables
 | gatherer_image                   | registry.access.redhat.com/ubi8/ubi | String | No          | Image for disk-gatherer deployment                                       |
 | odf_setup_oc_tool_path                   | '/usr/local/bin/oc` | String | No          | Path to the OpenShift Command Line Interface binary.
 | ocs_total_deviceset              | length of local_storage_devices | Int | No          | (Optional) number of device sets for OCS |
+| odf_setup_enable_encryption      | false | Boolean | No          | Whether enable disk cluster-wide encryption for ODF |
+| odf_setup_key_rotation_period    | weekly | String | No          | Period of key rotation: daily, weekly, monthly, etc. |
 
 
 Inventory Groups and Variables

--- a/roles/odf_setup/defaults/main.yml
+++ b/roles/odf_setup/defaults/main.yml
@@ -33,3 +33,7 @@ gatherer_image: registry.access.redhat.com/ubi8/ubi
 
 # OpenShift Command Line Interface path
 odf_setup_oc_tool_path: /usr/local/bin/oc
+
+# ODF encryption support
+odf_setup_enable_encryption: false
+odf_setup_key_rotation_period: weekly

--- a/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
+++ b/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
@@ -4,6 +4,14 @@ metadata:
   namespace: {{ ocs_storage_namespace }}
   name: {{ ocs_storagecluster_name }}
 spec:
+{% if odf_setup_enable_encryption | default(false) | bool %}
+  encryption:
+    clusterWide: true
+    keyRotation:
+      enable: true
+      schedule: '@{{ odf_setup_key_rotation_period }}'
+    kms: {}
+{% endif %}
 {% if enable_object_gateway | default(false) | bool %}
   multiCloudGateway:
     reconcileStrategy: ignore

--- a/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
+++ b/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
@@ -4,7 +4,7 @@ metadata:
   namespace: {{ ocs_storage_namespace }}
   name: {{ ocs_storagecluster_name }}
 spec:
-{% if odf_setup_enable_encryption | default(false) | bool %}
+{% if odf_setup_enable_encryption | bool %}
   encryption:
     clusterWide: true
     keyRotation:


### PR DESCRIPTION
##### SUMMARY

[odf_setup] allow cluster-wide disk encryption without kms

##### ISSUE TYPE

Enhanced Feature

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/4beb04c3-82a3-463d-bb31-064447197213/jobStates

TestHints: no-check