### PR TITLE
Bump default certsuite version to v5.5.9

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.8
+kbpc_version: v5.5.9
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
SUMMARY
Bump default certsuite version to v5.5.9

ISSUE TYPE
Bump version

Tests
 TestBos2Workload: certsuite-green certsuite-green:ansible_extravars=kbpc_version:v5.5.9