### PR TITLE
add role `redhatci.ocp.report_metadata_gen`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,10 @@
 # verification team
 /roles/jenkins_job_launcher          @redhatci/verification
 /roles/junit2json                    @redhatci/verification
+/roles/report_metadata_gen           @redhatci/verification
+/plugins/filter                      @redhatci/verification @redhatci/dci
+/tests/unit/filter                   @redhatci/verification @redhatci/dci
+/tests/unit/data                     @redhatci/verification @redhatci/dci
 
 # platform team
 /roles/sideload_kernel               @redhatci/platform

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Name | Description
 [redhatci.ocp.pyxis](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/pyxis/README.md) | Interacts with Pyxis API to submit Preflight certification results
 [redhatci.ocp.redhat_tests](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/redhat_tests/README.md) | [Openshift End to End tests](https://github.com/openshift/openshift-tests)
 [redhatci.ocp.remove_ztp_gitops_resources](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/remove_ztp_gitops_resources/README.md) | Remove all GitOps related resources for a given spoke cluster, excepting the cluster namespace, which is not deleted because this will imply the spoke cluster is detached from the hub cluster.
+[redhatci.ocp.report_metadata_gen](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/report_metadata_gen/README.md) | Generates metadata from running CI job to be consumed by [redhatci.ocp.report_combine](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/report_combine/README.md)
 [redhatci.ocp.resources_to_components](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/resources_to_components/README.md) | Creates DCI components based on Kubernetes resources
 [redhatci.ocp.rhoai](roles/rhoai/README.md) | Install the Red Hat OpenShift AI operators
 [redhatci.ocp.setup_gitea](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_gitea/README.md) | Deployment of [Gitea](https://about.gitea.com)

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        2.7.EPOCH
+Version:        2.9.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -29,6 +29,7 @@ Requires: podman
 Requires: python3-jmespath
 Requires: python3-netaddr
 Requires: python3-pyyaml
+Requires: python3-lxml
 Requires: skopeo
 Conflicts: dci-openshift-agent < 1.1.0
 
@@ -54,6 +55,10 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Wed Jul 16 2025 Max Kovgan <makovgan@redhat.com> - 2.9.EPOCH-VERS
+- upd collection metadata
+- add role redhatci.ocp.report_metadata_gen
+
 * Fri Jul 11 2025 Beto Rdz <josearod@redhat.com> - 2.7.EPOCH-VERS
 - Changes in deploy_cr
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ocp
 # Always leave patch version as .0
 # Patch version is replaced from commit date in UNIX epoch format
 # example: 1.3.2147483647
-version: 2.7.0
+version: 2.9.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/report_metadata_gen/README.md
+++ b/roles/report_metadata_gen/README.md
@@ -1,0 +1,279 @@
+<!-- DOCSIBLE START -->
+
+# 📃 Role overview
+
+## report_metadata_gen
+
+
+
+Description: Role to generate CI metadata for test reporting
+
+
+
+
+
+
+
+
+
+### Defaults
+
+**These are static variables with lower priority**
+
+#### File: defaults/main.yml
+
+| Var          | Type         | Value       |Required    | Title       |
+|--------------|--------------|-------------|-------------|-------------|
+| [rmg_ci_system](defaults/main.yml#L6)   | str   | `unknown` |    n/a  |  n/a |
+| [rmg_ci_system_autodetect](defaults/main.yml#L7)   | bool   | `True` |    n/a  |  n/a |
+| [rmg_ci_systems_supported](defaults/main.yml#L10)   | list   | `['dci', 'jenkins', 'unknown']` |    n/a  |  n/a |
+| [rmg_metadata_output_path](defaults/main.yml#L16)   | str   | `{{ playbook_dir }}/metadata.json` |    n/a  |  n/a |
+| [rmg_metadata_output_format](defaults/main.yml#L17)   | str   | `json` |    n/a  |  n/a |
+| [rmg_default_ts](defaults/main.yml#L20)   | str   | `{{ now(fmt='%Y-%m-%dT%H:%M:%S') }}` |    n/a  |  n/a |
+| [rmg_debug](defaults/main.yml#L23)   | bool   | `False` |    n/a  |  n/a |
+| [rmg_ci_runtime](defaults/main.yml#L26)   | dict   | `{}` |    n/a  |  n/a |
+| [rmg_meta_data](defaults/main.yml#L27)   | dict   | `{}` |    n/a  |  n/a |
+| [rmg_existing_metadata](defaults/main.yml#L30)   | dict   | `{}` |    n/a  |  n/a |
+
+
+
+
+
+### Tasks
+
+
+#### File: tasks/env2vars-populate.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Include env2vars variable for {{ rmg_ci_system }} | ansible.builtin.include_vars | False |
+| Set facts from environment variables into rmg_vars_dict | ansible.builtin.set_fact | True |
+
+#### File: tasks/ci-detect.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Recognize rmg_ci_system as DCI | ansible.builtin.set_fact | True |
+| Recognize rmg_ci_system as Jenkins | ansible.builtin.set_fact | True |
+| Validating rmg_ci_system is supported | ansible.builtin.assert | False |
+
+#### File: tasks/main.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Initialize metadata with existing data | ansible.builtin.set_fact | False |
+| Initialize rmg_ci_runtime | ansible.builtin.set_fact | False |
+| CI system auto-detection | ansible.builtin.include_tasks | True |
+| Validate CI system is supported | ansible.builtin.assert | False |
+| Include variables for {{ rmg_ci_system }} | ansible.builtin.include_vars | True |
+| Detect dynamic metadata from environment | ansible.builtin.include_tasks | True |
+| Generate CI-specific metadata | ansible.builtin.include_tasks | False |
+| Print generated metadata | ansible.builtin.debug | True |
+| Update metadata with runtime data | ansible.builtin.set_fact | False |
+| Write metadata to output file | ansible.builtin.copy | True |
+
+#### File: tasks/ci-metadata/jenkins.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Update is_ci in rmg_ci_runtime attribute for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Update helper variables for ci attributes for {{ trs_ci_system }} | ansible.builtin.set_fact | False |
+| Update helper variables for ci attributes for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Update helper variables for ci_runner attributes for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Update helper variables for rmg_ci_runtime attributes for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Update helper variables for job attributes for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Update helper variables for source attributes for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Update helper variables for source_change attributes for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Update helper variables for source attributes for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Construct the final rmg_ci_runtime metadata dictionary for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+
+#### File: tasks/ci-metadata/dci.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Set is_ci attribute | ansible.builtin.set_fact | True |
+| Update rmg_ci_runtime.type for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Update rmg_ci_runtime.url for {{ rmg_ci_system }} | ansible.builtin.set_fact | False |
+| Print rmg_meta_data (Before squash of metadata key) | ansible.builtin.debug | False |
+| Update ci in metadata | ansible.builtin.set_fact | False |
+| Merge "metadata" into root rmg_meta_data | ansible.builtin.set_fact | True |
+| Print rmg_meta_data (AFTER squash of metadata key) | ansible.builtin.debug | False |
+| Delete rmg_meta_data key "metadata" | ansible.builtin.set_fact | True |
+| Print rmg_meta_data (AFTER deleting of metadata key) | ansible.builtin.debug | False |
+
+#### File: tasks/ci-metadata/unknown.yml
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Unsupported CI system | ansible.builtin.debug | False |
+| Fail for unsupported CI system | ansible.builtin.fail | False |
+
+
+## Task Flow Graphs
+
+
+
+### Graph for env2vars-populate.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Include vars| ___role_path____vars_env2vars0[include env2vars variable for rmg ci system<br>include_vars:    role path    vars env2vars]:::includeVars
+  ___role_path____vars_env2vars0-->|Task| Set_facts_from_environment_variables_into_rmg_vars_dict1[set facts from environment variables into rmg vars<br>dict<br>When: **env2vars   default       length   0**]:::task
+  Set_facts_from_environment_variables_into_rmg_vars_dict1-->End
+```
+
+
+### Graph for ci-detect.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Recognize_rmg_ci_system_as_DCI0[recognize rmg ci system as dci<br>When: **rmg ci system     unknown  and lookup  env    dci<br>cs url     length   0**]:::task
+  Recognize_rmg_ci_system_as_DCI0-->|Task| Recognize_rmg_ci_system_as_Jenkins1[recognize rmg ci system as jenkins<br>When: **rmg ci system     unknown  and lookup  env   <br>jenkins url     length   0**]:::task
+  Recognize_rmg_ci_system_as_Jenkins1-->|Task| Validating_rmg_ci_system_is_supported2[validating rmg ci system is supported]:::task
+  Validating_rmg_ci_system_is_supported2-->End
+```
+
+
+### Graph for main.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Initialize_metadata_with_existing_data0[initialize metadata with existing data]:::task
+  Initialize_metadata_with_existing_data0-->|Task| Initialize_rmg_ci_runtime1[initialize rmg ci runtime]:::task
+  Initialize_rmg_ci_runtime1-->|Include task| ci_detect_yml2[ci system auto detection<br>When: **rmg ci system autodetect**<br>include_task: ci detect yml]:::includeTasks
+  ci_detect_yml2-->|Task| Validate_CI_system_is_supported3[validate ci system is supported]:::task
+  Validate_CI_system_is_supported3-->|Include vars| vars4[include variables for rmg ci system<br>When: **rmg ci system     unknown**<br>include_vars: vars]:::includeVars
+  vars4-->|Include task| env2vars_populate_yml5[detect dynamic metadata from environment<br>When: **rmg ci system     unknown**<br>include_task: env2vars populate yml]:::includeTasks
+  env2vars_populate_yml5-->|Include task| ci_metadata____rmg_ci_system____yml6[generate ci specific metadata<br>include_task: ci metadata    rmg ci system    yml]:::includeTasks
+  ci_metadata____rmg_ci_system____yml6-->|Task| Print_generated_metadata7[print generated metadata<br>When: **rmg debug**]:::task
+  Print_generated_metadata7-->|Task| Update_metadata_with_runtime_data8[update metadata with runtime data]:::task
+  Update_metadata_with_runtime_data8-->|Task| Write_metadata_to_output_file9[write metadata to output file<br>When: **rmg metadata output path   length   0**]:::task
+  Write_metadata_to_output_file9-->End
+```
+
+
+### Graph for ci-metadata/jenkins.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Update_is_ci_in_rmg_ci_runtime_attribute_for_rmg_ci_system0[update is ci in rmg ci runtime attribute for rmg<br>ci system]:::task
+  Update_is_ci_in_rmg_ci_runtime_attribute_for_rmg_ci_system0-->|Task| Update_helper_variables_for_ci_attributes_for_trs_ci_system1[update helper variables for ci attributes for trs<br>ci system]:::task
+  Update_helper_variables_for_ci_attributes_for_trs_ci_system1-->|Task| Update_helper_variables_for_ci_attributes_for_rmg_ci_system2[update helper variables for ci attributes for rmg<br>ci system]:::task
+  Update_helper_variables_for_ci_attributes_for_rmg_ci_system2-->|Task| Update_helper_variables_for_ci_runner_attributes_for_rmg_ci_system3[update helper variables for ci runner attributes<br>for rmg ci system]:::task
+  Update_helper_variables_for_ci_runner_attributes_for_rmg_ci_system3-->|Task| Update_helper_variables_for_rmg_ci_runtime_attributes_for_rmg_ci_system4[update helper variables for rmg ci runtime<br>attributes for rmg ci system]:::task
+  Update_helper_variables_for_rmg_ci_runtime_attributes_for_rmg_ci_system4-->|Task| Update_helper_variables_for_job_attributes_for_rmg_ci_system5[update helper variables for job attributes for rmg<br>ci system]:::task
+  Update_helper_variables_for_job_attributes_for_rmg_ci_system5-->|Task| Update_helper_variables_for_source_attributes_for_rmg_ci_system6[update helper variables for source attributes for<br>rmg ci system]:::task
+  Update_helper_variables_for_source_attributes_for_rmg_ci_system6-->|Task| Update_helper_variables_for_source_change_attributes_for_rmg_ci_system7[update helper variables for source change<br>attributes for rmg ci system]:::task
+  Update_helper_variables_for_source_change_attributes_for_rmg_ci_system7-->|Task| Update_helper_variables_for_source_attributes_for_rmg_ci_system8[update helper variables for source attributes for<br>rmg ci system]:::task
+  Update_helper_variables_for_source_attributes_for_rmg_ci_system8-->|Task| Construct_the_final_rmg_ci_runtime_metadata_dictionary_for_rmg_ci_system9[construct the final rmg ci runtime metadata<br>dictionary for rmg ci system]:::task
+  Construct_the_final_rmg_ci_runtime_metadata_dictionary_for_rmg_ci_system9-->End
+```
+
+
+### Graph for ci-metadata/dci.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Set_is_ci_attribute0[set is ci attribute<br>When: **lookup  env   ci     lower     true  and lookup <br>env   dci cs url   is defined**]:::task
+  Set_is_ci_attribute0-->|Task| Update_rmg_ci_runtime_type_for_rmg_ci_system1[update rmg ci runtime type for rmg ci system]:::task
+  Update_rmg_ci_runtime_type_for_rmg_ci_system1-->|Task| Update_rmg_ci_runtime_url_for_rmg_ci_system2[update rmg ci runtime url for rmg ci system]:::task
+  Update_rmg_ci_runtime_url_for_rmg_ci_system2-->|Task| Print_rmg_meta_data__Before_squash_of_metadata_key_3[print rmg meta data  before squash of metadata key<br>]:::task
+  Print_rmg_meta_data__Before_squash_of_metadata_key_3-->|Task| Update_ci_in_metadata4[update ci in metadata]:::task
+  Update_ci_in_metadata4-->|Task| Merge__metadata__into_root_rmg_meta_data5[merge  metadata  into root rmg meta data<br>When: **rmg meta data   length   0 and   metadata  in rmg<br>meta data keys    and rmg meta data metadata  <br>length   0**]:::task
+  Merge__metadata__into_root_rmg_meta_data5-->|Task| Print_rmg_meta_data__AFTER_squash_of_metadata_key_6[print rmg meta data  after squash of metadata key ]:::task
+  Print_rmg_meta_data__AFTER_squash_of_metadata_key_6-->|Task| Delete_rmg_meta_data_key__metadata_7[delete rmg meta data key  metadata <br>When: **rmg meta data   length   0 and   metadata  in rmg<br>meta data keys    and rmg meta data metadata  <br>length   0**]:::task
+  Delete_rmg_meta_data_key__metadata_7-->|Task| Print_rmg_meta_data__AFTER_deleting_of_metadata_key_8[print rmg meta data  after deleting of metadata<br>key ]:::task
+  Print_rmg_meta_data__AFTER_deleting_of_metadata_key_8-->End
+```
+
+
+### Graph for ci-metadata/unknown.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Unsupported_CI_system0[unsupported ci system]:::task
+  Unsupported_CI_system0-->|Task| Fail_for_unsupported_CI_system1[fail for unsupported ci system]:::task
+  Fail_for_unsupported_CI_system1-->End
+```
+
+
+
+
+
+## Author Information
+Red Hat CI
+
+#### License
+
+Apache-2.0
+
+#### Minimum Ansible Version
+
+2.14
+
+#### Platforms
+
+- **EL**: ['8', '9']
+- **Fedora**: ['37', '38', '39']
+
+<!-- DOCSIBLE END -->

--- a/roles/report_metadata_gen/defaults/main.yml
+++ b/roles/report_metadata_gen/defaults/main.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# defaults file for redhatci.ocp.report_metadata_gen
+
+# CI system detection
+rmg_ci_system: unknown
+rmg_ci_system_autodetect: true
+
+# Supported CI systems
+rmg_ci_systems_supported:
+  - dci
+  - jenkins
+  - unknown
+
+# Output configuration
+rmg_metadata_output_path: "{{ playbook_dir }}/metadata.json"
+rmg_metadata_output_format: json
+
+# Default timestamp
+rmg_default_ts: "{{ now(fmt='%Y-%m-%dT%H:%M:%S') }}"
+
+# Debug
+rmg_debug: false
+
+# Runtime metadata (populated by the role)
+rmg_ci_runtime: {}
+rmg_meta_data: {}
+
+# Existing metadata to merge (optional)
+rmg_existing_metadata: {}

--- a/roles/report_metadata_gen/meta/argument_specs.yml
+++ b/roles/report_metadata_gen/meta/argument_specs.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# argument_specs file for redhatci.ocp.report_metadata_gen
+argument_specs:
+  main:
+    short_description: Generate CI metadata for test reporting
+    description: |
+      This role detects the CI system from environment variables and generates
+      structured metadata for test reporting. It supports DCI, Jenkins, and other
+      CI systems.
+    options:
+      rmg_ci_system:
+        description: CI system type (auto-detected if not specified)
+        type: str
+        required: false
+        default: "unknown"
+        choices: ["dci", "jenkins", "unknown"]
+      rmg_ci_system_autodetect:
+        description: Enable automatic CI system detection
+        type: bool
+        required: false
+        default: true
+      rmg_metadata_output_path:
+        description: Path where to save the generated metadata JSON file
+        type: str
+        required: false
+        default: "{{ playbook_dir }}/metadata.json"
+      rmg_existing_metadata:
+        description: Existing metadata to merge with generated data
+        type: dict
+        required: false
+        default: {}
+      rmg_debug:
+        description: Enable debug output
+        type: bool
+        required: false
+        default: false

--- a/roles/report_metadata_gen/meta/main.yml
+++ b/roles/report_metadata_gen/meta/main.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# meta file for redhatci.ocp.report_metadata_gen
+
+galaxy_info:
+  author: Red Hat CI
+  description: Role to generate CI metadata for test reporting
+  company: Red Hat
+  license: Apache-2.0
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Fedora
+      versions:
+        - "37"
+        - "38"
+        - "39"
+  galaxy_tags:
+    - testing
+    - reporting
+    - metadata
+    - ci
+    - dci
+    - jenkins
+
+dependencies: []

--- a/roles/report_metadata_gen/tasks/ci-detect.yml
+++ b/roles/report_metadata_gen/tasks/ci-detect.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# CI detection tasks for redhatci.ocp.test_report_send
+
+- name: Recognize rmg_ci_system as DCI
+  ansible.builtin.set_fact:
+    rmg_ci_system: dci
+  when:
+    - rmg_ci_system == "unknown"
+    - lookup("env", "DCI_CS_URL") | length > 0
+
+- name: Recognize rmg_ci_system as Jenkins
+  ansible.builtin.set_fact:
+    rmg_ci_system: jenkins
+  when:
+    - rmg_ci_system == "unknown"
+    - lookup("env", "JENKINS_URL") | length > 0
+
+- name: Validating rmg_ci_system is supported
+  ansible.builtin.assert:
+    that: "{{ condition }}"
+    fail_msg: "Assertion failed: {{ condition }}"
+  loop:
+    - rmg_ci_system != "unknown"
+    - rmg_ci_system in rmg_ci_systems_supported
+  loop_control:
+    loop_var: condition

--- a/roles/report_metadata_gen/tasks/ci-metadata/dci.yml
+++ b/roles/report_metadata_gen/tasks/ci-metadata/dci.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# DCI metadata detection tasks for redhatci.ocp.test_report_send
+
+- name: Set is_ci attribute
+  ansible.builtin.set_fact:
+    rmg_ci_runtime: "{{ rmg_ci_runtime | combine({'is_ci': true}) }}"
+  when:
+    - lookup("env","CI") | lower == "true"
+    - lookup("env","DCI_CS_URL") is defined
+
+- name: Update rmg_ci_runtime.type for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    ci: "{{ ci | default({}) | combine({'type': rmg_ci_system}) }}"
+
+- name: Update rmg_ci_runtime.url for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    ci: "{{ ci | combine({'url': lookup('env', 'DCI_CS_URL')}) }}"
+
+- name: Print rmg_meta_data (Before squash of metadata key)
+  ansible.builtin.debug:
+    var: rmg_meta_data
+
+- name: Update ci in metadata
+  ansible.builtin.set_fact:
+    rmg_meta_data: "{{ rmg_meta_data | combine({'metadata': rmg_meta_data.metadata | combine({'ci': ci})}) }}"
+
+- name: Merge "metadata" into root rmg_meta_data
+  ansible.builtin.set_fact:
+    rmg_meta_data: "{{ rmg_meta_data | combine(rmg_meta_data.metadata) }}"
+  when:
+    - rmg_meta_data | length > 0
+    - ("metadata" in rmg_meta_data.keys())
+    - rmg_meta_data.metadata | length > 0
+
+- name: Print rmg_meta_data (AFTER squash of metadata key)
+  ansible.builtin.debug:
+    var: rmg_meta_data
+
+- name: Delete rmg_meta_data key "metadata"
+  ansible.builtin.set_fact:
+    rmg_meta_data: "{{ rmg_meta_data | combine({'metadata': omit}) }}"
+  when:
+    - rmg_meta_data | length > 0
+    - ("metadata" in rmg_meta_data.keys())
+    - rmg_meta_data.metadata | length > 0
+
+- name: Print rmg_meta_data (AFTER deleting of metadata key)
+  ansible.builtin.debug:
+    var: rmg_meta_data

--- a/roles/report_metadata_gen/tasks/ci-metadata/jenkins.yml
+++ b/roles/report_metadata_gen/tasks/ci-metadata/jenkins.yml
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Jenkins metadata detection tasks for redhatci.ocp.test_report_send
+
+- name: Update is_ci in rmg_ci_runtime attribute for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    rmg_ci_runtime: "{{ rmg_ci_runtime | combine({'is_ci': true}) }}"
+
+- name: Update helper variables for ci attributes for {{ trs_ci_system }}
+  ansible.builtin.set_fact:
+    ci:
+      runner: "{{ trs_vars_dict.ci_runner_labels | default({}) }}"
+
+
+- name: Update helper variables for ci attributes for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    ci: "{{ ci | combine({item.key: item.value}) }}"
+  loop:
+    - key: type
+      value: "{{ rmg_ci_system }}"
+    - key: url
+      value: "{{ rmg_vars_dict.ci_url | default('') }}"
+
+- name: Update helper variables for ci_runner attributes for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    ci_runner: "{{ ci_runner | default({}) | combine({item.key: item.value}) }}"
+  loop:
+    - key: name
+      value: "{{ rmg_vars_dict.ci_runner_name | default('') }}"
+    - key: executor
+      value: "{{ rmg_vars_dict.ci_runner_id | default('') }}"
+
+- name: Update helper variables for rmg_ci_runtime attributes for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    ci: "{{ ci | combine({'runner': ci.runner | combine(ci_runner | default({}), recursive=True)}, recursive=True) }}"
+    pipeline: {} # TODO: support populating `pipeline` by parent jobs that triggered this job
+
+## job
+- name: Update helper variables for job attributes for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    job: "{{ job | default({}) | combine({item.key: item.value}) }}"
+  loop:
+    - key: name
+      value: "{{ rmg_vars_dict.job_name | default('') }}"
+    - key: url
+      value: "{{ rmg_vars_dict.job_url | default('') }}"
+    - key: build
+      value: "{{ rmg_vars_dict.job_build | default(rmg_vars_dict.job_build_id | default('')) }}"
+    - key: build_url
+      value: "{{ rmg_vars_dict.job_build_url | default('') }}"
+      # value The cause of the build.
+    - key: cause
+      value: "{{ rmg_vars_dict.job_build_cause | default([]) | list }}"
+
+## source info
+- name: Update helper variables for source attributes for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    source: "{{ source | default({}) | combine({item.key: item.value}) }}"
+  loop:
+    - key: repo_url
+      value: "{{ rmg_vars_dict.source_repo_url | default('') }}"
+    - key: ref
+      value: "{{ rmg_vars_dict.source_ref | default('') }}"
+    - key: ref_type
+      value: "{{ 'tag' if (rmg_vars_dict.source_ref_type | default('')) != '' else 'branch' }}"
+    - key: ref_name
+      value: "{{ rmg_vars_dict.source_ref_name | default('') }}"
+    - key: sha
+      value: "{{ rmg_vars_dict.source_sha | default('') }}"
+    - key: change_url
+      value: "{{ rmg_vars_dict.source_change_url | default('') }}"
+    - key: actor
+      value: "{{ rmg_vars_dict.source_change_author | default('') }}"
+    - key: actor_name
+      value: "{{ rmg_vars_dict.source_change_author_name | default('') }}"
+    - key: server_url
+      value: "{{ rmg_vars_dict.source_ci_server_url | default('') }}"
+    - key: owner
+      value: "{{ rmg_vars_dict.source_owner | default('') }}"
+    - key: repo
+      value: "{{ rmg_vars_dict.source_repo | default('') }}"
+    - key: repo_path
+      value: "{{ rmg_vars_dict.source_repo_path | default('') }}"
+    - key: event_payload
+      value: "{{ {} }}"
+
+
+## source change info: Merge Request (MR) or Pull Request (PR) or ChangeId (cId))
+- name: Update helper variables for source_change attributes for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    source_change: "{{ source_change | default({}) | combine({item.key: item.value}) }}"
+  loop:
+    - key: number
+      value: "{{ rmg_vars_dict.source_change_id | default('') }}"
+    - key: base_ref
+      value: "{{ rmg_vars_dict.source_change_base_ref | default('') }}"
+    - key: head_ref
+      value: "{{ rmg_vars_dict.source_change_head_ref | default('') }}"
+
+## stage 2 merges
+- name: Update helper variables for source attributes for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    source: "{{ source | default({}) | combine({'change': source_change}) }}"
+
+- name: Construct the final rmg_ci_runtime metadata dictionary for {{ rmg_ci_system }}
+  ansible.builtin.set_fact:
+    rmg_ci_runtime: "{{ rmg_ci_runtime | combine({item.key: item.value}) }}"
+  loop:
+    - key: ci
+      value: "{{ ci }}"
+    - key: pipeline
+      value: "{{ pipeline }}"
+    - key: job
+      value: "{{ job }}" # Now _job_info contains current job details and peer_jobs array
+    - key: source
+      value: "{{ source }}"

--- a/roles/report_metadata_gen/tasks/ci-metadata/unknown.yml
+++ b/roles/report_metadata_gen/tasks/ci-metadata/unknown.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Unknown CI system stub tasks for redhatci.ocp.test_report_send
+
+- name: Unsupported CI system
+  ansible.builtin.debug:
+    msg: "unsupported CI system"
+
+- name: Fail for unsupported CI system
+  ansible.builtin.fail:
+    msg: "Unsupported CI system: {{ rmg_ci_system }}"

--- a/roles/report_metadata_gen/tasks/empty.yml
+++ b/roles/report_metadata_gen/tasks/empty.yml
@@ -1,0 +1,2 @@
+---
+# no tasks here

--- a/roles/report_metadata_gen/tasks/env2vars-populate.yml
+++ b/roles/report_metadata_gen/tasks/env2vars-populate.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Include env2vars variable for {{ rmg_ci_system }}
+  ansible.builtin.include_vars:
+    dir: "{{ role_path }}/vars/env2vars"
+    files_matching: "{{ rmg_ci_system }}.yml"
+
+- name: Set facts from environment variables into rmg_vars_dict
+  ansible.builtin.set_fact:
+    rmg_vars_dict: "{{ rmg_vars_dict | default({}) | combine({(item.key): processed_value}) }}"
+  vars:
+    processed_value: "{{ lookup('template', role_path ~ '/templates/env2vars.j2') }}"
+  loop: "{{ env2vars }}"
+  when:
+    - env2vars | default({}) | length > 0

--- a/roles/report_metadata_gen/tasks/main.yml
+++ b/roles/report_metadata_gen/tasks/main.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# tasks file for redhatci.ocp.report_metadata_gen
+
+- name: Initialize metadata with existing data
+  ansible.builtin.set_fact:
+    rmg_meta_data: "{{ rmg_existing_metadata | default({}) }}"
+
+- name: Initialize rmg_ci_runtime
+  ansible.builtin.set_fact:
+    rmg_ci_runtime: {}
+
+- name: CI system auto-detection
+  ansible.builtin.include_tasks: "ci-detect.yml"
+  when:
+    - rmg_ci_system_autodetect
+
+- name: Validate CI system is supported
+  ansible.builtin.assert:
+    that:
+      - rmg_ci_system in rmg_ci_systems_supported
+    fail_msg: "Unsupported CI system: {{ rmg_ci_system }}"
+
+- name: Include variables for {{ rmg_ci_system }}
+  ansible.builtin.include_vars:
+    dir: vars
+    files_matching: "{{ rmg_ci_system }}.yml"
+    name: "{{ rmg_ci_system }}"
+  when:
+    - rmg_ci_system != "unknown"
+
+- name: Detect dynamic metadata from environment
+  ansible.builtin.include_tasks: "env2vars-populate.yml"
+  when:
+    - rmg_ci_system != "unknown"
+
+- name: Generate CI-specific metadata
+  ansible.builtin.include_tasks: "ci-metadata/{{ rmg_ci_system }}.yml"
+
+- name: Print generated metadata
+  ansible.builtin.debug:
+    var: rmg_ci_runtime
+  when:
+    - rmg_debug
+
+- name: Update metadata with runtime data
+  ansible.builtin.set_fact:
+    rmg_meta_data: "{{ rmg_meta_data | combine(rmg_ci_runtime) }}"
+
+- name: Write metadata to output file
+  ansible.builtin.copy:
+    content: "{{ rmg_meta_data | to_nice_json }}"
+    dest: "{{ rmg_metadata_output_path }}"
+    mode: '0644'
+  when:
+    - rmg_metadata_output_path | length > 0

--- a/roles/report_metadata_gen/templates/env2vars.j2
+++ b/roles/report_metadata_gen/templates/env2vars.j2
@@ -1,0 +1,34 @@
+{%- set env_value = lookup('env', item.var, default='') -%}
+{%- if 'var_type' in item and item.var_type == 'list' -%}
+  {%- set splitter = (item.splitter | default([' ']) | first) -%}
+  {{ env_value.split(splitter) if env_value != '' else [] }}
+{%- elif 'var_type' in item and item.var_type == 'dict' -%}
+  {%- set outer = (item.splitter | default([' ', ':']) | first) -%}
+  {%- set inner = (item.splitter | default([' ', ':']) | last) -%}
+  {%- set temp_dict = {} -%}
+  {%- if env_value is defined and env_value != '' -%}
+    {%- for pair in env_value.split(outer) -%}
+      {%- set parts = pair.split(inner) -%}
+      {%- if parts | length == 2 -%}
+        {%- set d_key = parts[0] | trim(chars='\n') -%}
+        {%- set d_val = parts[1] | trim(chars='\n') -%}
+        {%- if d_key in temp_dict -%}
+          {%- if temp_dict[d_key] is string -%}
+            {%- set _ = temp_dict.update({d_key: [temp_dict[d_key], d_val]}) -%}
+          {%- elif temp_dict[d_key] is iterable -%}
+            {%- set _ = temp_dict.update({d_key: temp_dict[d_key] + [d_val]}) -%}
+          {%- endif -%}
+        {%- else -%}
+          {%- set _ = temp_dict.update({d_key: d_val}) -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+  {{ temp_dict }}
+{%- elif 'var_type' in item and item.var_type == 'int' -%}
+  {{ env_value | trim(chars='\n') | int if env_value is defined and env_value != '' else 0 }}
+{%- elif 'var_type' in item and item.var_type == 'bool' -%}
+  {{ env_value | trim(chars='\n') | bool if env_value is defined and env_value != '' else false }}
+{%- else -%}
+  {{ env_value | trim(chars='\n') }}
+{%- endif -%}

--- a/roles/report_metadata_gen/vars/env2vars/dci.yml
+++ b/roles/report_metadata_gen/vars/env2vars/dci.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# DCI environment variable mappings for metadata generation
+
+env2vars:
+  - key: ci_url
+    var: DCI_CS_URL
+    var_type: string
+  - key: ci_type
+    var: DCI_TYPE
+    var_type: string
+  - key: job_id
+    var: DCI_JOB_ID
+    var_type: string
+  - key: job_name
+    var: DCI_JOB_NAME
+    var_type: string
+  - key: job_url
+    var: DCI_JOB_URL
+    var_type: string
+  - key: team_id
+    var: DCI_TEAM_ID
+    var_type: string
+  - key: team_name
+    var: DCI_TEAM_NAME
+    var_type: string
+  - key: topic_id
+    var: DCI_TOPIC_ID
+    var_type: string
+  - key: topic_name
+    var: DCI_TOPIC_NAME
+    var_type: string

--- a/roles/report_metadata_gen/vars/env2vars/example.yml
+++ b/roles/report_metadata_gen/vars/env2vars/example.yml
@@ -1,0 +1,53 @@
+---
+# example variable types initiated from env variable
+
+env2vars:
+  ########################################## INPUT: ############################################
+  # Given an env variable was defined:
+  # export NODE_LABELS="bla:asd boo:ba bee:bea"
+  - key: ci_runner_labels
+    var: NODE_LABELS
+    var_type: dict
+    # the below are optional for 'dict', if this is the case, don't override
+    # splitter:
+    #   - " "
+    #   - ":"
+  ########################################## RESULT: ############################################
+  # inside `vars_dict` new key `ci_runner_labels` will appear with this dict:
+  # {'bla': 'asd', 'boo': 'ba', 'bee': 'bea'}
+  ###############################################################################################
+  ########################################## INPUT: ############################################
+  # Given an env variable was defined:
+  # export SOME_LIST="bla:asd, boo:ba ,bee:bea"
+  - key: example_list_key
+    var: SOME_LIST
+    var_type: list
+    splitter: ','
+  ########################################## RESULT: ############################################
+  # inside `vars_dict` new key `example_list_key` will appear with the following list value:
+  # ['bla:asd', ' boo:ba ', 'bee:bea'] # note the spaces
+  ###############################################################################################
+  ########################################## INPUT: ############################################
+  # Given an env variable was defined:
+  # export SOME_INT="123"
+  - key: example_int
+    var: SOME_INT
+    var_type: int
+  ########################################## RESULT: ############################################
+  # inside `vars_dict` new key `example_int` will appear with the following int value:
+  # 123
+  ###############################################################################################
+  ########################################## INPUT: ############################################
+  # Given an env variable was defined in either way:
+  # export SOME_BOOLEAN=1
+  # export SOME_BOOLEAN=TRUE
+  # export SOME_BOOLEAN=falSE
+  # export SOME_BOOLEAN=0
+  - key: example_bool
+    var: SOME_BOOLEAN
+    var_type: bool
+  ########################################## RESULT: ############################################
+  # inside `vars_dict` new key `example_bool` will appear with the following value:
+  # True # for truthy value
+  # False # for falsy value
+  ###############################################################################################

--- a/roles/report_metadata_gen/vars/env2vars/jenkins.yml
+++ b/roles/report_metadata_gen/vars/env2vars/jenkins.yml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# env2var list for redhatci.ocp.test_report_send for jenkins
+
+env2vars:
+  - key: ci_runner_labels
+    var: NODE_LABELS
+    var_type: dict
+    splitter:
+      - " "
+      - ":"
+  - key: ci_runner_id
+    var: EXECUTOR_NUMBER
+    var_type: int
+  - key: ci_runner_name
+    var: NODE_NAME
+  - key: ci_url
+    var: JENKINS_URL
+  - key: job_name
+    var: JOB_NAME
+  - key: job_url
+    var: JOB_URL
+  - key: job_build
+    var: BUILD_NUMBER
+    var_type: int
+  - key: job_build_tag
+    var: BUILD_TAG
+  - key: job_build_id
+    var: BUILD_ID
+  - key: job_build_url
+    var: BUILD_URL
+  - key: job_build_cause
+    var: BUILD_CAUSE
+    var_type: list
+    splitter:
+      - ','
+  - key: source_repo_url
+    var: GIT_URL
+  - key: source_ref
+    var: CHANGE_BRANCH
+  - key: source_ref_name
+    var: GIT_BRANCH
+  - key: source_sha
+    var: GIT_COMMIT
+  - key: source_ref_type
+    var: GIT_COMMIT_TAG
+  - key: source_change_url
+    var: CHANGE_URL
+  - key: source_change_author
+    var: CHANGE_AUTHOR
+  - key: source_change_author_name
+    var: CHANGE_AUTHOR_DISPLAY_NAME
+  - key: source_ci_server_url
+    var: CI_SERVER_URL
+  - key: source_owner
+    var: CI_PROJECT_NAMESPACE
+  - key: source_repo
+    var: CI_PROJECT_NAME
+  - key: source_repo_path
+    var: CI_PROJECT_PATH
+    # Mapping to Merge Request (MR)
+  - key: source_change_id
+    var: CHANGE_ID
+  - key: source_change_base_ref
+    var: CHANGE_TARGET
+  - key: source_change_head_ref
+    var: CHANGE_BRANCH


### PR DESCRIPTION
##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->

- New Feature: Implements role CI metadata collection for reporting role

##### Tests

<!-- Document the tests for this change, if any -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

integration: 
packaged into `eco-ci-cd` container, list of tested CI system will be updated here.
(at least local jenkins job)

<!-- Examples:
- [ ] TestDallas: ocp-4.17-vanilla - <JobURL>
- [ ] TestDallasHybrid: ocp-4.17-vanilla-hybrid - <JobURL>
- [ ] TestDallasWorkload: preflight-green - <JobURL>
- [ ] TestBos2: virt - <JobURL>
- [ ] TestBos2Sno: sno - <JobURL>
- [ ] TestBos2SnoBaremetal: sno - <JobURL>
-->

---

<!-- Include the test and dependencies for this change -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->


<!-- Examples: -->

Test-Hint: no-check


Depends-on: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/731 
Depends-on: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/732
Depends-on: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/733
