### PR TITLE
Bump default certsuite version to v5.5.8

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.7
+kbpc_version: v5.5.8
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
##### SUMMARY

Bump default certsuite version to v5.5.8

##### ISSUE TYPE

- Bump version

##### Tests

- [x] TestBos2Workload: certsuite-green certsuite-green:ansible_extravars=kbpc_version:v5.5.8 - https://www.distributed-ci.io/jobs/1e2aeda7-23f3-4d3e-a907-2f094494d4da/jobStates

Test-Hints: no-check