### PR TITLE
Update ansible stable version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,7 +90,7 @@ jobs:
       matrix:
         ansible:
           - stable-2.9          # used by DCI on RHEL8
-          - stable-2.17         # latest stable version
+          - stable-2.18         # latest stable version
       fail-fast: false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
##### SUMMARY

Current latest stable version is 2.18.

https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix

##### ISSUE TYPE

- Nominal change

##### Tests

Test-Hint: no-check
