### PR TITLE
Allow ansible tests to run individually

### DIFF
--- a/hack/run_ansible_test.sh
+++ b/hack/run_ansible_test.sh
@@ -21,11 +21,51 @@ if [ -z "$GITHUB_STEP_SUMMARY" ]; then
     GITHUB_STEP_SUMMARY=/dev/null
 fi
 
+# Parse test types from arguments, default to all
+TEST_TYPES=()
+if [[ $# -eq 0 ]]; then
+  TEST_TYPES=(
+    sanity
+    units
+    integration
+  )
+else
+  for arg in "$@"; do
+    case "${arg}" in
+      sanity|units|integration)
+        TEST_TYPES+=("${arg}")
+        ;;
+      *)
+        echo "Unknown test type: ${arg}"
+        echo "Usage: $0 [sanity] [units] [integration]"
+        exit 2
+        ;;
+    esac
+  done
+fi
+
 branch=$(git rev-parse --abbrev-ref HEAD)
 
 trap 'git checkout -- "$branch"' EXIT
 
 git fetch --unshallow origin main || :
+
+run_tests() {
+  local version=$1
+  for test_type in "${TEST_TYPES[@]}"; do
+    case "$test_type" in
+      sanity)
+        ansible-test sanity $EXCLUDE --verbose --docker --python ${version} --color --coverage --failure-ok
+        ;;
+      units)
+        ansible-test units --verbose --docker --python ${version} --color --coverage || :
+        ;;
+      integration)
+        ansible-test integration --verbose --docker --python ${version} --color --coverage || :
+        ;;
+    esac
+  done
+}
 
 # extract all the supported python versions from the error message, excluding 3.5
 EXCLUDE="--exclude tests/ --exclude hack/ --exclude plugins/modules/nmcli.py"
@@ -33,22 +73,24 @@ PY_VERS=$(ansible-test sanity $EXCLUDE --verbose --docker --python 1.0 --color -
   grep -Po "invalid.*?\K'3.*\d'" |
   tr -d ,\' |
   sed -e 's/3.5 //g')
+
+# Tests in current branch
 for version in $PY_VERS; do
-  ansible-test sanity $EXCLUDE --verbose --docker --python $version --color --coverage --failure-ok
-  ansible-test units --verbose --docker --python $version --color --coverage || :
-  ansible-test integration --verbose --docker --python $version --color --coverage || :
+  run_tests "${version}"
 done 2> >(tee -a branch.output >&2)
+
+# Tests in main branch
 git checkout origin/main
 for version in $PY_VERS; do
-  ansible-test sanity $EXCLUDE --verbose --docker --python $version --color --coverage --failure-ok
-  ansible-test units --verbose --docker --python $version --color --coverage || :
-  ansible-test integration --verbose --docker --python $version --color --coverage || :
+  run_tests "${version}"
 done 2> main.output 1>/dev/null
+
 for key in branch main; do
   grep -E "((ERROR|FATAL):|FAILED )" "$key.output" |
   grep -v "issue(s) which need to be resolved\|See error output above for details.\|Command \"ansible-doc -t module .*\" returned exit status .*\." |
   sed -r 's/\x1B\[[0-9]{1,2}[mGK]//g' > "$key.errors"
 done
+
 # remove line numbers
 sed -i -E -e 's/:[0-9]+:/:/' -e 's/:[0-9]+:/:/' branch.errors main.errors
 set +ex


### PR DESCRIPTION
##### SUMMARY

For developing purposes, running locally it's useful to select what type of test is required to validate, to avoid running all the tests, all the time.

Fixes a bug introduced in #679 where the tests running against main branch were broken

The CI of the PR shows the failure: https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/15131359605/job/42532964350?pr=679#step:6:1779

##### ISSUE TYPE

- Enhancement
- Bug fix

##### Tests

Through the CI

This run shows a lint error introduced in commit 611a030160b21158d82eb2a45797edf344c600cd to test the main branch is tested and catching errors: 
https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/15744445591?pr=709

The error is shown in 3 tests: ansible-lint, sanity for 2.9 and sanity for 2.18.

This other run for PR #710 shows no issues for the same lint error in the sanity for 2.18: https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/runs/15744725852/job/44378423459?pr=710


Test-Hints: no-check