### PR TITLE
Update eject blocking media using key

### DIFF
--- a/roles/vendors/hpe/tasks/eject.yml
+++ b/roles/vendors/hpe/tasks/eject.yml
@@ -23,7 +23,8 @@
 
     - name: Get blocking virtual_media
       ansible.builtin.set_fact:
-        blocking_virtual_media: "{{ result.redfish_facts.virtual_media.entries
+        blocking_virtual_media: "{{ result.redfish_facts.virtual_media
+            | dict2items
             | flatten(levels=2)
             | selectattr('ConnectedVia', 'defined') | list
             | json_query('[?(
@@ -46,8 +47,7 @@
         baseuri: "{{ bmc_address }}"
         username: "{{ bmc_user }}"
         password: "{{ bmc_password }}"
-        virtual_media:
-          image_url: "{{ item.Image }}"
+        virtual_media: "{{ item.key }}"
         resource_id: 1
       loop: "{{ blocking_virtual_media }}"
       no_log: true


### PR DESCRIPTION
##### SUMMARY

When blocking_media exists, eject using device key instead of image_url

##### ISSUE TYPE
Bug
