### PR TITLE
include_components: Add components for repos in /usr/src

### DIFF
--- a/roles/include_components/tasks/main.yml
+++ b/roles/include_components/tasks/main.yml
@@ -11,13 +11,14 @@
     ( ic_dev_gits |
     map('regex_replace', '^(?:.*/(.+)|.*/([^/]+))$', '\\1') | list)
 
-- name: Track src repos
-  block: 
+- name: Include source as components when using container
+  when: run_in_container | default(false) | bool
+  block:
     - name: Get /usr/src directories
-      find:
+      ansible.builtin.find:
         paths: /usr/src
         file_type: directory
-        register: output
+      register: output
     - name: Track src git found
       ansible.builtin.include_tasks: track_dev_git_repo.yml
       loop: "{{ output.files }}"

--- a/roles/include_components/tasks/main.yml
+++ b/roles/include_components/tasks/main.yml
@@ -11,6 +11,18 @@
     ( ic_dev_gits |
     map('regex_replace', '^(?:.*/(.+)|.*/([^/]+))$', '\\1') | list)
 
+- name: Track src repos
+  block: 
+    - name: Get /usr/src directories
+      find:
+        paths: /usr/src
+        file_type: directory
+        register: output
+    - name: Track src git found
+      ansible.builtin.include_tasks: track_dev_git_repo.yml
+      loop: "{{ output.files }}"
+      when: output.files is defined
+
 - name: Gather the package facts
   ansible.builtin.package_facts:
     manager: auto


### PR DESCRIPTION
##### SUMMARY

Add dci components for all git repositories inside the /usr/src directory. Very usefull for podman usecase

##### ISSUE TYPE

Enhanced Feature

##### Tests

- [ ] TestBos2Sno: sno - 