### PR TITLE
Update regex for Site generator image

### DIFF
--- a/roles/configure_ztp_gitops_apps/tasks/main.yaml
+++ b/roles/configure_ztp_gitops_apps/tasks/main.yaml
@@ -179,7 +179,7 @@
     - name: Replace ztp-site-generate image container URL in argocd-openshift-gitops-patch.json
       ansible.builtin.replace:
         path: "{{ temp_dir.path }}/ztp/argocd/deployment/argocd-openshift-gitops-patch.json"
-        regexp: '[^"]*ztp-site-generate[^"]*'
+        regexp: '[^"]*ztp-site-generat[^"]*'
         replace: "{{ czga_site_generator_image }}:{{ czga_site_generator_version }}"
 
     - name: Replace multicluster-operators-subscription image container URL in argocd-openshift-gitops-patch.json


### PR DESCRIPTION
##### SUMMARY

In the latest version of the ArgoCD template, the image reference in the template has changed to image: quay.io/openshift-kni/ztp-site-generator:latest. Therefore, updating the regex to match both cases (generate/generator). 

##### ISSUE TYPE

-  Nominal change

##### Tests

- [x]  TestDallas: ocp-4.19-vanilla - https://www.distributed-ci.io/jobs/3bfd2d6f-a597-4db7-bb76-2db1b1dfe50c/jobStates


Test-Hint: no-check
