### PR TITLE
create_certification_project: Fix multiple project issue

### DIFF
--- a/roles/create_certification_project/tasks/check_if_cnf_project_exists.yml
+++ b/roles/create_certification_project/tasks/check_if_cnf_project_exists.yml
@@ -53,7 +53,7 @@
 
 - name: Set project ID to reuse it later
   ansible.builtin.set_fact:
-    cert_project_id: "{{ cert_project_data | json_query(query_data) | flatten | last }}"  # noqa: jinja[invalid]
+    ccp_cert_project_id: "{{ cert_project_data | json_query(query_data) | flatten | last }}"  # noqa: jinja[invalid]
   vars:
     query_data: "[]._id"
   when:

--- a/roles/create_certification_project/tasks/check_if_container_project_exists.yml
+++ b/roles/create_certification_project/tasks/check_if_container_project_exists.yml
@@ -62,7 +62,7 @@
 
 - name: Set project ID to reuse it later
   ansible.builtin.set_fact:
-    cert_project_id: "{{ cert_project_data | json_query(query_data) | flatten | last }}"  # noqa: jinja[invalid]
+    ccp_cert_project_id: "{{ cert_project_data | json_query(query_data) | flatten | last }}"  # noqa: jinja[invalid]
   vars:
     query_data: "[]._id"
   when:

--- a/roles/create_certification_project/tasks/create_project.yml
+++ b/roles/create_certification_project/tasks/create_project.yml
@@ -21,12 +21,12 @@
 
 - name: Set project ID to reuse it later
   ansible.builtin.set_fact:
-    cert_project_id: "{{ cert_project_output.json | json_query('_id') }}"
+    ccp_cert_project_id: "{{ cert_project_output.json | json_query('_id') }}"
   when: not cert_project_output.failed
 
 - name: Set and Save New Project IDs for Preflight Parallel Tests
   ansible.builtin.set_fact:
-    ccp_new_cert_project_ids: "{{ ccp_new_cert_project_ids | default([]) + [{'pyxis_container_identifier': cert_project_id}] }}"
+    ccp_new_cert_project_ids: "{{ ccp_new_cert_project_ids | default([]) + [{'pyxis_container_identifier': ccp_cert_project_id}] }}"
   when:
     - not cert_project_output.failed
     - do_container_parallel_test
@@ -35,6 +35,6 @@
   ansible.builtin.debug:
     msg: |
       Certification project was created and could be checked here:
-      {{ connect_url }}/{{ cert_project_id }}/overview
+      {{ connect_url }}/{{ ccp_cert_project_id }}/overview
   when: not cert_project_output.failed
 ...

--- a/roles/create_certification_project/tasks/get_all_projects_for_product_listing.yml
+++ b/roles/create_certification_project/tasks/get_all_projects_for_product_listing.yml
@@ -28,7 +28,7 @@
 
 - name: "Append the current project into the list to link to PL"
   ansible.builtin.set_fact:
-    all_cert_projects: "{{ prev_projects | default([]) + [cert_project_id] }}"
+    all_cert_projects: "{{ prev_projects | default([]) + [ccp_cert_project_id] }}"
 
 - name: Ensure that all_cert_projects is not empty
   ansible.builtin.assert:

--- a/roles/create_certification_project/tasks/main.yml
+++ b/roles/create_certification_project/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Reset the project id to handle multiple CNF
   ansible.builtin.set_fact:
-    cert_project_id: ""
+    ccp_cert_project_id: ""
 
 - name: Handle the situation when cert project already exists
   ansible.builtin.include_tasks: check_if_project_exists.yml
@@ -23,7 +23,7 @@
 
 - name: Create cert project
   ansible.builtin.include_tasks: create_project.yml
-  when: cert_project_id | default('') | length == 0
+  when: ccp_cert_project_id | default('') | length == 0
 
 - name: Update the project with company info when cert_settings is defined
   ansible.builtin.include_tasks: update_project.yml
@@ -35,12 +35,16 @@
     # To avoid multiple PRs request to Charts repo,
     # no project update during helm chart project creation
     - product_type != 'helmchart'
-    - cert_project_id | default('') | length
+    - ccp_cert_project_id | default('') | length
 
 - name: Attach all product listings
   ansible.builtin.include_tasks: attach_product_listings.yml
   when:
     - cert_item.pyxis_product_lists is defined
     - cert_item.pyxis_product_lists | length > 0
-    - cert_project_id | default('') | length
+    - ccp_cert_project_id | default('') | length
+
+- name: Set and Save Project IDs for k8s tests
+  ansible.builtin.set_fact:
+    ccp_all_cert_project_ids: "{{ ccp_all_cert_project_ids | default([]) + [ccp_cert_project_id] }}"
 ...

--- a/roles/create_certification_project/tasks/main.yml
+++ b/roles/create_certification_project/tasks/main.yml
@@ -7,6 +7,10 @@
     fail_msg: "The parameter cert_item is required to create cert project"
     success_msg: "The parameter {{ cert_item }} is present"
 
+- name: Reset the project id to handle multiple CNF
+  ansible.builtin.set_fact:
+    cert_project_id: ""
+
 - name: Handle the situation when cert project already exists
   ansible.builtin.include_tasks: check_if_project_exists.yml
   when:

--- a/roles/create_certification_project/tasks/update_project.yml
+++ b/roles/create_certification_project/tasks/update_project.yml
@@ -12,7 +12,7 @@
   vars:
     template_filename: "templates/update_project_{{ product_type }}.json.j2"
   ansible.builtin.uri:
-    url: "{{ catalog_url }}/projects/certification/id/{{ cert_project_id }}"
+    url: "{{ catalog_url }}/projects/certification/id/{{ ccp_cert_project_id }}"
     method: PATCH
     headers:
       X-API-KEY: "{{ lookup('file', pyxis_apikey_path) }}"


### PR DESCRIPTION
##### SUMMARY

Only the first project is created and correctly linked to the corresponding product ID. However, subsequent projects are not created because the project ID from the first entry in the certification project job was not reset.

As a result, this initial project ID is incorrectly associated with all product list IDs.

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestDallasWorkload: preflight-green - https://www.distributed-ci.io/jobs/1904ea3d-4e8c-4d57-a937-855682ffe774/jobStates
- [x] Test with multiple projects - https://www.distributed-ci.io/jobs/66b0a2b0-c909-421b-83fb-20002299e320/jobStates?sort=date&task=2455b3c1-95cf-4750-ad0e-fa169eb35518

