### PR TITLE
[wip] podman: add compatibility with ABI jobs

### DIFF
--- a/roles/merge_registry_creds/tasks/main.yml
+++ b/roles/merge_registry_creds/tasks/main.yml
@@ -26,7 +26,6 @@
     content: "{{ mrc_auth_data | to_json }}"
     dest: "{{ mrc_auth_file.path }}"
     owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_gid }}"
     mode: "0400"
 
 - name: "Set path for combined auths file"

--- a/roles/mirror_ocp_release/tasks/artifacts.yml
+++ b/roles/mirror_ocp_release/tasks/artifacts.yml
@@ -82,7 +82,6 @@
         path: "{{ mor_cache_dir }}/{{ mor_version }}/{{ mor_installer }}"
         state: file
         owner: "{{ mor_owner }}"
-        group: "{{ mor_group }}"
         mode: "0755"
         setype: "httpd_sys_content_t"
       register: _mor_install_mode


### PR DESCRIPTION
##### SUMMARY

Add compatibility when dci-openshift-agent user is used to run the pipeline

##### ISSUE TYPE

- Bug

##### Tests

- [ ] TestBos2SnoPodman: sno -

Depends-on: 33715
