### PR TITLE
olm_operator: starting_csv setting does not force automatic install a…

### DIFF
--- a/roles/olm_operator/tasks/main.yml
+++ b/roles/olm_operator/tasks/main.yml
@@ -120,8 +120,6 @@
           spec: "{{ operator_group_spec | default(group_spec, true) }}"
 
     - name: Create subscription for OLM operator
-      vars:
-        _oo_approval: "{{ (install_approval == 'Automatic' or (starting_csv | length > 0)) | ternary('Automatic', 'Manual') }}"
       kubernetes.core.k8s:
         definition:
           apiVersion: operators.coreos.com/v1alpha1
@@ -131,7 +129,7 @@
             namespace: "{{ namespace }}"
           spec:
             channel: "{{ desired_channel }}"
-            installPlanApproval: "{{ _oo_approval }}"
+            installPlanApproval: "{{ install_approval }}"
             config:
               resources: {}
             name: "{{ operator }}"


### PR DESCRIPTION
…pproval

##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->

<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change
- New or Enhanced Feature

##### Tests

<!-- Document the tests for this change, if any -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

<!-- Examples:
- [ ] Testvcp: ocp-4.17-vanilla - <JobURL>
- [ ] TestvcpHybrid: ocp-4.17-vanilla-hybrid - <JobURL>
- [ ] TestvcpWorkload: preflight-green - <JobURL>
- [ ] TestBos2: virt - <JobURL>
- [ ] TestBos2Sno: sno - <JobURL>
- [ ] TestBos2SnoBaremetal: sno - <JobURL>
-->

---

<!-- Include the test and dependencies for this change -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

