### PR TITLE
Don't push built preflight without registry

### DIFF
--- a/roles/preflight/tasks/prepare_preflight_image.yml
+++ b/roles/preflight/tasks/prepare_preflight_image.yml
@@ -16,7 +16,7 @@
     dest: "{{ preflight_tmp_dir.path }}/preflight-source/"
     mode: "0755"
 
-- name: Set preflight_image name
+- name: Set preflight_image name # noqa: jinja[spacing]
   vars:
     preflight_fqar: >-
       {%- if dci_local_registry | length > 0 -%}
@@ -40,7 +40,7 @@
 
 # We have to tag using the last stable version
 # to make Pyxis submission work
-- name: Build Preflight image
+- name: Build Preflight image  # noqa: command-instead-of-shell
   vars:
     push_image: >-
       && podman push
@@ -50,6 +50,7 @@
     cmd: >-
       podman build .
       --no-cache
+      --pull=always
       -t {{ preflight_image }}
       --build-arg=release_tag={{ preflight_github_tags.json[0].name }}
       {{ (dci_local_registry | length > 0) | ternary(push_image, "") }}

--- a/roles/preflight/tasks/prepare_preflight_image.yml
+++ b/roles/preflight/tasks/prepare_preflight_image.yml
@@ -41,17 +41,18 @@
 # We have to tag using the last stable version
 # to make Pyxis submission work
 - name: Build Preflight image
+  vars:
+    push_image: >-
+      && podman push
+      --authfile {{ partner_creds }}
+      {{ preflight_image }}
   ansible.builtin.shell:
-    cmd: >
+    cmd: >-
       podman build .
       --no-cache
       -t {{ preflight_image }}
       --build-arg=release_tag={{ preflight_github_tags.json[0].name }}
-      {% if dci_local_registry | length > 0 %}
-        && podman push
-        --authfile {{ partner_creds }}
-        {{ preflight_image }}
-      {% endif %}
+      {{ (dci_local_registry | length > 0) | ternary(push_image, "") }}
     chdir: "{{ preflight_tmp_dir.path }}/preflight-source"
   notify:
     - "Remove the local preflight image"

--- a/roles/preflight/tasks/prepare_preflight_image.yml
+++ b/roles/preflight/tasks/prepare_preflight_image.yml
@@ -17,8 +17,15 @@
     mode: "0755"
 
 - name: Set preflight_image name
+  vars:
+    preflight_fqar: >-
+      {%- if dci_local_registry | length > 0 -%}
+      {{ dci_local_registry }}/preflight/preflight:{{ preflight_branch }}
+      {%- else -%}
+      localhost/preflight/preflight:{{ preflight_branch }}
+      {%- endif -%}
   ansible.builtin.set_fact:
-    preflight_image: "{{ dci_local_registry }}/preflight/preflight:{{ preflight_branch }}"
+    preflight_image: "{{ preflight_fqar }}"
 
 - name: "Append to image name the job id"
   ansible.builtin.set_fact:
@@ -39,10 +46,12 @@
       podman build .
       --no-cache
       -t {{ preflight_image }}
-      --build-arg=release_tag={{ preflight_github_tags.json[0].name }} &&
-      podman push
-      --authfile {{ partner_creds }}
-      {{ preflight_image }}
+      --build-arg=release_tag={{ preflight_github_tags.json[0].name }}
+      {% if dci_local_registry | length > 0 %}
+        && podman push
+        --authfile {{ partner_creds }}
+        {{ preflight_image }}
+      {% endif %}
     chdir: "{{ preflight_tmp_dir.path }}/preflight-source"
   notify:
     - "Remove the local preflight image"


### PR DESCRIPTION
##### SUMMARY

When a registry is not provided, usually connected environments, don't force the pushing of the built preflight image, keep and use it locally instead.


##### ISSUE TYPE

- Bug Fix

##### Tests

- [x] TestDallasWorkload: preflight-green (no build) - https://www.distributed-ci.io/jobs/789b3103-5710-4db3-8f7c-7106f7bc0b31
- [x] TestDallasWorkload: preflight-green (build) - https://www.distributed-ci.io/jobs/8ace66da-0c62-4ab2-b98b-55f829eb1156
- [x] TestBos2Workload: preflight-green (no build) -  https://www.distributed-ci.io/jobs/cfc5380b-97f0-4d8d-ae19-9dd59eea32e5
- [x] TestBos2Workload: preflight-green (build) - https://www.distributed-ci.io/jobs/4e26fa12-79c9-4161-b032-be24c2261d4

---


Test-hints: no-check