### PR TITLE
switch oc context to default namespace for collecting hw data

### DIFF
--- a/roles/node_info/tasks/main.yml
+++ b/roles/node_info/tasks/main.yml
@@ -30,10 +30,11 @@
         var: ni_ready_node_names
       when: ni_ready_node_names is defined
 
+    #switch oc context to default namespace for collecting hw data
     - name: Get kernel information for all nodes
       ansible.builtin.shell:
         cmd: >
-          {{ ni_oc_tool_path }} debug node/{{ node_name }}
+          {{ ni_oc_tool_path }} debug node/{{ node_name }} -n default
           -- chroot /host sh -c 'echo "{\"node\": \"{{ node_name }}\",
           \"version\": \"$(uname -r)\", \"params\": \"$(cat /proc/cmdline)\"}"'
       register: _ni_kernel_info

--- a/roles/node_info/tasks/main.yml
+++ b/roles/node_info/tasks/main.yml
@@ -30,7 +30,7 @@
         var: ni_ready_node_names
       when: ni_ready_node_names is defined
 
-    #switch oc context to default namespace for collecting hw data
+    # Switch oc context to default namespace for collecting hw data
     - name: Get kernel information for all nodes
       ansible.builtin.shell:
         cmd: >
@@ -125,7 +125,7 @@
           }}
       ansible.builtin.shell:
         cmd: >
-          {{ ni_oc_tool_path }} debug node/{{ node_name }}
+          {{ ni_oc_tool_path }} debug node/{{ node_name }} -n default
           --image={{ _ni_hw_img }}
           --
           bash -c "${preinstall} lshw -json -sanitize -numeric"


### PR DESCRIPTION
##### SUMMARY

oc client operates within a namespace context. If the current (or explicitly set) namespace doesn’t exist, the command fails before it even reaches the node.Eg of failure: https://www.distributed-ci.io/jobs/b2d9ffa5-9897-4096-8e1f-585c68328aaa/jobStates?sort=date&task=6739436e-cf16-4c73-81fd-574281ef8ee6

Hence , using default namespace for collecting kernel information

##### ISSUE TYPE

Enhanced Feature

