### PR TITLE
Gitea: retrying creating the container secrets

### DIFF
--- a/roles/setup_gitea/tasks/install.yml
+++ b/roles/setup_gitea/tasks/install.yml
@@ -24,6 +24,9 @@
     detach: false
   changed_when: false
   register: _sg_jwt_secret
+  retries: 5
+  delay: 10
+  until: not _sg_jwt_secret.failed
   no_log: true
 
 - name: Generate the LFS JWT secret
@@ -35,6 +38,9 @@
     detach: false
   changed_when: false
   register: _sg_lfs_jwt_secret
+  retries: 5
+  delay: 10
+  until: not _sg_lfs_jwt_secret.failed
   no_log: true
 
 - name: Generate the internal token
@@ -46,6 +52,9 @@
     detach: true
   changed_when: false
   register: _sg_internal_token
+  retries: 5
+  delay: 10
+  until: not _sg_internal_token.failed
   no_log: true
 
 - name: Generate the secret key
@@ -57,6 +66,9 @@
     detach: true
   changed_when: false
   register: _sg_secret_key
+  retries: 5
+  delay: 10
+  until: not _sg_secret_key.failed
   no_log: true
 
 - name: Create Secret with the Gitea configuration
@@ -87,7 +99,7 @@
   register: _sg_gitea_healthz
   retries: 10
   delay: 10
-  until: _sg_gitea_healthz is not failed
+  until: not _sg_gitea_healthz.failed
 
 - name: Create the initial user
   when: sg_username | default("") != ""


### PR DESCRIPTION
##### SUMMARY

A deployment job failed when generating the JWT secret. This task pulls the Gitea image and runs an internal command.

The task has the output hidden so it was difficult to troubleshoot. In this change we add retries to the gitea secret generation tasks to prevent a similar issue from happening in the future.

##### ISSUE TYPE

- Bug

##### Tests

- [ ] TestDallas: ocp-4.17-vanilla - https://www.distributed-ci.io/jobs/f02681f2-7950-4bc8-b19a-6207d5be399c/jobStates

---

TestDallas: ocp-4.18-hub-abi-sno
