### PR TITLE
include_components: skip listed components if already defined

### DIFF
--- a/roles/include_components/tasks/main.yml
+++ b/roles/include_components/tasks/main.yml
@@ -34,5 +34,10 @@
 - name: Track listed components
   ansible.builtin.include_tasks: track_listed_component.yml
   loop: "{{ ic_listed | default([]) }}"
+  when:
+    - item.name is not in
+      ( (ic_gits + ic_dev_gits) |
+        map('regex_replace', '^(?:.*/(.+)|.*/([^/]+))$', '\\1') |
+        map('regex_replace', 'python', 'python3') | list)
 
 ...


### PR DESCRIPTION
##### SUMMARY

Avoid creating components from `ic_listed` when they already exist in either `ic_gits` or `ic_dev_gits`. This prevents duplicate definitions and ensures component uniqueness across configuration sources.


##### Tests

[x] TestBos2Podman: sno - https://www.distributed-ci.io/jobs/bcaf3738-97cd-4510-8a06-81c0af5194fb/jobStates
