### PR TITLE
Use API beta1 in ArgoCD tasks

### DIFF
--- a/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
+++ b/roles/acm_spoke_mgmt/tasks/delete-ztp-by-ref.yaml
@@ -9,7 +9,7 @@
 
 - name: Get all ArgoCD Applications
   kubernetes.core.k8s_info:
-    api_version: argoproj.io/v1alpha1
+    api_version: argoproj.io/v1beta1
     kind: Application
     namespace: openshift-gitops
   register: _asm_all_apps
@@ -46,7 +46,7 @@
   block:
     - name: Patch ArgoCD application finalizers
       kubernetes.core.k8s:
-        api_version: argoproj.io/v1alpha1
+        api_version: argoproj.io/v1beta1
         kind: Application
         name: "{{ app }}"
         namespace: "{{ app_ns }}"
@@ -63,7 +63,7 @@
     - name: Delete Argo Applications
       kubernetes.core.k8s:
         state: absent
-        api_version: argoproj.io/v1alpha1
+        api_version: argoproj.io/v1beta1
         kind: Application
         name: "{{ app }}"
         namespace: "{{ app_ns }}"
@@ -73,7 +73,7 @@
 
     - name: Wait for ArgoCD application deletion
       kubernetes.core.k8s_info:
-        api_version: argoproj.io/v1alpha1
+        api_version: argoproj.io/v1beta1
         kind: Application
         name: "{{ app }}"
         namespace: "{{ app_ns }}"

--- a/roles/argocd_config/defaults/main.yml
+++ b/roles/argocd_config/defaults/main.yml
@@ -18,7 +18,7 @@ ac_permissions_def:
       namespace: "{{ ac_namespace }}"
 ac_project: project
 ac_project_def:
-  apiVersion: argoproj.io/v1alpha1
+  apiVersion: argoproj.io/v1beta1
   kind: AppProject
   metadata:
     name: "{{ ac_project }}"

--- a/roles/argocd_config/tasks/config-app-create.yml
+++ b/roles/argocd_config/tasks/config-app-create.yml
@@ -2,7 +2,7 @@
 - name: Create ArgoCD App
   vars:
     app_def:
-      apiVersion: argoproj.io/v1alpha1
+      apiVersion: argoproj.io/v1beta1
       kind: Application
       metadata:
         name: "{{ ac_app_name }}"

--- a/roles/argocd_config/tasks/config-app-delete.yml
+++ b/roles/argocd_config/tasks/config-app-delete.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if ArgoCD App exists
   kubernetes.core.k8s_info:
-    api_version: argoproj.io/v1alpha1
+    api_version: argoproj.io/v1beta1
     kind: Application
     name: "{{ ac_app_name }}"
     namespace: "{{ ac_namespace }}"
@@ -19,7 +19,7 @@
       when:
         - ac_action == 'delete'
       kubernetes.core.k8s:
-        api_version: argoproj.io/v1alpha1
+        api_version: argoproj.io/v1beta1
         kind: Application
         name: "{{ ac_app_name }}"
         namespace: "{{ ac_namespace }}"
@@ -31,7 +31,7 @@
       when:
         - ac_action == 'delete-cascade'
       kubernetes.core.k8s:
-        api_version: argoproj.io/v1alpha1
+        api_version: argoproj.io/v1beta1
         kind: Application
         name: "{{ ac_app_name }}"
         namespace: "{{ ac_namespace }}"
@@ -43,14 +43,14 @@
     - name: Delete ArgoCD App
       kubernetes.core.k8s:
         state: absent
-        api_version: argoproj.io/v1alpha1
+        api_version: argoproj.io/v1beta1
         kind: Application
         name: "{{ ac_app_name }}"
         namespace: "{{ ac_namespace }}"
 
     - name: Wait for ArgoCD App deletion
       kubernetes.core.k8s_info:
-        api_version: argoproj.io/v1alpha1
+        api_version: argoproj.io/v1beta1
         kind: Application
         name: "{{ ac_app_name }}"
         namespace: "{{ ac_namespace }}"

--- a/roles/argocd_config/tasks/config-app-sync.yml
+++ b/roles/argocd_config/tasks/config-app-sync.yml
@@ -4,7 +4,7 @@
     - ac_action == "sync-on"
   kubernetes.core.k8s:
     definition:
-      apiVersion: argoproj.io/v1alpha1
+      apiVersion: argoproj.io/v1beta1
       kind: Application
       metadata:
         name: "{{ ac_app_name }}"
@@ -22,7 +22,7 @@
     - ac_action == "sync-off"
   kubernetes.core.k8s:
     definition:
-      apiVersion: argoproj.io/v1alpha1
+      apiVersion: argoproj.io/v1beta1
       kind: Application
       metadata:
         name: "{{ ac_app_name }}"

--- a/roles/argocd_config/tasks/wait-for-healthy.yml
+++ b/roles/argocd_config/tasks/wait-for-healthy.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for ArgoCD Application to be healthy
   kubernetes.core.k8s_info:
-    api_version: argoproj.io/v1alpha1
+    api_version: argoproj.io/v1beta1
     kind: Application
     namespace: "{{ ac_namespace }}"
     name: "{{ ac_app_name }}"

--- a/roles/remove_ztp_gitops_resources/tasks/main.yaml
+++ b/roles/remove_ztp_gitops_resources/tasks/main.yaml
@@ -5,7 +5,7 @@
 # given hub.
 - name: Delete SiteConfig and Policy Applications
   kubernetes.core.k8s:
-    api_version: argoproj.io/v1alpha1
+    api_version: argoproj.io/v1beta1
     kind: Application
     name: "{{ _rzgr_gitops_application }}"
     namespace: openshift-gitops
@@ -19,7 +19,7 @@
 
 - name: Delete SiteConfig and Policy AppProjects
   kubernetes.core.k8s:
-    api_version: argoproj.io/v1alpha1
+    api_version: argoproj.io/v1beta1
     kind: AppProject
     name: "{{ _rzgr_gitops_appproject }}"
     namespace: openshift-gitops

--- a/roles/setup_gitops/tasks/main.yml
+++ b/roles/setup_gitops/tasks/main.yml
@@ -21,23 +21,10 @@
   when:
     - sg_local_registry | length > 0
 
-
-- name: Get ArgoCD CRD definition
-  kubernetes.core.k8s_info:
-    api_version: apiextensions.k8s.io/v1
-    kind: CustomResourceDefinition
-    name: argocds.argoproj.io
-  register: _sg_argocd_crd
-
 - name: Patch ArgoCD repo server for Kustomize and PolicyGenerator
-  vars:
-    argocd_version: >-
-      {{ (_sg_argocd_crd.resources[0].spec.versions
-          | selectattr('storage', 'equalto', true)
-          | map(attribute='name'))[0] }}
   kubernetes.core.k8s:
     definition:
-      apiVersion: "argoproj.io/{{ argocd_version }}"
+      apiVersion: argoproj.io/v1beta1
       kind: ArgoCD
       metadata:
         name: openshift-gitops

--- a/roles/setup_gitops/tasks/main.yml
+++ b/roles/setup_gitops/tasks/main.yml
@@ -21,10 +21,23 @@
   when:
     - sg_local_registry | length > 0
 
+
+- name: Get ArgoCD CRD definition
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: argocds.argoproj.io
+  register: _sg_argocd_crd
+
 - name: Patch ArgoCD repo server for Kustomize and PolicyGenerator
+  vars:
+    argocd_version: >-
+      {{ (_sg_argocd_crd.resources[0].spec.versions
+          | selectattr('storage', 'equalto', true)
+          | map(attribute='name'))[0] }}
   kubernetes.core.k8s:
     definition:
-      apiVersion: argoproj.io/v1beta1
+      apiVersion: "argoproj.io/{{ argocd_version }}"
       kind: ArgoCD
       metadata:
         name: openshift-gitops


### PR DESCRIPTION
##### SUMMARY

In pre-ga catalog dci_pre_ga_catalog:quay.io/prega/prega-operator-index:v4.20-20250912T11484 the ArgoCD API changes to v1alpha1 are removed after being marked as deprecated. Beta1 is already available.

##### ISSUE TYPE

- nominal change

##### Tests

- [x] TestBos2: virt-prega-4.20 https://www.distributed-ci.io/jobs/46cb5404-2e07-44d2-91ae-76612db1dac2/jobStates
- [ ] acm-hub ztp-spoke-vm-4.17 -  

---

Test-Hint: no-check

