### PR TITLE
Preflight: Create certification project if necessary

### DIFF
--- a/roles/create_certification_project/tasks/main.yml
+++ b/roles/create_certification_project/tasks/main.yml
@@ -19,6 +19,7 @@
 
 - name: Create cert project
   ansible.builtin.include_tasks: create_project.yml
+  when: cert_project_id is undefined
 
 - name: Update the project with company info when cert_settings is defined
   ansible.builtin.include_tasks: update_project.yml

--- a/roles/create_certification_project/tasks/main.yml
+++ b/roles/create_certification_project/tasks/main.yml
@@ -19,7 +19,7 @@
 
 - name: Create cert project
   ansible.builtin.include_tasks: create_project.yml
-  when: cert_project_id is undefined
+  when: cert_project_id | default('') | length == 0
 
 - name: Update the project with company info when cert_settings is defined
   ansible.builtin.include_tasks: update_project.yml


### PR DESCRIPTION
##### SUMMARY
Presently the create_certification_project role try to create a project even when the project already exists.

This patch avoid this bad behavior

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### Tests
- [x] TestDallasWorkload: preflight-green : https://www.distributed-ci.io/jobs/de08d5bb-c6b7-4979-9046-19812b70aeaa/jobStates
