### PR TITLE
Search sites and policy

### DIFF
--- a/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
+++ b/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
@@ -22,7 +22,7 @@
                 | selectattr('spec.source.targetRevision', 'equalto', asm_target_revision)
                 | map(attribute='metadata.name') | list }}"
     app_policies: "{{ _asm_all_apps.resources | selectattr('spec.source.repoURL', 'equalto', asm_source_repo)
-                | selectattr('spec.source.path', 'search', '(^|/)policies($)')
+                | selectattr('spec.source.path', 'search', '(^|/)policies$')
                 | selectattr('spec.source.targetRevision', 'equalto', asm_target_revision)
                 | map(attribute='metadata.name') | list }}"
     apps_list: "{{ app_sites + app_policies | default([]) }}"

--- a/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
+++ b/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
@@ -18,11 +18,11 @@
 - name: Delete ArgoCD Applications
   vars:
     app_sites: "{{ _asm_all_apps.resources | selectattr('spec.source.repoURL', 'equalto', asm_source_repo)
-                | selectattr('spec.source.path', 'equalto', 'sites')
+                | selectattr('spec.source.path', 'search', '(^|/)sites($)')
                 | selectattr('spec.source.targetRevision', 'equalto', asm_target_revision)
                 | map(attribute='metadata.name') | list }}"
     app_policies: "{{ _asm_all_apps.resources | selectattr('spec.source.repoURL', 'equalto', asm_source_repo)
-                | selectattr('spec.source.path', 'equalto', 'policies')
+                | selectattr('spec.source.path', 'search', '(^|/)policies($)')
                 | selectattr('spec.source.targetRevision', 'equalto', asm_target_revision)
                 | map(attribute='metadata.name') | list }}"
     apps_list: "{{ app_sites + app_policies | default([]) }}"

--- a/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
+++ b/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
@@ -18,7 +18,7 @@
 - name: Delete ArgoCD Applications
   vars:
     app_sites: "{{ _asm_all_apps.resources | selectattr('spec.source.repoURL', 'equalto', asm_source_repo)
-                | selectattr('spec.source.path', 'search', '(^|/)sites($)')
+                | selectattr('spec.source.path', 'search', '(^|/)sites$')
                 | selectattr('spec.source.targetRevision', 'equalto', asm_target_revision)
                 | map(attribute='metadata.name') | list }}"
     app_policies: "{{ _asm_all_apps.resources | selectattr('spec.source.repoURL', 'equalto', asm_source_repo)


### PR DESCRIPTION
##### SUMMARY

Policies and Sites directories could be inside subdirectories. Using search to match the ArgoCD application that will be deleted

##### ISSUE TYPE

- Bug

##### Tests
- [x] Tested: ocp-4.18-spoke-ztp-sno openshift-ztp-sno:ansible_extravars=dci_teardown_on_success:true openshift-ztp-sno:components=ocp=4.18.0-0.nightly-2025-05-07-172834 https://www.distributed-ci.io/jobs/cfa8cf1c-bcd0-4e48-a5d5-cf598c557fd1/jobStates

Test-Hint: no-check