### PR TITLE
Authorizing ClusterInstance resource in the GitOps Operator configuration

### DIFF
--- a/roles/configure_ztp_gitops_apps/tasks/main.yaml
+++ b/roles/configure_ztp_gitops_apps/tasks/main.yaml
@@ -159,6 +159,16 @@
             - "    kind: ClusterImageSet"
             - "  - group: hive.openshift.io"
 
+    - name: Add ClusterInstance to app-project.yaml
+      ansible.builtin.blockinfile:
+        path: "{{ temp_dir.path }}/ztp/argocd/deployment/app-project.yaml"
+        block: |
+          {% filter indent(width=2, first=true) %}
+          - group: siteconfig.open-cluster-management.io
+            kind: ClusterInstance
+          {% endfilter %}
+        insertafter: namespaceResourceWhitelist.*
+
     - name: Replace ztp-site-generate image container URL in argocd-openshift-gitops-patch.json
       ansible.builtin.replace:
         path: "{{ temp_dir.path }}/ztp/argocd/deployment/argocd-openshift-gitops-patch.json"


### PR DESCRIPTION
##### SUMMARY

In order to support ZTP cluster manifest format based on siteConfig V2 on GitOps, the ClusterInstance custom resource must be authorized in the OpenShift GitOps Operator configuration so the operator will be allowed to synchronize with repositories containing manifests for this kind of object.

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x] TestPartnerLab: ztp-spoke - https://www.distributed-ci.io/jobs/4e93b8be-9d05-4a56-bdec-3b2d23485bd8/jobStates?sort=date

---

Test-Hints: no-check
