### PR TITLE
redhat_tests: wait more before executing tests

### DIFF
--- a/roles/redhat_tests/tasks/main.yml
+++ b/roles/redhat_tests/tasks/main.yml
@@ -8,7 +8,7 @@
     name: redhatci.ocp.check_resource
   vars:
     resource_to_check: "MachineConfigPool"
-    check_wait_retries: 30
+    check_wait_retries: 40
     check_wait_delay: 10
 
 - name: "redhat_tests : Run openshift conformance tests"  # noqa: name[casing]


### PR DESCRIPTION
##### SUMMARY

Increase wait_retries for checking if all nodes in MCP are updated and ready before running RedHat tests
Some servers can be slow to reboot.

##### ISSUE TYPE

- Bug
