### PR TITLE
Set only one default storageclass

### DIFF
--- a/roles/odf_setup/tasks/local-storage-operator.yml
+++ b/roles/odf_setup/tasks/local-storage-operator.yml
@@ -54,15 +54,4 @@
   retries: 30
   delay: 10
   until: lso_storage_class.resources != []
-
-- name: Set Default Local Storage Class
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: storage.k8s.io/v1
-      kind: StorageClass
-      metadata:
-        name: "{{ local_storage_class }}"
-        annotations:
-          "{{ default_storageclass_annotation }}"
 ...


### PR DESCRIPTION
##### SUMMARY

The role sets 2 SCs as the default. There should not be more than one default StorageClass. Keeping only cephrbd as the default.

##### ISSUE TYPE

- Nominal change

##### Tests
- [ ] TestBos2: abi

TestBos2: abi