### PR TITLE
[ipi] add machine net and vips according to dual or single stack

### DIFF
--- a/roles/installer/templates/install-config-virtualmedia.j2
+++ b/roles/installer/templates/install-config-virtualmedia.j2
@@ -9,28 +9,32 @@ proxy:
 metadata:
   name: {{ cluster }}
 networking:
-{% if not dualstack_baremetal|bool %}
+  networkType: {{ network_type }}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) %}
+  machineNetwork:
+{% if dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool %}
+  - cidr: {{ extcidrnet }}
+{% endif %}
+{% if dualstack_baremetal|bool or ipv6_enabled|bool %}
+  - cidr: {{ extcidrnet6 }}
+{% endif %}
+{% else %}
   machineCIDR: {{ extcidrnet }}
 {% endif %}
-  networkType: {{ network_type }}
-{% if ipv6_enabled|bool and not (ipv4_baremetal|bool or dualstack_baremetal|bool) %}
   clusterNetwork:
-  - cidr: fd01::/48
-    hostPrefix: 64
-  serviceNetwork:
-  - fd02::/112
-{% endif %}
-{% if ipv6_enabled|bool and dualstack_baremetal|bool %}
-  machineNetwork:
-  - cidr: {{ extcidrnet }}
-  - cidr: {{ extcidrnet6 }}
-  clusterNetwork:
+{% if dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool %}
   - cidr: 10.128.0.0/14
     hostPrefix: 23
+{% endif %}
+{% if dualstack_baremetal|bool or ipv6_enabled|bool %}
   - cidr: fd02::/48
     hostPrefix: 64
+{% endif %}
   serviceNetwork:
+{% if dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool %}
   - 172.30.0.0/16
+{% endif %}
+{% if dualstack_baremetal|bool or ipv6_enabled|bool %}
   - fd03::/112
 {% endif %}
 {% if fips_enabled is defined and fips_enabled|bool %}
@@ -46,24 +50,24 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
-{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) and dualstack_baremetal|bool and dualstack_vips|bool %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) %}
     apiVIPs:
-{% if apivip is defined and apivip|ipv4 %}
+{% if (dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool) and apivip is defined and apivip|ipv4 %}
       - {{ apivip }}
 {% endif %}
-{% if ipv6_enabled|bool and apivip6 is defined and apivip6|ipv6 %}
+{% if (dualstack_baremetal|bool or ipv6_enabled|bool) and apivip6 is defined and apivip6|ipv6 %}
       - {{ apivip6 }}
 {% endif %}
     ingressVIPs:
-{% if ingressvip is defined and ingressvip|ipv4 %}
+{% if (dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool) and ingressvip is defined and ingressvip|ipv4 %}
       - {{ ingressvip }}
 {% endif %}
-{% if ipv6_enabled|bool and ingressvip6 is defined and ingressvip6|ipv6 %}
+{% if (dualstack_baremetal|bool or ipv6_enabled|bool) and ingressvip6 is defined and ingressvip6|ipv6 %}
       - {{ ingressvip6 }}
 {% endif %}
 {% else %}
-    apiVIP: {{ apivip }}
-    ingressVIP: {{ ingressvip }}
+    apiVIP: {{ (apivip is defined and apivip|ipv4) | ternary(apivip, apivip6) }}
+    ingressVIP: {{ (ingressvip is defined and ingressvip|ipv4) | ternary(ingressvip, ingressvip6) }}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 5)) %}
     dnsVIP: {{ dnsvip }}

--- a/roles/installer/templates/install-config.j2
+++ b/roles/installer/templates/install-config.j2
@@ -9,28 +9,32 @@ proxy:
 metadata:
   name: {{ cluster }}
 networking:
-{% if not dualstack_baremetal|bool  %}
+  networkType: {{ network_type }}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) %}
+  machineNetwork:
+{% if dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool %}
+  - cidr: {{ extcidrnet }}
+{% endif %}
+{% if dualstack_baremetal|bool or ipv6_enabled|bool %}
+  - cidr: {{ extcidrnet6 }}
+{% endif %}
+{% else %}
   machineCIDR: {{ extcidrnet }}
 {% endif %}
-  networkType: {{ network_type }}
-{% if ipv6_enabled|bool and not (ipv4_baremetal|bool or dualstack_baremetal|bool) %}
   clusterNetwork:
-  - cidr: fd01::/48
-    hostPrefix: 64
-  serviceNetwork:
-  - fd02::/112
-{% endif %}
-{% if ipv6_enabled|bool and dualstack_baremetal|bool %}
-  machineNetwork:
-  - cidr: {{ extcidrnet }}
-  - cidr: {{ extcidrnet6 }}
-  clusterNetwork:
+{% if dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool %}
   - cidr: 10.128.0.0/14
     hostPrefix: 23
+{% endif %}
+{% if dualstack_baremetal|bool or ipv6_enabled|bool %}
   - cidr: fd02::/48
     hostPrefix: 64
+{% endif %}
   serviceNetwork:
+{% if dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool %}
   - 172.30.0.0/16
+{% endif %}
+{% if dualstack_baremetal|bool or ipv6_enabled|bool %}
   - fd03::/112
 {% endif %}
 {% if fips_enabled is defined and fips_enabled|bool %}
@@ -46,24 +50,24 @@ controlPlane:
     baremetal: {}
 platform:
   baremetal:
-{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) and dualstack_baremetal|bool and dualstack_vips|bool %}
+{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) %}
     apiVIPs:
-{% if apivip is defined and apivip|ipv4 %}
+{% if (dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool) and apivip is defined and apivip|ipv4 %}
       - {{ apivip }}
 {% endif %}
-{% if ipv6_enabled|bool and apivip6 is defined and apivip6|ipv6 %}
+{% if (dualstack_baremetal|bool or ipv6_enabled|bool) and apivip6 is defined and apivip6|ipv6 %}
       - {{ apivip6 }}
 {% endif %}
     ingressVIPs:
-{% if ingressvip is defined and ingressvip|ipv4 %}
+{% if (dualstack_baremetal|bool or ipv4_baremetal|bool or not ipv6_enabled|bool) and ingressvip is defined and ingressvip|ipv4 %}
       - {{ ingressvip }}
 {% endif %}
-{% if ipv6_enabled|bool and ingressvip6 is defined and ingressvip6|ipv6 %}
+{% if (dualstack_baremetal|bool or ipv6_enabled|bool) and ingressvip6 is defined and ingressvip6|ipv6 %}
       - {{ ingressvip6 }}
 {% endif %}
 {% else %}
-    apiVIP: {{ apivip }}
-    ingressVIP: {{ ingressvip }}
+    apiVIP: {{ (apivip is defined and apivip|ipv4) | ternary(apivip, apivip6) }}
+    ingressVIP: {{ (ingressvip is defined and ingressvip|ipv4) | ternary(ingressvip, ingressvip6) }}
 {% endif %}
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 5)) %}
     dnsVIP: {{ dnsvip }}

--- a/roles/node_prep/defaults/main.yml
+++ b/roles/node_prep/defaults/main.yml
@@ -11,7 +11,6 @@ https_proxy: ""
 ipv4_baremetal: false
 ipv4_provisioning: false
 dualstack_baremetal: false
-dualstack_vips: false
 provisioning_bridge: "provisioning"
 webserver_url: ""
 baremetal_bridge: "baremetal"

--- a/roles/node_prep/tasks/10_validation.yml
+++ b/roles/node_prep/tasks/10_validation.yml
@@ -125,7 +125,9 @@
 - name: Fail if incorrect API VIP
   fail:
     msg: "The API VIP IP seems to be incorrect. Value was NXDOMAIN or empty string."
-  when: (apivip == 'NXDOMAIN') or (apivip|length == 0)
+  when:
+    - dualstack_baremetal|bool or ipv4_baremetal|bool
+    - (apivip == 'NXDOMAIN') or (apivip|length == 0)
   tags:
     - always
     - validation
@@ -133,7 +135,9 @@
 - name: Fail if incorrect Ingress VIP
   fail:
     msg: "The Ingress VIP IP seems to be incorrect. Value was NXDOMAIN or empty string."
-  when: (ingressvip == 'NXDOMAIN') or (ingressvip|length == 0)
+  when:
+    - dualstack_baremetal|bool or ipv4_baremetal|bool
+    - (ingressvip == 'NXDOMAIN') or (ingressvip|length == 0)
   tags:
     - always
     - validation
@@ -299,8 +303,6 @@
   when:
     - release_version is ansible.builtin.version('4.12', '>=')
     - ipv6_enabled | bool
-    - dualstack_baremetal | bool
-    - dualstack_vips | bool
   block:
     - name: Verify DNS records for Wildcard (Ingress) IPv6 VIP
       ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY

Add machine net and vips according to dual or single stack
    - OCP >= 4.12 can use either IPv4/IPv6 dual or single stack
    - anything before will default to IPv4
    - use IPv4/IPv6 machineCIDR and VIPs accordingly

##### ISSUE TYPE

Enhanced Feature

##### Tests

- [x] virt - IPv4 only - https://www.distributed-ci.io/jobs/d555799c-2c2e-46d9-9fcf-3b5128dfbf30/jobStates
- [ ] baremetal - IPv6 only - pending
- [ ] baremetal - dualstack - pending

TestBos2: virt 

