### PR TITLE
increase number of retries for install plan and csv

### DIFF
--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -146,7 +146,7 @@
         namespace: "{{ namespace }}"
       register: _oo_install_plans
       no_log: true
-      retries: 18
+      retries: 30
       delay: 10
       until:
         - _oo_install_plans.resources is defined
@@ -181,7 +181,7 @@
             kind: ClusterServiceVersion
             name: "{{ operator_csv }}"
           register: _oo_csv
-          retries: 20
+          retries: 30
           delay: 30
           until:
             - _oo_csv.resources is defined


### PR DESCRIPTION
##### SUMMARY

certain operators take longer to get installed, sometimes jobs fail but when checking must-gathers installations were completed

##### ISSUE TYPE

- minor fix

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/67e1747d-62db-46de-abc4-8b738e0fe65c/jobStates


TestHints: no-check