### PR TITLE
Handle multiple spokes in a ZTP repo

### DIFF
--- a/roles/configure_ztp_gitops_apps/README.md
+++ b/roles/configure_ztp_gitops_apps/README.md
@@ -3,6 +3,15 @@ Configure ZTP GitOps Apps
 
 This Role downloads the clusters and sites from a ZTP site generator image. It replaces several values to configure the tracking repositories.
 
+Multiple Spoke Clusters
+-----------------------
+
+In the case where multiple spoke clusters are deployed by the same ZTP GitOps repository, there are some behaviors to note:
+
+* `czga_clusters_list` should be populated with an array of cluster names. It should be left undefined in the single cluster default case.
+* `czga_clusters_namespace` need not be defined, the role will loop over the cluster names instead.
+* The same pull secret specified in `czga_ocp_pull_secret` will be used for all spoke clusters.
+
 Requirements
 ------------
 
@@ -25,6 +34,7 @@ czga_multicluster_version   | string | yes      | -                             
 czga_site_generator_image   | string | no       | `registry.redhat.io/openshif4/ztp-site-generate-rhel8` | ZTP site generator container image
 czga_multicluster_image     | string | no       | `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9` | Multicluster operators subscription container image
 czga_podman_runner_host     | string | no       | podman-runner                                      |  Identity of the inventory host pulling the sites template generator image.
+czga_clusters_list          | list of strings | no | undefined                                       | List of clusters to be deployed.
 czga_clusters_namespace     | string | no       | cluster-sub                                        | Namespace for the site config resources.
 czga_kubeconfig_path        | string | no       | `{{ omit }}`                                       | Path to the ACM hub kubeconfig file.
 czga_ocp_pull_secret        | string | yes      | -                                                  | Pull secret for the Spoke cluster.

--- a/roles/configure_ztp_gitops_apps/defaults/main.yaml
+++ b/roles/configure_ztp_gitops_apps/defaults/main.yaml
@@ -4,6 +4,6 @@ czga_podman_runner_host: podman-runner
 czga_clusters_namespace: clusters-sub
 czga_kubeconfig_path: "{{ omit }}"
 czga_policies_namespace: policies-sub
-czga_oc_tool_path: "{{ oc_tool_path | default('/usr/loca/bin/oc') }}"
+czga_oc_tool_path: "{{ oc_tool_path | default('/usr/local/bin/oc') }}"
 czga_site_generator_image: registry.redhat.io/openshift4/ztp-site-generate-rhel8
 czga_multicluster_image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9

--- a/roles/configure_ztp_gitops_apps/tasks/main.yaml
+++ b/roles/configure_ztp_gitops_apps/tasks/main.yaml
@@ -28,6 +28,12 @@
   delegate_to: "{{ czga_podman_runner_host }}"
   block:
 
+    - name: Set a cluster name list if not defined
+      ansible.builtin.set_fact:
+        czga_clusters_list: ["{{ czga_clusters_namespace }}"]
+      when:
+        - czga_clusters_list is not defined
+
     - name: Create temporary directory for cloning the repo
       ansible.builtin.tempfile:
         state: directory
@@ -67,7 +73,8 @@
       ansible.builtin.replace:
         path: "{{ temp_dir.path }}/ztp/argocd/deployment/clusters-app.yaml"
         regexp: "clusters-sub"
-        replace: "{{ czga_clusters_namespace }}"
+        replace: "{{ (czga_clusters_list | length == 1) | ternary(czga_clusters_list[0], '') }}"
+        after: "kind: Application"
 
     - name: Replace path in clusters-app.yaml
       ansible.builtin.replace:
@@ -203,7 +210,8 @@
           apiVersion: v1
           kind: Namespace
           metadata:
-            name: "{{ czga_clusters_namespace }}"
+            name: "{{ item }}"
+      loop: "{{ czga_clusters_list }}"
 
     - name: Save pull-secret in a variable
       ansible.builtin.slurp:
@@ -218,11 +226,12 @@
           kind: Secret
           metadata:
             name: assisted-deployment-pull-secret
-            namespace: "{{ czga_clusters_namespace }}"
+            namespace: "{{ item }}"
           type: kubernetes.io/dockerconfigjson
           data:
             .dockerconfigjson: "{{ _czga_encoded_pull_secret['content'] }}"
       no_log: true
+      loop: "{{ czga_clusters_list }}"
 
     - name: Wait for the GitOps ZTP plugin activation
       kubernetes.core.k8s_info:


### PR DESCRIPTION
##### SUMMARY

In the case where a single ztp repo deploys multiple spoke clusters, this PR will allow you to define a list `czga_clusters_list` to inform the role.

This has the following effects:
 
* When more than one cluster exists, the GitOps Application deployed by the role targets the `''` Namespace instead of `czga_clusters_namespace`.
* Namespaces and pull secrets are created for each cluster.

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- New or Enhanced Feature

##### Tests

- [x] TestBos2: acm-hub ztp-spoke-vm-4.17 - SUCCESS https://www.distributed-ci.io/jobs/32c8d896-8e86-43a9-ac4e-874f2d6710ec/jobStates / SUCCESS https://www.distributed-ci.io/jobs/9b16d1dd-e512-42f6-81a7-124d093e2087/jobStates

Test-Hint: no-check