### PR TITLE
Rename the BMC Secrets used by BMH in ACM

### DIFF
--- a/roles/acm_sno/tasks/create-cluster.yml
+++ b/roles/acm_sno/tasks/create-cluster.yml
@@ -243,7 +243,7 @@
   retries: 15
   delay: 6
 
-- name: "BMC credentials"
+- name: "BMC credentials for BareMetalHost"
   kubernetes.core.k8s:
     definition:
       apiVersion: v1
@@ -252,7 +252,7 @@
         password: "{{ acm_bmc_pass | b64encode }}"
       kind: Secret
       metadata:
-        name: "bmc-{{ acm_cluster_name }}"
+        name: "bmh-{{ acm_cluster_name }}"
         namespace: "{{ acm_cluster_name }}"
       type: Opaque
 
@@ -274,7 +274,7 @@
         automatedCleaningMode: disabled
         bmc:
           address: "{{ acm_bmc_address }}"
-          credentialsName: "bmc-{{ acm_cluster_name }}"
+          credentialsName: "bmh-{{ acm_cluster_name }}"
           disableCertificateVerification: true
         bootMACAddress: "{{ acm_boot_mac_address }}"
         online: true

--- a/roles/acm_sno/tasks/delete-cluster.yml
+++ b/roles/acm_sno/tasks/delete-cluster.yml
@@ -28,18 +28,18 @@
       apiVersion: v1
       kind: Secret
       metadata:
-        name: "bmc-{{ acm_cluster_name }}"
+        name: "bmh-{{ acm_cluster_name }}"
         namespace: "{{ acm_cluster_name }}"
         finalizers: null
         ownerReferences: null
   ignore_errors: true
 
-- name: "Delete BMC credentials"
+- name: "Delete BMC credentials for BareMetalHost"
   kubernetes.core.k8s:
     state: absent
     api: v1
     kind: Secret
-    name: "bmc-{{ acm_cluster_name }}"
+    name: "bmh-{{ acm_cluster_name }}"
     namespace: "{{ acm_cluster_name }}"
   ignore_errors: true
 


### PR DESCRIPTION
##### SUMMARY

Standardize the naming of the BMC secrets so it can be consistent with other ways to deploy clusters through ACM, allowing easier cleanup of deployments when needed.

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestDallasSno: ocp-4.18-spoke-sno -  https://www.distributed-ci.io/jobs/01fb4402-e830-4007-bbc8-4b861a9d82c8
- [x] TestDallasSno: ocp-4.18-spoke-ztp-clusterinstance - https://www.distributed-ci.io/jobs/e8c14c29-86a0-43e5-842c-9353fd508d77

---

Test-Hint: no-check
