### PR TITLE
Wait for ACM InstallPlan 20 min instead of 5 min

### DIFF
--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -149,7 +149,7 @@
         kind: InstallPlan
         namespace: "{{ namespace }}"
       register: _oo_install_plan
-      retries: 30
+      retries: 120
       delay: 10
       no_log: true
       until: >


### PR DESCRIPTION
##### SUMMARY

Wait for ACM InstallPlan 20 min instead of 5 min to account to three-times larger catalog and avoid redhat-operators timeout.

##### ISSUE TYPE

We have repeated failures to install ACM operator on 4.16, [example](https://www.distributed-ci.io/jobs/5b33030d-af41-4da9-9fcb-25d72ab5bd3f/jobStates?sort=date&task=c6572938-0253-4a85-b445-433307f0a5e8). 
5 minutes seem to be not enough to get InstallPlan to appear.

```
null                                              
2025-07-08T21:11:15Z  2025-07-08T21:13:15Z  
Warning  ResolutionFailed                            
Namespace/open-cluster-management                                
error using catalogsource openshift-marketplace/redhat-operators: 
error encountered while listing bundles: 
rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

There is a [related BZ](https://issues.redhat.com/browse/OCPBUGS-43966), explaining that catalog starting from 4.15 and especially 4.16 is three times larger than before and hence redhat-operators might be stale while responding to the queries. The implemented fix was to simply increase cache lifetime up to 30 minutes without any logic change.

##### Tests

Tests are green: [InstallPlan took 1 min to be ready](https://www.distributed-ci.io/jobs/7d8c822f-4df2-4294-847f-2f64380166ea/jobStates?sort=date&task=8993f986-b4e6-49b7-9d33-f17b9f9e9119 ). Going to merge anyway to see if that improves hub installation stability.