### PR TITLE
part-1: add filter plugin `redhatci.ocp.reportsmerger`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,9 @@
 # verification team
 /roles/jenkins_job_launcher          @redhatci/verification
 /roles/junit2json                    @redhatci/verification
+/plugins/filter                      @redhatci/verification @redhatci/dci
+/tests/unit/filter                   @redhatci/verification @redhatci/dci
+/tests/unit/data                     @redhatci/verification @redhatci/dci
 
 # platform team
 /roles/sideload_kernel               @redhatci/platform

--- a/README.md
+++ b/README.md
@@ -150,12 +150,13 @@ Name | Description
 
 Name | Type | Description
 --- | --- | ---
+[redhatci.ocp.get_compatible_rhocp_repo]() | Module | A module to find the latest available version of the RHOCP repository
 [redhatci.ocp.junit2dict]() | Filter | Transforms a JUnit into a dictionary
 [redhatci.ocp.junit2obj]() | Filter | Transforms a JUnit XML into a corresponding JSON text
-[redhatci.ocp.ocp_compatibility]() | Filter | Parse the deprecated and to-be-deprecated API after the workload installation
-[redhatci.ocp.regex_diff]() | Filter | Obtain differences between two lists
-[redhatci.ocp.get_compatible_rhocp_repo]() | Module | A module to find the latest available version of the RHOCP repository
 [redhatci.ocp.nmcli]() | Module | A modified module to manage networking based on [community.general.nmcli](https://github.com/ansible-collections/community.general)
+[redhatci.ocp.ocp_compatibility]() | Filter | Parse the deprecated and to-be-deprecated API after the workload installation
+[redhatci.ocp.reportsmerger]() | Filter | Merges multiple similarly formatted JSON test reports into 1
+[redhatci.ocp.regex_diff]() | Filter | Obtain differences between two lists
 
 ## License
 

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        2.7.EPOCH
+Version:        2.8.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -29,6 +29,7 @@ Requires: podman
 Requires: python3-jmespath
 Requires: python3-netaddr
 Requires: python3-pyyaml
+Requires: python3-lxml
 Requires: skopeo
 Conflicts: dci-openshift-agent < 1.1.0
 
@@ -54,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Wed Jul 16 2025 Max Kovgan <makovgan@redhat.com> - 2.8.EPOCH-VERS
+- impl filter plugin redhatci.ocp.reportsmerger
+
 * Fri Jul 11 2025 Beto Rdz <josearod@redhat.com> - 2.7.EPOCH-VERS
 - Changes in deploy_cr
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 1.3.2147483647
-version: 2.7.0
+version: 2.8.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,4 +1,4 @@
 ---
 version: 3
 dependencies:
-  python: requirements.txt  # List Python package requirements in the file
+  python: meta/requirements.txt  # List Python package requirements in the file

--- a/meta/requirements.txt
+++ b/meta/requirements.txt
@@ -1,4 +1,5 @@
 jmespath
 junit_xml
 junitparser
+lxml
 python-dateutil

--- a/plugins/filter/junit2obj.py
+++ b/plugins/filter/junit2obj.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Copyright (C) 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -12,132 +14,138 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 __version__: str = "1.0.0"
 
 DOCUMENTATION = r"""
-  name: junit2obj
-  version_added: "1.0.0"
-  short_description: transform JUnit XML text data as dictionary retaining suites and cases structure to JSON text
-  description: >
-    This filter plugin transforms a string JUnit XML data to JSON representation of it.
-    It is being implemented because `junit2dict` filter does not retain suites information (timings),
-    hence not allowing collecting of running times as metrics for future analysis.
-  positional: xml_report_text
-  options:
-    xml_report_text:
-      description: The junit report xml text data
-      type: str
-      required: true
+---
+name: junit2obj
+version_added: "1.0.0"
+short_description: transform JUnit XML text data as dictionary retaining suites and cases structure to JSON text.
+description: >
+  This filter plugin transforms a string JUnit XML data to JSON
+  representation of it.
+  It is being implemented because 'redhatci.ocp.junit2dict' filter does not
+  retain suites information (timings), hence not allowing collection of
+  running times as metrics for future analysis.
+positional: xml_report_text
+options:
+  xml_report_text:
+    description: The junit report xml text data
+    type: str
+    required: true
 """
 
 
 EXAMPLES = r"""
-
+---
+- name: Convert JUnit report to a structured object
+  vars:
     xml_report_text: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <testsuites tests="3" disabled="2" errors="0" failures="0" time="0.000426228">
-            <testsuite name="Performance Addon Operator Reboot" package="/home/jenkins/workspace/CNF/cnf-compute-4.18"
-                tests="3" disabled="0" skipped="2" errors="0" failures="0" time="0.000426228" timestamp="2024-12-12T20:12:23">
-                <properties>
-                    <property name="SuiteSucceeded" value="true"></property>
-                    <property name="SuiteHasProgrammaticFocus" value="false"></property>
-                    <property name="SpecialSuiteFailureReason" value=""></property>
-                    <property name="SuiteLabels" value="[]"></property>
-                    <property name="RandomSeed" value="1734025939"></property>
-                    <property name="RandomizeAllSpecs" value="false"></property>
-                    <property name="LabelFilter" value="(!openshift &amp;&amp; tier-0)"></property>
-                </properties>
-                <testcase name="[It] [disruptive][node][kubelet][devicemanager] Device management tests"
-                    classname="Performance Addon Operator Reboot" status="skipped" time="0">
-                    <skipped message="skipped"></skipped>
-                </testcase>
-                <testcase name="[It] [disruptive][node][kubelet][devicemanager] Device management tests [tier-3]"
-                    classname="Performance Addon Operator Reboot" status="skipped" time="0">
-                    <skipped message="skipped"></skipped>
-                </testcase>
-                <testcase name="[ReportAfterSuite] e2e serial suite"
-                    classname="Performance Addon Operator Reboot" status="passed" time="6.826e-05">
-                    <system-err>&gt; Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;</system-err>
-                </testcase>
-            </testsuite>
-        </testsuites>
-
-
-    test_result: '{{ "path/to/junit.xml" | redhat.ocp.junit2obj }}'
-    # =>
-    # {
-    #     "time": 0.000426228,
-    #     "tests": 3,
-    #     "failures": 0,
-    #     "errors": 0,
-    #     "skipped": 2,
-    #     "test_suites": [
-    #         {
-    #             "name": "Performance Addon Operator Reboot",
-    #             "time": 0.0,
-    #             "timestamp": "2024-12-12T20:12:23",
-    #             "tests": 3,
-    #             "failures": 0,
-    #             "errors": 0,
-    #             "skipped": 2,
-    #             "properties": {
-    #                 "SuiteSucceeded": "true",
-    #                 "SuiteHasProgrammaticFocus": "false",
-    #                 "SpecialSuiteFailureReason": "",
-    #                 "SuiteLabels": "[]",
-    #                 "RandomSeed": "1734025939",
-    #                 "RandomizeAllSpecs": "false",
-    #                 "LabelFilter": "(!openshift && tier-0)"
-    #             },
-    #             "test_cases": [
-    #                 {
-    #                     "name": "[It] [disruptive][node][kubelet][devicemanager] Device management tests",
-    #                     "classname": "Performance Addon Operator Reboot",
-    #                     "time": 0.0,
-    #                     "result": [
-    #                         {
-    #                             "message": "skipped",
-    #                             "status": "skipped"
-    #                         }
-    #                     ]
-    #                 },
-    #                 {
-    #                     "name": "[It] [disruptive][node][kubelet][devicemanager] Device management tests [tier-3]",
-    #                     "classname": "Performance Addon Operator Reboot",
-    #                     "time": 0.0,
-    #                     "result": [
-    #                         {
-    #                             "message": "skipped",
-    #                             "status": "skipped"
-    #                         }
-    #                     ]
-    #                 },
-    #                 {
-    #                     "name": "[ReportAfterSuite] e2e serial suite",
-    #                     "classname": "Performance Addon Operator Reboot",
-    #                     "time": 6.826e-05,
-    #                     "result": [
-    #                         {
-    #                             "message": "passed",
-    #                             "status": "passed"
-    #                         }
-    #                     ],
-    #                     "system_err": "> &gt; Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;"
-    #                 }
-    #             ]
-    #         }
-    #     ]
-    # }
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites tests="3" disabled="2" errors="0" failures="0" time="0.000426228">
+          <testsuite name="Performance Addon Operator Reboot" package="/home/jenkins/workspace/CNF/cnf-compute-4.18"
+              tests="3" disabled="0" skipped="2" errors="0" failures="0" time="0.000426228" timestamp="2024-12-12T20:12:23">
+              <properties>
+                  <property name="SuiteSucceeded" value="true"></property>
+                  <property name="SuiteHasProgrammaticFocus" value="false"></property>
+                  <property name="SpecialSuiteFailureReason" value=""></property>
+                  <property name="SuiteLabels" value="[]"></property>
+                  <property name="RandomSeed" value="1734025939"></property>
+                  <property name="RandomizeAllSpecs" value="false"></property>
+                  <property name="LabelFilter" value="(!openshift &amp;&amp; tier-0)"></property>
+              </properties>
+              <testcase name="[It] [disruptive][node][kubelet][devicemanager] Device management tests"
+                  classname="Performance Addon Operator Reboot" status="skipped" time="0">
+                  <skipped message="skipped"></skipped>
+              </testcase>
+              <testcase name="[It] [disruptive][node][kubelet][devicemanager] Device management tests [tier-3]"
+                  classname="Performance Addon Operator Reboot" status="skipped" time="0">
+                  <skipped message="skipped"></skipped>
+              </testcase>
+              <testcase name="[ReportAfterSuite] e2e serial suite"
+                  classname="Performance Addon Operator Reboot" status="passed" time="6.826e-05">
+                  <system-err>&gt; Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;</system-err>
+              </testcase>
+          </testsuite>
+      </testsuites>
+  ansible.builtin.debug:
+    msg: "{{ xml_report_text | redhatci.ocp.junit2obj }}"
+# =>
+# {
+#     "time": 0.000426228,
+#     "tests": 3,
+#     "failures": 0,
+#     "errors": 0,
+#     "skipped": 2,
+#     "test_suites": [
+#         {
+#             "name": "Performance Addon Operator Reboot",
+#             "time": 0.0,
+#             "timestamp": "2024-12-12T20:12:23",
+#             "tests": 3,
+#             "failures": 0,
+#             "errors": 0,
+#             "skipped": 2,
+#             "properties": {
+#                 "SuiteSucceeded": "true",
+#                 "SuiteHasProgrammaticFocus": "false",
+#                 "SpecialSuiteFailureReason": "",
+#                 "SuiteLabels": "[]",
+#                 "RandomSeed": "1734025939",
+#                 "RandomizeAllSpecs": "false",
+#                 "LabelFilter": "(!openshift && tier-0)"
+#             },
+#             "test_cases": [
+#                 {
+#                     "name": "[It] [disruptive][node][kubelet][devicemanager] Device management tests",
+#                     "classname": "Performance Addon Operator Reboot",
+#                     "time": 0.0,
+#                     "result": [
+#                         {
+#                             "message": "skipped",
+#                             "status": "skipped"
+#                         }
+#                     ]
+#                 },
+#                 {
+#                     "name": "[It] [disruptive][node][kubelet][devicemanager] Device management tests [tier-3]",
+#                     "classname": "Performance Addon Operator Reboot",
+#                     "time": 0.0,
+#                     "result": [
+#                         {
+#                             "message": "skipped",
+#                             "status": "skipped"
+#                         }
+#                     ]
+#                 },
+#                 {
+#                     "name": "[ReportAfterSuite] e2e serial suite",
+#                     "classname": "Performance Addon Operator Reboot",
+#                     "time": 6.826e-05,
+#                     "result": [
+#                         {
+#                             "message": "passed",
+#                             "status": "passed"
+#                         }
+#                     ],
+#                     "system_err": "> &gt; Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;"
+#                 }
+#             ]
+#         }
+#     ]
+# }
 """
 
 
 RETURN = r"""
-  _value:
-    description:
-      - JSON data
-    type: dict
+---
+_value:
+  description:
+    - JSON data
+  type: dict
 """
 
 
@@ -166,10 +174,12 @@ class FilterModule(object):
             processing test case into a dict
             """
             curr_case: dict = {}
-            curr_case.update({
-                "name": str(testcase.name),
-                "classname": str(testcase.classname),
-            })
+            curr_case.update(
+                {
+                    "name": str(testcase.name),
+                    "classname": str(testcase.classname),
+                }
+            )
             case_time = testcase.time
             if case_time is None:
                 case_time = 0
@@ -194,10 +204,12 @@ class FilterModule(object):
                         attr_dict.update({"status": item.message.split(" ")[0]})
                     attr_values.append(attr_dict)
                 if len(value) == 0:
-                    attr_dict.update({
-                        "message": "passed",
-                        "status": "passed",
-                    })
+                    attr_dict.update(
+                        {
+                            "message": "passed",
+                            "status": "passed",
+                        }
+                    )
                     attr_values.append(attr_dict)
                 curr_case.update({attr: attr_values})
 
@@ -216,29 +228,37 @@ class FilterModule(object):
             processing test suite into a dict
             """
             curr_suite = {}
-            curr_suite.update({
-                "name": str(testsuite.name),
-                "time": float(testsuite.time),
-            })
+            curr_suite.update(
+                {
+                    "name": str(testsuite.name),
+                    "time": float(testsuite.time),
+                }
+            )
             if curr_suite.get("time") is None:
                 curr_suite.update({"time": float(0)})
 
             curr_suite.update({"timestamp": str(testsuite.timestamp)})
             if curr_suite.get("timestamp") == "None":
-                curr_suite.update({"timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(0))})
+                curr_suite.update(
+                    {"timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(0))}
+                )
 
-            curr_suite.update({
-                "tests": int(testsuite.tests),
-                "failures": int(testsuite.failures),
-                "errors": int(testsuite.errors),
-                "skipped": int(testsuite.skipped),
-            })
+            curr_suite.update(
+                {
+                    "tests": int(testsuite.tests),
+                    "failures": int(testsuite.failures),
+                    "errors": int(testsuite.errors),
+                    "skipped": int(testsuite.skipped),
+                }
+            )
             if testsuite.properties is not None:
                 suite_properties = {}
                 for prop in testsuite.properties():
-                    suite_properties.update({
-                        str(prop.name): prop.value,
-                    })
+                    suite_properties.update(
+                        {
+                            str(prop.name): prop.value,
+                        }
+                    )
                 curr_suite.update({"properties": suite_properties})
 
             curr_suite.update({"test_cases": []})
@@ -248,17 +268,19 @@ class FilterModule(object):
                 curr_suite["test_cases"].append(curr_case)
             return curr_suite
 
-        junit_xml: jup.JUnitXml = jup.JUnitXml.fromstring(xml_report_text)
+        junit_xml: jup.JUnitXml = jup.JUnitXml.fromstring(xml_report_text.encode('utf-8'))
         report = {}
-        report.update({
-            "time": float(junit_xml.time),
-            "tests": int(junit_xml.tests),
-            "failures": int(junit_xml.failures),
-            "errors": int(junit_xml.errors),
-            "skipped": int(junit_xml.skipped),
-            "test_suites": [],
-            "schema_version": __version__,
-        })
+        report.update(
+            {
+                "time": float(junit_xml.time),
+                "tests": int(junit_xml.tests),
+                "failures": int(junit_xml.failures),
+                "errors": int(junit_xml.errors),
+                "skipped": int(junit_xml.skipped),
+                "test_suites": [],
+                "schema_version": __version__,
+            }
+        )
 
         tstsuite: jup.TestSuite
         for tstsuite in junit_xml:

--- a/plugins/filter/reportsmerger.py
+++ b/plugins/filter/reportsmerger.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+"""Ansible filter plugin that merges multiple json files into one
+
+The files should be the result of junit2obj conversion
+"""
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+from typing import Any
+from ansible.utils.display import Display
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+__version__ = "1.0.0"
+
+DOCUMENTATION = r"""
+---
+name: reportsmerger
+version_added: "1.0.0"
+short_description: merge multiple similarly built JSON files into one
+description: >
+  This filter plugin merges multiple test report JSON files (usually
+  converted by junit2obj filter) into a single consolidated test report.
+  It combines all test suites and recalculates aggregated statistics.
+positional: filenames
+options:
+  filenames:
+    description: List of filenames containing test report JSON data
+    type: list
+    elements: str
+    required: true
+"""
+
+EXAMPLES = r"""
+---
+# Merge multiple test report files
+- name: merge reports
+  ansible.builtin.set_fact:
+    merged: "{{ ['1.json', '2.json', '3.json'] | redhatci.ocp.reportsmerger }}"
+
+# The result will be a merged test report with:
+# - Combined test_suites list from all input files
+# - Aggregated statistics (tests, failures, errors, skipped counts, total time)
+"""
+
+RETURN = r"""
+---
+_value:
+  description:
+    - Merged test report data structure
+  type: dict
+  contains:
+    time:
+      description: Total time from all test suites
+      type: float
+    tests:
+      description: Total number of tests
+      type: int
+    failures:
+      description: Total number of failures
+      type: int
+    errors:
+      description: Total number of errors
+      type: int
+    skipped:
+      description: Total number of skipped tests
+      type: int
+    test_suites:
+      description: Combined list of all test suites from input files
+      type: list
+    schema_version:
+      description: Schema version
+      type: str
+"""
+
+
+class FilterModule:
+    """
+    Filter for merging multiple test report JSON files
+    """
+
+    def filters(self) -> dict[str, Any]:
+        """
+        filter boilerplate
+        """
+        return {
+            "reportsmerger": self.reportsmerger,
+        }
+
+    # pylint: disable=bad-whitespace
+    def reportsmerger(self, filenames: list[str], output_file: str | None = None) -> dict[str, Any] | str:
+        """
+        Merge multiple test report JSON files into a single test report.
+
+        Args:
+            filenames: List of file paths containing test report JSON data
+            output_file: Optional output file path. If provided, writes merged
+                         data to file and returns the file path instead of
+                         the data
+
+        Returns:
+            dict: Merged report with aggregated statistics (if no output_file)
+            str: Output file path (if output_file provided)
+        """
+        import json
+        import os
+
+        display = Display()
+        if not isinstance(filenames, list):
+            raise TypeError("reportsmerger expects a list of filenames")
+        if not filenames:
+            raise ValueError("reportsmerger requires at least one filename")
+
+        merged_report: dict[str, Any] = {
+            "time": 0.0,
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "test_suites": [],
+            "schema_version": __version__,
+        }
+
+        for filename in filenames:
+            if not os.path.exists(filename):
+                msg = (
+                    f"reportsmerger plugin: file {filename} "
+                    "does not exist and was skipped"
+                )
+                display.warning(msg)
+                continue
+
+            report_data = self._load_and_validate_report(filename, display)
+            self._accumulate_report_stats(report_data, merged_report, filename, display)
+        msg: str = "\n".join(
+            [
+                f"Merged {len(filenames)} files:",
+                f"  tests:\t{merged_report['tests']}",
+                f"  failures:\t{merged_report['failures']}",
+                f"  errors:\t{merged_report['errors']}",
+                f"  skipped:\t{merged_report['skipped']}",
+                f"  time:\t{merged_report['time']}",
+                f"  test_suites:\t{len(merged_report['test_suites'])}",
+            ]
+        )
+        display.v(msg)
+
+        # NEW: If output file specified, write directly and return path
+        if output_file:
+            with open(output_file, "w", encoding="utf-8") as f:
+                json.dump(merged_report, f, indent=2)
+            display.v(f"Merged report written to {output_file}")
+            return output_file  # Return just the path, not the data
+
+        # Original behavior: return the data
+        return merged_report
+
+    def _load_and_validate_report(
+        self, filename: str, display: Display
+    ) -> dict[str, Any]:
+        """Load and validate a single report file."""
+        import json
+
+        try:
+            with open(filename, "r", encoding="utf-8") as f:
+                report_data: dict[str, Any] = json.load(f)
+        except json.JSONDecodeError as jde:
+            msg = f"Invalid JSON in file {filename}: {jde}"
+            display.error(msg)
+            raise ValueError(msg) from jde
+        except Exception as exc:
+            msg = f"Error reading file {filename}: {exc}"
+            display.error(msg)
+            raise RuntimeError(msg) from exc
+
+        # Validate required fields
+        if "test_suites" not in report_data:
+            msg = f"Missing 'test_suites' field in {filename}"
+            display.error(msg)
+            raise ValueError(msg)
+
+        return report_data
+
+    def _accumulate_report_stats(
+        self,
+        report_data: dict[str, Any],
+        merged_report: dict[str, Any],
+        filename: str,
+        display: Display,
+    ) -> None:
+        """Accumulate statistics from a report into the merged report."""
+        # Update numeric statistics directly in merged_report
+        for field in ["time", "tests", "failures", "errors", "skipped"]:
+            value = report_data.get(field, 0)
+            if value is not None:
+                try:
+                    if field == "time":
+                        merged_report[field] += float(value)
+                    else:
+                        merged_report[field] += int(value)
+                except (ValueError, TypeError) as e:
+                    msg = f"Invalid numeric data in {filename}: {e}"
+                    display.error(msg)
+                    raise ValueError(msg) from e
+
+        # Merge test suites
+        test_suites = report_data.get("test_suites", [])
+        if not isinstance(test_suites, list):
+            msg = f"Invalid 'test_suites' format in {filename}: expected list"
+            display.error(msg)
+            raise ValueError(msg)
+
+        merged_report["test_suites"].extend(test_suites)
+        msg = f"Successfully processed {filename}: {report_data.get('tests', 0)} tests"
+        display.vv(msg)

--- a/tests/unit/data/merged.junit.json
+++ b/tests/unit/data/merged.junit.json
@@ -1,5 +1,5 @@
 {
-    "time": 0.044,
+    "time": 0.044454510165527344,
     "tests": 5,
     "failures": 2,
     "errors": 0,
@@ -7,7 +7,7 @@
     "test_suites": [
         {
             "name": "Performance Addon Operator Reboot",
-            "time": 0.0,
+            "time": 0.000426228,
             "timestamp": "2024-12-12T20:12:23",
             "tests": 3,
             "failures": 0,
@@ -72,7 +72,7 @@
         },
         {
             "name": "dci-openshift-app-agent",
-            "time": 0.044,
+            "time": 0.044028282165527344,
             "timestamp": "1970-01-01T00:00:00",
             "tests": 2,
             "failures": 2,
@@ -86,6 +86,7 @@
                     "time": 0.026203,
                     "result": [
                         {
+                            "failure_type": "failure",
                             "message": "The following expectations failed: [{'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_sites_deployment_time', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_managedcluster_ztp_done_label', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_policies_compliant', 'passed': False}}]",
                             "text": "{\n\"changed\": false,\n\"msg\": \"The following expectations failed: [{'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_sites_deployment_time', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_managedcluster_ztp_done_label', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_policies_compliant', 'passed': False}}]\"\n}",
                             "status": "failure"
@@ -98,6 +99,7 @@
                     "time": 0.017825,
                     "result": [
                         {
+                            "failure_type": "failure",
                             "message": "Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/8b7e1fd4-9804-4abc-98c2-a9ecc39ba72c/jobStates",
                             "text": "{\n\"changed\": false,\n\"msg\": \"Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/8b7e1fd4-9804-4abc-98c2-a9ecc39ba72c/jobStates\"\n}",
                             "status": "failure"

--- a/tests/unit/data/test_reportsmerger_empty_result.json
+++ b/tests/unit/data/test_reportsmerger_empty_result.json
@@ -1,0 +1,10 @@
+{
+    "time": 0.0,
+    "tests": 0,
+    "failures": 0,
+    "errors": 0,
+    "skipped": 0,
+    "test_suites": [],
+    "schema_version": "1.0.0"
+}
+

--- a/tests/unit/data/test_reportsmerger_input1.json
+++ b/tests/unit/data/test_reportsmerger_input1.json
@@ -1,0 +1,48 @@
+{
+    "time": 1.5,
+    "tests": 5,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 2,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/tests/unit/data/test_reportsmerger_input2.json
+++ b/tests/unit/data/test_reportsmerger_input2.json
@@ -1,0 +1,59 @@
+{
+    "time": 2.0,
+    "tests": 3,
+    "failures": 0,
+    "errors": 1,
+    "skipped": 1,
+    "test_suites": [
+        {
+            "name": "Test Suite 2",
+            "time": 2.0,
+            "timestamp": "2024-12-12T20:15:30",
+            "tests": 3,
+            "failures": 0,
+            "errors": 1,
+            "skipped": 1,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "production"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 3",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "connection timeout",
+                            "status": "error"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 4",
+                    "classname": "TestClass2",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped due to environment",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 5",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "passed",
+                            "status": "passed"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/tests/unit/data/test_reportsmerger_invalid.json
+++ b/tests/unit/data/test_reportsmerger_invalid.json
@@ -1,0 +1,1 @@
+invalid json content

--- a/tests/unit/data/test_reportsmerger_missing_test_suites.json
+++ b/tests/unit/data/test_reportsmerger_missing_test_suites.json
@@ -1,0 +1,7 @@
+{
+    "time": 1.0,
+    "tests": 1,
+    "failures": 0,
+    "errors": 0,
+    "skipped": 0
+} 

--- a/tests/unit/data/test_reportsmerger_mixed_result.json
+++ b/tests/unit/data/test_reportsmerger_mixed_result.json
@@ -1,0 +1,20 @@
+{
+    "time": 2.5,
+    "tests": 3,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 1,
+    "test_suites": [
+        {
+            "name": "Valid Suite",
+            "time": 2.5,
+            "tests": 3,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 1,
+            "test_cases": []
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/tests/unit/data/test_reportsmerger_mixed_valid.json
+++ b/tests/unit/data/test_reportsmerger_mixed_valid.json
@@ -1,0 +1,19 @@
+{
+    "time": 2.5,
+    "tests": 3,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 1,
+    "test_suites": [
+        {
+            "name": "Valid Suite",
+            "time": 2.5,
+            "tests": 3,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 1,
+            "test_cases": []
+        }
+    ],
+    "schema_version": "1.0.0"
+} 

--- a/tests/unit/data/test_reportsmerger_multi_result.json
+++ b/tests/unit/data/test_reportsmerger_multi_result.json
@@ -1,0 +1,96 @@
+{
+    "time": 3.5,
+    "tests": 8,
+    "failures": 1,
+    "errors": 1,
+    "skipped": 3,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Test Suite 2",
+            "time": 2.0,
+            "timestamp": "2024-12-12T20:15:30",
+            "tests": 3,
+            "failures": 0,
+            "errors": 1,
+            "skipped": 1,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "production"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 3",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "connection timeout",
+                            "status": "error"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 4",
+                    "classname": "TestClass2",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped due to environment",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 5",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "passed",
+                            "status": "passed"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/tests/unit/data/test_reportsmerger_none_input.json
+++ b/tests/unit/data/test_reportsmerger_none_input.json
@@ -1,0 +1,34 @@
+{
+    "time": null,
+    "tests": null,
+    "failures": 1,
+    "errors": null,
+    "skipped": 0,
+    "test_suites": [
+        {
+            "name": "Test Suite with None Values",
+            "time": 1.0,
+            "timestamp": "2024-12-12T20:20:00",
+            "tests": 1,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {},
+            "test_cases": [
+                {
+                    "name": "Test Case with None parent",
+                    "classname": "TestClassNone",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "test failed",
+                            "status": "failure"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/tests/unit/data/test_reportsmerger_none_result.json
+++ b/tests/unit/data/test_reportsmerger_none_result.json
@@ -1,0 +1,34 @@
+{
+    "time": 0.0,
+    "tests": 0,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 0,
+    "test_suites": [
+        {
+            "name": "Test Suite with None Values",
+            "time": 1.0,
+            "timestamp": "2024-12-12T20:20:00",
+            "tests": 1,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {},
+            "test_cases": [
+                {
+                    "name": "Test Case with None parent",
+                    "classname": "TestClassNone",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "test failed",
+                            "status": "failure"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/tests/unit/data/test_reportsmerger_single_result.json
+++ b/tests/unit/data/test_reportsmerger_single_result.json
@@ -1,0 +1,48 @@
+{
+    "time": 1.5,
+    "tests": 5,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 2,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/tests/unit/filter/test_reportsmerger.py
+++ b/tests/unit/filter/test_reportsmerger.py
@@ -1,0 +1,177 @@
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+# TODO: reconcile current data conversion and pass it using the CI
+from ansible_collections.redhatci.ocp.plugins.filter import reportsmerger
+
+
+@pytest.fixture
+def input_data(request):  # type: ignore
+    file_path: str = str(request.param)  # type: ignore
+    with open(file_path, "r") as fd:
+        return json.loads(fd.read())
+
+
+@pytest.fixture
+def expected_data_object(request):  # type: ignore
+    file_path: str = str(request.param)  # type: ignore
+    with open(file_path, "r") as fd:
+        return json.loads(fd.read())
+
+
+@pytest.mark.parametrize(
+    "input_files,expected_data_object",
+    [
+        # Single file test
+        (
+            [
+                "tests/unit/data/test_reportsmerger_input1.json",
+            ],
+            "tests/unit/data/test_reportsmerger_single_result.json",
+        ),
+        # Multiple files test
+        (
+            [
+                "tests/unit/data/test_reportsmerger_input1.json",
+                "tests/unit/data/test_reportsmerger_input2.json",
+            ],
+            "tests/unit/data/test_reportsmerger_multi_result.json",
+        ),
+        # None values test
+        (
+            [
+                "tests/unit/data/test_reportsmerger_none_input.json",
+            ],
+            "tests/unit/data/test_reportsmerger_none_result.json",
+        ),
+        # Mixed existing files test (valid files only, ignoring missing ones)
+        (
+            [
+                "tests/unit/data/test_reportsmerger_mixed_valid.json",
+            ],
+            "tests/unit/data/test_reportsmerger_mixed_result.json",
+        ),
+    ],
+    indirect=["expected_data_object"],
+)
+def test_reportsmerger_with_static_data(input_files, expected_data_object):  # type: ignore
+    """Test reportsmerger filter with static test data files"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Test the filter with the input files
+    actual = filter_plugin.filters()["reportsmerger"](input_files)  # type: ignore
+
+    # Compare with expected result
+    assert expected_data_object == actual
+
+
+def test_reportsmerger_empty_list():
+    """Test error handling for empty file list"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    with pytest.raises(ValueError, match="requires at least one filename"):
+        filter_plugin.filters()["reportsmerger"]([])
+
+
+def test_reportsmerger_invalid_input():
+    """Test error handling for non-list input"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    with pytest.raises(TypeError, match="expects a list of filenames"):
+        filter_plugin.filters()["reportsmerger"]("not_a_list")
+
+
+def test_reportsmerger_missing_file():
+    """Test handling of missing files (should emit warning and skip)"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    expected_data: str = "tests/unit/data/test_reportsmerger_empty_result.json"
+    # Load expected empty result from static file
+    with open(expected_data, "r") as f:
+        expected_result = json.load(f)
+
+    # Mock the Display class to capture warning calls
+    with patch('ansible_collections.redhatci.ocp.plugins.filter.reportsmerger.Display') as mock_display_class:
+        mock_display = MagicMock()
+        mock_display_class.return_value = mock_display
+
+        fname: str = "nonexistent_file.json"
+        # Test with only missing files - should return empty result
+        result = filter_plugin.filters()["reportsmerger"]([fname])
+
+        # Verify warning was called with correct message
+        mock_display.warning.assert_called_once_with(
+            f"reportsmerger plugin: file {fname} does not exist and was skipped"
+        )
+
+    # Compare with expected result from static file
+    assert expected_result == result
+
+
+def test_reportsmerger_mixed_existing_missing_files():
+    """Test handling of mix of existing and missing files"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static test data files
+    valid_file: str = "tests/unit/data/test_reportsmerger_mixed_valid.json"
+    expected_data: str = "tests/unit/data/test_reportsmerger_mixed_result.json"
+    # Load expected result from static file
+    with open(expected_data, "r") as f:
+        expected_result = json.load(f)
+
+    # Mock the Display class to capture warning calls
+    with patch('ansible_collections.redhatci.ocp.plugins.filter.reportsmerger.Display') as mock_display_class:
+        mock_display = MagicMock()
+        mock_display_class.return_value = mock_display
+        fname = "nonexistent"
+        missing_files_list = [f"{fname}{i}.json" for i in range(1, 3)]
+        files_list = missing_files_list + [valid_file]
+        # Test with mix of existing and missing files
+        result = filter_plugin.filters()["reportsmerger"](files_list)
+        # Verify warnings were called for missing files
+        expected_warnings = [f"reportsmerger plugin: file {f} does not exist and was skipped" for f in missing_files_list]
+
+        assert mock_display.warning.call_count == len(missing_files_list)
+        actual_warning_calls = [call[0][0] for call in mock_display.warning.call_args_list]
+        assert actual_warning_calls == expected_warnings
+
+    # Compare with expected result from static file
+    assert expected_result == result
+
+
+def test_reportsmerger_invalid_json():
+    """Test error handling for invalid JSON"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static invalid JSON file
+    test_file: str = "tests/unit/data/test_reportsmerger_invalid.json"
+
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        filter_plugin.filters()["reportsmerger"]([test_file])
+
+
+def test_reportsmerger_missing_test_suites():
+    """Test error handling for missing test_suites field"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static file with missing test_suites field
+    test_file: str = "tests/unit/data/test_reportsmerger_missing_test_suites.json"
+
+    with pytest.raises(ValueError, match="Missing 'test_suites' field"):
+        filter_plugin.filters()["reportsmerger"]([test_file])

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,5 +1,6 @@
+jmespath
 junit_xml
 junitparser
-jmespath
+lxml
 python-dateutil
 semver


### PR DESCRIPTION
##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->
implements json merging for test reports
part of obsoletion of `junitparser`.

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change
- New or Enhanced Feature

##### Tests

unit tests under `tests/units/filter`

<!-- Document the tests for this change, if any -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

<!-- Examples:
- [ ] TestDallas: ocp-4.17-vanilla - <JobURL>
- [ ] TestDallasHybrid: ocp-4.17-vanilla-hybrid - <JobURL>
- [ ] TestDallasWorkload: preflight-green - <JobURL>
- [ ] TestBos2: virt - <JobURL>
- [ ] TestBos2Sno: sno - <JobURL>
- [ ] TestBos2SnoBaremetal: sno - <JobURL>
-->

---

<!-- Include the test and dependencies for this change -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

