### PR TITLE
Allow set a random tag on the target

### DIFF
--- a/roles/mirror_images/README.md
+++ b/roles/mirror_images/README.md
@@ -12,7 +12,8 @@ Mirrors images from one repository to another.
 | mi_dst_authfile  | undefined  | No       | An authfile with permissions to push the target images
 | mi_options       | undefined  | No       | skopeo options while copying the images
 | mi_src_authfile  | undefined  | No       | An authfile with permissions to pull the source images
-| mi_dst_org       | undefined  | No       | The organization target where to copy the images
+| mi_dst_org       | ""         | No       | The organization target where to copy the images
+| mi_random_tag    | false      | No       | Set a random tag on the target registry
 
 ## Requirements
 

--- a/roles/mirror_images/defaults/main.yml
+++ b/roles/mirror_images/defaults/main.yml
@@ -1,1 +1,4 @@
+---
 mi_dst_org: ""
+mi_random_tag: false
+...

--- a/roles/mirror_images/tasks/mirror-images.yml
+++ b/roles/mirror_images/tasks/mirror-images.yml
@@ -5,7 +5,13 @@
     _image_name: "{{ '/'.join(image.split('@')[0].split('/')[-1:]) }}"
     _image_org: "{{ '/'.join(image.split('@')[0].split('/')[1:-1]) }}"
     _image_org_path: "{{ (mi_dst_org | length) | ternary(mi_dst_org, _image_org) }}"
-    _image_img_path: "{{ _image_name }}{%- if _image_tag | length %}{{ _image_tag }}{% endif %}"
+    _image_rdn_tag: "{{ image.split('@')[0].split(':')[0].split('/')[-1] }}:{{ lookup('community.general.random_string', length=12, special=false) }}"
+    _image_img_path: >-
+      {%- if mi_random_tag -%}
+      {{ _image_rdn_tag }}
+      {%- else -%}
+      {{ _image_name }}{%- if _image_tag | length %}{{ _image_tag }}{%- endif -%}
+      {%- endif -%}
     _tgt_image_location: "{{ mi_registry }}/{{ _image_org_path }}/{{ _image_img_path }}"
   block:
     - name: "Mirror image"


### PR DESCRIPTION
##### SUMMARY

Allow to generation of a random tag for the mirrored image on the target. This allows preserving previous images that may be re-tagged with the same ID at the source

##### ISSUE TYPE

- nominal change

##### Tests

