### PR TITLE
include_components: add support for tracking listed components

### DIFF
--- a/roles/include_components/README.md
+++ b/roles/include_components/README.md
@@ -1,6 +1,6 @@
 # Include DCI components
 
-Create and attach DCI components to DCI jobs from git repositories, RPMs or commit URLs.
+Create and attach DCI components to DCI jobs from git repositories, RPMs, commit URLs or just listed.
 
 The `include_components` role creates and attaches DCI components to the DCI jobs by generating them from provided resources. Possible resource inputs include RPM packages, Git repositories, and GitHub commits.
 
@@ -21,6 +21,7 @@ Variables used by this role:
 | ic_dev_gits    | True     | List   | Mandatory. List of complimentary directories from GIT repositories to include as components.
 | ic_rpms        | False    | List   | Optional. List of RPM names to include as components.
 | ic_commit_urls | False    | List   | Optional. List of GitHub URLs pointing directly to code commits. The URL format is `https://github.com/organisation/reponame/commit/commit_hash` and should contain the full commit hash. See examples.
+| ic_listed      | False    | List   | Optional. List of components, each element must contain name and version keys. The type key is optional, if not provided, it defaults to the value of name.
 
 ## Examples
 
@@ -48,4 +49,23 @@ Create a component providing the commit URLs
       - "https://github.com/redhat-openshift-ecosystem/openshift-preflight/commit/b6bcc3506c0d84baa0c020f6b776asfasfasdfa"
     ic_gits: []
     ic_dev_gits: []
+```
+
+Create a components providing a list
+
+```yaml
+- name: Create listed components
+  ansible.builtin.include_role:
+    name: redhatci.ocp.include_components
+  vars:
+    ic_gits:
+      - "{{ code_source_dir }}"
+    ic_dev_gits: []
+    ic_listed:
+      - name: component_name_1
+        version: 0.1
+      - name: component_name_2
+        version: 0.1
+        type: mytype
+
 ```

--- a/roles/include_components/tasks/main.yml
+++ b/roles/include_components/tasks/main.yml
@@ -30,4 +30,9 @@
   loop: "{{ ic_commit_urls | default([]) }}"
   loop_control:
     loop_var: ic_commit_url
+
+- name: Track listed components
+  ansible.builtin.include_tasks: track_listed_component.yml
+  loop: "{{ ic_listed | default([]) }}"
+
 ...

--- a/roles/include_components/tasks/track_listed_component.yml
+++ b/roles/include_components/tasks/track_listed_component.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Create listed component
+  ansible.legacy.dci_component:
+    display_name: "{{ item.name }} {{ item.version }}"
+    version: "{{ item.version }}"
+    team_id: "{{ job_info['job']['team_id'] }}"
+    topic_id: "{{ job_info['job']['topic_id'] }}"
+    type: "{{ item.type | default(item.name | lower) }}"
+    state: present
+  register: _ic_listed_component
+
+- name: Attach listed component to the job
+  ansible.legacy.dci_job_component:
+    component_id: "{{ _ic_listed_component.component.id }}"
+    job_id: "{{ job_id }}"
+  register: _ic_job_component_result
+  until: _ic_job_component_result is not failed
+  retries: 5
+  delay: 20
+  when:
+    - "'component' in _ic_listed_component"
+    - "'id' in _ic_listed_component.component"
+...


### PR DESCRIPTION
##### SUMMARY

This commit introduces the `ic_listed` variable, which allows tracking a list of components defined as a dictionary. Each component entry includes a `name` and `version`, for example:

  ic_listed:
    - name: component_name_1 
      version: 0.1
      type: source
    - name: component_name_2
      version: 0.1

This provides a structured way to define and manage component versions explicitly.

##### ISSUE TYPE


- Enhanced Feature

##### Tests

- [x]  workload - https://www.distributed-ci.io/jobs/a1a5df4b-089c-4b3f-88e5-2b13dcd8782e
- [x] tnf-test-cnf-green - https://www.distributed-ci.io/jobs/8317907d-42e4-4e37-90c4-2d3120835c0d/jobStates?sort=date
