### PR TITLE
setup_gitea: optional parameter sg_kubeconfig

### DIFF
--- a/roles/setup_gitea/README.md
+++ b/roles/setup_gitea/README.md
@@ -18,6 +18,7 @@ Role tasks:
 | --------              | -------                               | -------- | -----------
 | sg_action             | install                               | No       | Default role's action
 | sg_gitea_image        | docker.io/gitea/gitea:latest-rootless | No       | Default Gitea server image
+| sg_kugeconfig         | *omit*                                | No       | Path to the kubeconfig file to log into the OCP cluster.
 | sg_namespace          | gitea                                 | No       | Deployment Namespace
 | sg_url                | http://localhost:3000                 | No       | Root URL to the Gitea service
 | sg_username           | *undefined*                           | No       | Gitea's initial username. Mandatory if the initial repository (sg_repository) is created.

--- a/roles/setup_gitea/tasks/cleanup.yml
+++ b/roles/setup_gitea/tasks/cleanup.yml
@@ -5,12 +5,14 @@
     api: "v1"
     kind: "Namespace"
     name: "{{ sg_namespace }}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
 
 - name: "Wait for the Gitea Namespace to be terminated"
   kubernetes.core.k8s_info:
     api: "v1"
     kind: "Namespace"
     name: "{{ sg_namespace }}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
   register: _sg_gitea_namespace
   retries: 10
   delay: 5

--- a/roles/setup_gitea/tasks/install.yml
+++ b/roles/setup_gitea/tasks/install.yml
@@ -2,18 +2,22 @@
 - name: Create namespace for Gitea
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'namespace.j2') | from_yaml}}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
 
 - name: Create Service Account
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'sa_anyuid.j2') | from_yaml}}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
 
 - name: Create Role
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'role_scc_anyuid.j2') | from_yaml}}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
 
 - name: Create RoleBinding
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'role_binding_sa_to_scc_anyuid.j2') | from_yaml}}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
 
 - name: Generate JWT secret
   containers.podman.podman_container:
@@ -74,19 +78,23 @@
 - name: Create Secret with the Gitea configuration
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'secret_gitea_app_ini.j2') | from_yaml}}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
   no_log: true
 
 - name: Create the Gitea deployment
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'deployment_gitea.j2') | from_yaml}}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
 
 - name: Create the gitea service
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'service_gitea.j2') | from_yaml}}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
 
 - name: Create the Gitea route
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'route_gitea.j2') | from_yaml}}"
+    kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
   register: _sg_gitea_route
 
 - name: Export Gitea service domain
@@ -110,6 +118,7 @@
         namespace: "{{ sg_namespace }}"
         label_selectors:
           - "app = gitea"
+        kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
       register: _sg_gitea_pod
 
     - name: Create the Gitea initial user
@@ -123,6 +132,7 @@
           --username {{ sg_username }}
           --password {{ sg_password }}
           --email {{ sg_email }}
+        kubeconfig: "{{ sg_kubeconfig | default(omit) }}"
       no_log: true
 
 - name: Create the initial repository


### PR DESCRIPTION
##### SUMMARY

The ztp-spoke deployment jobs in disconnected environment may access both, the hub and the spoke clusters, using their respective kubeconfig files.

In disconnected environments, if the GitOps git repository is cloned during the spoke deployment phase, it needs to be specifically told to use the hub kubeconfig file.

To achieve this we added the sg_kubeconfig variable that defaults to *omit* so setting it may be skipped in favor of the environment KUBECONFIG variable.

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [ ] TestDallasSno: ocp-4.16-sno-abi - <JobURL>

---

TestDalllasSno: ocp-4.16-sno-abi
