### PR TITLE
Convert IDMS/ICSP into registries.conf

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        2.2.EPOCH
+Version:        2.3.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -54,6 +54,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Thu May 14 2025 Tony Garcia <tonyg@redhat.com> - 2.3.EPOCH-VERS
+- Version bump for role updates - acm.utils
+
 * Thu Apr 10 2025 Tony Garcia <tonyg@redhat.com> - 2.2.EPOCH-VERS
 - Version bump for role updates - acm.utils
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 1.3.2147483647
-version: 2.2.0
+version: 2.3.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/acm/utils/README.md
+++ b/roles/acm/utils/README.md
@@ -5,12 +5,16 @@ Brings functionality that is commonly used among those roles.
 
 ## Variables
 
-| Variable                | Default  | Required by                      | Description
-| ----------------------- | -------- | -------------------------------- | -----------
-| utils_cluster_name      | None     | get-credentials, monitor-install | Name of the spoke cluster
-| utils_cluster_namespace | None     | get-credentials, monitor-install | Namespace for the spoke cluster
-| utils_monitor_timeout   | 90       | monitor-install                  | Timeout in minutes for the installation process.
-| utils_monitor_wait_time | 3        | monitor-install                  | Wait time in minutes between each progress check.
+| Variable                            | Default                             | Required by                      | Description
+| ----------------------------------- | ----------------------------------- | -------------------------------- | -----------
+| utils_cluster_name                  | None                                | get-credentials, monitor-install | Name of the spoke cluster
+| utils_cluster_namespace             | None                                | get-credentials, monitor-install | Namespace for the spoke cluster
+| utils_monitor_timeout               | 90                                  | monitor-install                  | Timeout in minutes for the installation process.
+| utils_monitor_wait_time             | 3                                   | monitor-install                  | Wait time in minutes between each progress check.
+| utils_imagesource_file              | None                                | image-sources                    | File with Image Digest Mirror Sets or Image Content Source Policies to transform into registries.conf format
+| utils_hub_mirrors                   | None                                | image-sources                    | List of mirrors and sources in the Hub cluster.
+| utils_registry                      | None                                | image-sources                    | The custom registry to use for the registries.conf.
+| utils_unqualified_search_registries | ['registry.redhat.io', 'docker.io'] | image-sources                    | List of unqualified search registries.
 
 ## Utilities
 
@@ -58,4 +62,30 @@ Monitor installation of a cluster through ACM
   ansible.builtin.include_role:
     name: redhatci.ocp.acm.utils
     tasks_from: monitor-install
+```
+
+### Example: Image Sources
+
+Transform and combine an ImageDigestMirrorSet or ImageContentSourcePolicy file with the Hub mirrors and sources
+into the `registries.conf` format using a custom registry.
+This task generates the `utils_acm_registries` variable containing the transformed and combined content.
+
+```yaml
+- name: Transform ImageDigestMirrorSet
+  vars:
+    utils_hub_mirrors:
+      - mirrors:
+        - my.local.registry/path/to/image
+        source: quay.io/path/to/image
+      - mirrors:
+        - my.local.registry/path/to/another/image
+        source: quay.io/path/to/another/image
+    utils_imagesource_file: /path/to/idms.yaml
+    utils_registry: "my.local.registry"
+    utils_unqualified_search_registries:
+      - quay.io
+      - my.local.registry
+  ansible.builtin.include_role:
+    name: redhatci.ocp.acm.utils
+    tasks_from: image-sources
 ```

--- a/roles/acm/utils/defaults/main.yml
+++ b/roles/acm/utils/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 utils_monitor_timeout: 90
 utils_monitor_wait_time: 3
+utils_unqualified_search_registries:
+  - registry.redhat.io
+  - docker.io
 ...

--- a/roles/acm/utils/meta/argument_specs.yml
+++ b/roles/acm/utils/meta/argument_specs.yml
@@ -38,3 +38,37 @@ argument_specs:
         default: 3
         description: >
           Wait time in minutes between each progress check. Default is 3 minutes.
+  image-sources:
+    short_description: Convert IDMS or ICSP to registries.conf format for ACM spokes
+    description: >
+      Convert the ImageDigestMirrorSet (IDMS) or ImageContentSourcePolicies (ICSP) to the registries.conf format.
+      Required by the spoke clusters in disconnected mode.
+    options:
+      utils_registry:
+        type: str
+        required: true
+        description: >
+          The custom/local registry to use for the spoke cluster. This is the registry where the images are stored.
+          For example: `registry.example.com:5000`
+      utils_hub_mirrors:
+        type: list
+        required: true
+        elements: dict
+        description: |
+          List of mirrors and sources in the hub cluster. The format is:
+          - mirrors:
+              - mirror1
+            source: source
+      utils_imagesource_file:
+        type: str
+        required: true
+        description: >
+          A file with either IDMS or ICSP to transform into the registries.conf format.
+          Additionally, it injects a mirror for the multicluster-engine image to the custom registry.
+      utils_unqualified_search_registries:
+        type: list
+        required: false
+        default: ['registry.redhat.io', 'docker.io']
+        elements: str
+        description: >
+          List of unqualified search registries. Default is ['registry.redhat.io', 'docker.io']

--- a/roles/acm/utils/tasks/image-sources.yml
+++ b/roles/acm/utils/tasks/image-sources.yml
@@ -1,0 +1,47 @@
+---
+- name: Combine and transform Image Source to registries.conf format
+  vars:
+    hub_query: "spec.*[*].{mirrors: mirrors, source: source}"
+    spoke_mirrors: >
+      {{ lookup('file', utils_imagesource_file) |
+         from_yaml |
+         json_query(hub_query) |
+         first
+      }}
+    combined_mirrors: |-
+      {%- set c = dict() %}
+      {%- for mirror in utils_hub_mirrors + spoke_mirrors %}
+      {%- set s = mirror.source %}
+      {%- set m = mirror.mirrors %}
+      {%- if c.get(s) %}
+      {{ c.update({s: c[s] + m}) }}
+      {%- else %}
+      {{ c.update({s: m}) }}
+      {%- endif %}
+      {%- endfor %}
+      {{ c }}
+  ansible.builtin.set_fact:
+    utils_acm_registries: |
+      unqualified-search-registries = {{ utils_unqualified_search_registries }}
+      short-name-mode = ""
+
+      {% for registry in combined_mirrors.keys() | list %}
+      [[registry]]
+        prefix = ""
+        location = "{{ registry }}"
+        mirror-by-digest-only = true
+
+      {% for mirror in combined_mirrors[registry] | unique | list %}
+        [[registry.mirror]]
+          location = "{{ mirror }}"
+
+      {% endfor %}
+      {% endfor %}
+
+      [[registry]]
+        prefix = ""
+        location = "registry.redhat.io/multicluster-engine"
+        mirror-by-digest-only = true
+
+        [[registry.mirror]]
+          location = "{{ utils_registry | urlsplit('netloc') }}/multicluster-engine"


### PR DESCRIPTION
##### SUMMARY

This is a functionality that is required to deploy clusters with a different version than the hub. It is used by the spoke clusters in disconnected mode.

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x] TestDallasSno:  ocp-4.18-hub-abi-sno ocp-4.18-spoke-sno - https://www.distributed-ci.io/jobs/0ef5675a-0a2c-4633-b805-0a070d1c7a6b

---

Test-Hints: no-check
