### PR TITLE
Added default empty list to _ecd_crd_info fact until condition

### DIFF
--- a/roles/example_cnf_deploy/tasks/catalog.yml
+++ b/roles/example_cnf_deploy/tasks/catalog.yml
@@ -12,8 +12,8 @@
   register: _ecd_crd_info
   retries: 1
   delay: 5
-  until: _ecd_crd_info.resources|length != 0
-  failed_when: _ecd_crd_info.resources|length == 0
+  until: _ecd_crd_info.resources | default([]) | length != 0
+  failed_when: _ecd_crd_info.resources | defaul([]) |length == 0
 
 - name: "Inspect index image"
   ansible.builtin.shell:


### PR DESCRIPTION
##### SUMMARY

The task "Check if catalogsource crd is present" implements an "until" condition that relies on the _ecd_crd_info variable being properly defined and including the resources object. However the until condition does not verify the resources object was created which may cause the tasks to fail.

This change adds an empty list as the default value for the resources object, so the task won't failed if the resources is not defined.

Fixes CILAB-2408: Failed at redhatci.ocp.example_cnf_deploy : Check if catalogsource crd is present

##### ISSUE TYPE

- Bug

##### Tests

- [ ] Testvcp: ocp-4.20-vanilla - <JobURL>

---

Testvcp: ocp-4.20-vanilla example-cnf example-cnf:ansible_extravars=ecd_numa_aware_topology:topo-aware-scheduler
