### PR TITLE
Bump to certsuite v5.5.4

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.3
+kbpc_version: v5.5.4
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
##### SUMMARY

Bump to certsuite v5.5.4

##### ISSUE TYPE

- Bump version

##### Tests

- [x] Validated job: https://www.distributed-ci.io/jobs/35aa60c7-69e0-480a-b965-cb7ba65bda99/jobStates

Test-Hints: no-check