### PR TITLE
Update certsuite default version

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.5
+kbpc_version: v5.5.6
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
##### SUMMARY

Update to latest release of certsuite v5.5.6

##### ISSUE TYPE

- Nominal change

##### Tests

- [ ] TestDallasWorkload: tnf-test-cnf-green - 

---

TestDallasWorkload: tnf-test-cnf-green