### PR TITLE
check_resource | Remove check for current/desired-state in wait-sriov.yml

### DIFF
--- a/roles/check_resource/tasks/wait-sriov.yml
+++ b/roles/check_resource/tasks/wait-sriov.yml
@@ -7,10 +7,6 @@
   vars:
     query_sync_status: 'resources[*].status.syncStatus'
     query_sync_status_results: "{{ _cr_sriovnetnode | json_query(query_sync_status) }}"
-    query_current_state: 'resources[*].metadata.annotations."sriovnetwork.openshift.io/current-state"'
-    query_current_state_results: "{{ _cr_sriovnetnode | json_query(query_current_state) }}"
-    query_desired_state: 'resources[*].metadata.annotations."sriovnetwork.openshift.io/desired-state"'
-    query_desired_state_results: "{{ _cr_sriovnetnode | json_query(query_desired_state) }}"
   kubernetes.core.k8s_info:
     api_version: sriovnetwork.openshift.io/v1
     kind: SriovNetworkNodeState
@@ -18,8 +14,6 @@
   until:
     - _cr_sriovnetnode.resources is defined
     - query_sync_status_results | unique == ['Succeeded']
-    - query_current_state_results | unique == ['Idle']
-    - query_desired_state_results | unique == ['Idle']
   retries: "{{ check_wait_retries }}"
   delay: "{{ check_wait_delay }}"
 


### PR DESCRIPTION
##### SUMMARY

It's not true that all the SriovNetworkNodeState checks have the SRIOV annotations present, e.g. https://www.distributed-ci.io/jobs/e655be15-f3ce-410b-8e75-a9476c50d4ae/jobStates?sort=date&task=625d5c02-78c2-4779-b561-2346840feacc, the task is failing because all checks were passing but desired-state annotation was not in place.

From what I've extracted from daily jobs, I could see that:

- These two annotations are not present in OCP 4.12
- Only `"sriovnetwork.openshift.io/current-state"` is present from OCP 4.14
- `"sriovnetwork.openshift.io/desired-state"` annotation looks like present from OCP 4.16, since daily jobs with that version and higher ones are passing, e.g. https://www.distributed-ci.io/jobs/724add53-e2bb-4c01-91a9-e41cd305b5ab/jobStates

So, with this change, I'm just returning to the original check, which is just to check the syncStatus,  just to be compliant with all available OCP releases. but still using the cleaner approach with `json_query`, introduced in this PR: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/661

It's true that it would be more precise to also use the two network annotations aforementioned, but with the syncStatus it should be fine; typically, syncStatus moves to Succeeded once the annotations (if they're defined) are in Idle status.

##### ISSUE TYPE

- Bug

##### Tests

- [x] Job passed in OCP 4.12 - https://www.distributed-ci.io/jobs/452c8dd6-ad39-4217-b2e5-f9f07f66b7bb/jobStates

Test-Hints: no-check