### PR TITLE
Retry eject and increase timeout

### DIFF
--- a/roles/vendors/dell/tasks/eject.yml
+++ b/roles/vendors/dell/tasks/eject.yml
@@ -12,8 +12,8 @@
   delay: 10
   until: result is succeeded
 
-- name: Get blocking virtual_media
-  ansible.builtin.set_fact:
+- name: Attempting to eject blocking media (if any)
+  vars:
     blocking_virtual_media: "{{ result.redfish_facts.virtual_media.entries
         | flatten(levels=2)
         | selectattr('ConnectedVia', 'defined') | list
@@ -28,13 +28,6 @@
           )]'
         ) | from_yaml
       }}"
-
-- name: Debug
-  ansible.builtin.debug:
-    var: blocking_virtual_media
-    verbosity: 1
-
-- name: Attempting to eject blocking media (if any)
   community.general.redfish_command:
     category: Manager
     command: VirtualMediaEject

--- a/roles/vendors/hpe/tasks/eject.yml
+++ b/roles/vendors/hpe/tasks/eject.yml
@@ -12,8 +12,8 @@
   delay: 10
   until: result is succeeded
 
-- name: Get blocking virtual_media
-  ansible.builtin.set_fact:
+- name: Attempting to eject blocking media (if any)
+  vars:
     blocking_virtual_media: "{{ result.redfish_facts.virtual_media.entries
         | flatten(levels=2)
         | selectattr('ConnectedVia', 'defined') | list
@@ -29,8 +29,6 @@
           )]'
         ) | from_yaml
       }}"
-
-- name: Attempting to eject blocking media (if any)
   community.general.redfish_command:
     category: Manager
     command: VirtualMediaEject


### PR DESCRIPTION
##### SUMMARY

Retry media eject and increase the timeout threshold.

Keep only what is present in the rescue as it can detect the current media and eject it. 

##### ISSUE TYPE

Nominal Change

##### Tests

- [x]  Dell: https://www.distributed-ci.io/jobs/f2b178c8-a365-4f6b-907b-e24e5bce16b3/jobStates
- [x]  HPE: https://www.distributed-ci.io/jobs/eef4af95-ccb9-4a23-9e04-a5bcdf152dee/jobStates

Test-Hint: no-check
