### PR TITLE
acm_spoke_mgmt: waiting for managed cluster to be deleted

### DIFF
--- a/roles/acm_spoke_mgmt/README.md
+++ b/roles/acm_spoke_mgmt/README.md
@@ -73,10 +73,11 @@ asm_cluster_name             | string | yes      | -                            
     asm_action: "attach"
     asm_cluster_kubeconfig_path: "/path/to/spoke/kubeconfig"
     asm_cluster_name: "mycluster"
+```
 
 ## Remove ZTP ArgoCD resources
 
-This action allows to remove the ArgoCD resources used to deploy a ZTP cluster. This could remove all the created resources in cascading. The role locates the ArgoCD applications used to create a cluster using the GitOps repository a source branch as references.
+This action allows to remove the ArgoCD resources used to deploy a ZTP cluster. This could remove all the created resources in cascading. The role locates the ArgoCD applications used to create a cluster using the GitOps repository and source branch as references. It finally waits for the Managed Cluster to be destroyed, so a fresh deployment may be launched.
 
 Two resources are deleted by this role.
 
@@ -93,7 +94,8 @@ Name                         | Type   | Required | Default                      
 ---------------------------- | ------ | -------- | -------------------------------------------------- | ------------------------------------------------------------
 asm_source_repo              | string | yes      | -                                                  | GitOps repository that was used to deploy the ZTP cluster
 asm_target_revision          | string | yes      | -                                                  | Branch used to deploy the ZTP cluster
-asm_delete_ztp_resources     | boolean| yes      | true                                               | Deletes the ArgoCD applications and all the related cluster deployments resources
+asm_delete_ztp_resources     | boolean| no       | true                                               | Deletes the ArgoCD applications and all the related cluster deployments resources
+asm_cluster_name             | string | no       | If asm_delete_ztp_resources is set to true, name of the Managed Cluster the role must wait to be destroyed after removing the GitOps applications.
 
 ### Example
 
@@ -104,6 +106,7 @@ asm_delete_ztp_resources     | boolean| yes      | true                         
   vars:
     asm_action: "delete-ztp-by-ref"
     asm_cluster_kubeconfig_path: "/path/to/spoke/kubeconfig"
+    asm_cluster_name: clusterN
     asm_source_repo: "http://<gitops-repository>/gituser/gitops"
     asm_target_revision: main
 ```

--- a/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
+++ b/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
@@ -6,6 +6,8 @@
       - asm_source_repo | length > 0
       - asm_target_revision is defined
       - asm_target_revision | length > 0
+      - not asm_delete_ztp_resources | bool or asm_cluster_name is defined
+      - not asm_delete_ztp_resources | bool or asm_cluster_name | length > 0
 
 - name: Get all ArgoCD Applications
   kubernetes.core.k8s_info:
@@ -70,4 +72,29 @@
       loop: "{{ apps_list }}"
       loop_control:
         loop_var: app
+
+- name: Waiting for ManagedCluster to be deleted
+  when: asm_delete_ztp_resources | bool
+  block:
+    - name: Wait for ManagedCluster to be deleted
+      kubernetes.core.k8s_info:
+        api_version: cluster.open-cluster-management.io/v1
+        kind: ManagedCluster
+        name: "{{ asm_cluster_name }}"
+      register: _asm_managed_cluster_status
+      until:
+        - _asm_managed_cluster_status.resources | length == 0
+      retries: 120
+      delay: 10
+
+    - name: Wait for cluster namespace to be deleted
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Namespace
+        name: "{{ asm_cluster_name }}"
+      register: _asm_namespace_status
+      until:
+        - _asm_namespace_status.resources | length == 0
+      retries: 120
+      delay: 10
 ...


### PR DESCRIPTION
##### SUMMARY

The acm_spoke_mgmt role may be used to run operations related to a spoke cluster on the ACM cluster configuration. When working with the GitOps operator, one of these operations includes deleting argocd applications what will result in the deletion of the ManagedCluster object.

Currently, if the applications are deleted and the deployment of a new cluster is immediately launched, this may cause the new installation to take the previous ManagedCluster as the current target and quit without actually starting the deployment.

This change adds two tasks to wait for the ManagedCluster and the namespace to be deleted.

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [ ] TestBos2Sno: sno - <JobURL>

---

Test-Hint: no-check
