### PR TITLE
mirror_images: allow empty org like for registry.access.redhat.com/ubi10

### DIFF
--- a/roles/mirror_images/tasks/mirror-images.yml
+++ b/roles/mirror_images/tasks/mirror-images.yml
@@ -12,7 +12,7 @@
       {%- else -%}
       {{ _image_name }}{%- if _image_tag | length %}{{ _image_tag }}{%- endif -%}
       {%- endif -%}
-    _tgt_image_location: "{{ mi_registry }}/{{ _image_org_path }}/{{ _image_img_path }}"
+    _tgt_image_location: "{{ mi_registry }}{% if _image_org_path | length %}/{{ _image_org_path }}{% endif %}/{{ _image_img_path }}"
   block:
     - name: "Mirror image"
       ansible.builtin.command:


### PR DESCRIPTION
##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug

##### Tests

