### PR TITLE
Add more space for imageservice PV

### DIFF
--- a/roles/acm_setup/defaults/main.yml
+++ b/roles/acm_setup/defaults/main.yml
@@ -8,6 +8,6 @@ hub_hugepages_type: hugepages-2Mi
 hub_hugepages_size: 1024Mi
 hub_db_volume_size: 40Gi
 hub_fs_volume_size: 50Gi
-hub_img_volume_size: 80Gi
+hub_img_volume_size: 200Gi
 hub_vm_external_network: true
 ...


### PR DESCRIPTION
##### SUMMARY

The RHCOS images used to generate the discovery ISOs require more space for the assisted-image service PV.

##### ISSUE TYPE

- nominal change

##### Tests

- [ ] TestBos2: acm-hub

TestBos2: acm-hub
