### PR TITLE
Add IDMS for gitops repo server

### DIFF
--- a/roles/setup_gitops/tasks/local-registry.yml
+++ b/roles/setup_gitops/tasks/local-registry.yml
@@ -33,4 +33,20 @@
           - mirrors:
               - "{{ sg_local_registry }}/rhacm2/multicluster-operators-subscription-rhel9"
             source: "{{ sg_mce_repo }}"
+
+- name: Apply IDMS for ZTP and MCE images
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: config.openshift.io/v1
+      kind: ImageDigestMirrorSet
+      metadata:
+        name: gitops-images
+      spec:
+        imageDigestMirrors:
+          - mirrors:
+              - "{{ sg_local_registry }}/openshift4/ztp-site-generate-rhel8"
+            source: "{{ sg_ztp_repo }}"
+          - mirrors:
+              - "{{ sg_local_registry }}/rhacm2/multicluster-operators-subscription-rhel9"
+            source: "{{ sg_mce_repo }}"
 ...


### PR DESCRIPTION
##### SUMMARY
Adding IDMS for repo server when local registry is used as a fallback for ITMS

##### ISSUE TYPE

- nominal change

##### Tests

- [x] TestDallas: ocp-4.20-vanilla - https://www.distributed-ci.io/jobs/b93330c7-0edc-4fb3-a840-f6c867107ac0/jobState 
Failure is not related to this change

Test-Hint: no-check
