### PR TITLE
SNO installer support for custom RHCOS images

### DIFF
--- a/roles/installer/templates/install-config-virtualmedia.j2
+++ b/roles/installer/templates/install-config-virtualmedia.j2
@@ -95,6 +95,9 @@ platform:
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}
 {% endif %}
+{% if clusterosimage is defined and clusterosimage|length %}
+    clusterOSImage: {{ clusterosimage }}
+{% endif %}
     hosts:
 {% for host in groups['masters'] %}
       - name: {{ hostvars[host]['inventory_hostname'] }}

--- a/roles/installer/templates/install-config.j2
+++ b/roles/installer/templates/install-config.j2
@@ -88,6 +88,9 @@ platform:
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}
 {% endif %}
+{% if clusterosimage is defined and clusterosimage|length %}
+    clusterOSImage: {{ clusterosimage }}
+{% endif %}
     hosts:
 {% for host in groups['masters'] %}
       - name: {{ hostvars[host]['inventory_hostname'] }}

--- a/roles/sno_installer/README.md
+++ b/roles/sno_installer/README.md
@@ -20,6 +20,8 @@ For any type of SNO installation, these variables are always required
 
 Variable                      | Required | Default    | Description
 ------------------------------|----------|------------|-------------
+si_bootstraposimage           | no       | (unset)    | When set, written to `install-config.yaml` as `BootstrapInPlace.bootstrapOSImage` (URL to the RHCOS image used during bootstrap; mirrors the `installer` role variable of the same name).
+si_clusterosimage             | no       | (unset)    | When set, written to `install-config.yaml` as `BootstrapInPlace.clusterOSImage` (URL to the RHCOS image used for the cluster; mirrors the `installer` role variable of the same name).
 si_cache_dir                  | no       | /opt/cache | Path to the directory in the registry host containing every OCP version installation artifacts.
 si_cache_server               | no       | {{ inventory_hostname }} | The cache server to use for storing and serving installation artifacts. Defaults to the current inventory host but can be overridden to point to a different SSH-accessible host containing the cache directory and serving the installation artifacts.
 si_cache_server_major_version | no       | {{ ansible_distribution_major_version }} | Distribution major version for the cache server if it's different than the version in the provision host.

--- a/roles/sno_installer/templates/install-config.j2
+++ b/roles/sno_installer/templates/install-config.j2
@@ -53,6 +53,12 @@ BootstrapInPlace:
 {% else %}
   InstallationDisk: /dev/vda
 {% endif %}
+{% if si_bootstraposimage is defined and si_bootstraposimage|length %}
+  bootstrapOSImage: '{{ si_bootstraposimage }}'
+{% endif %}
+{% if si_clusterosimage is defined and si_clusterosimage|length %}
+  clusterOSImage: '{{ si_clusterosimage }}'
+{% endif %}
 publish: External
 pullSecret: '{{ pullsecret }}'
 sshKey: '{{ key }}'


### PR DESCRIPTION
##### SUMMARY

For now this is only a testing PR.

The IPI SNO deployment retrieves the cluster node OS images based on the paths extracted with the openshift-install binary.

On the other hand, the install-config yaml file allows to set custom disk image URLs by means of the bootstrapOSImage and clusterOSImage variables.

This PR extends the install-config.yaml template so these variables may be set when calling the sno_installer role.


##### ISSUE TYPE

- Enhanced Feature

##### Tests

<!-- Examples:
- [ ] Testvcp: ocp-4.17-vanilla - <JobURL>
- [ ] TestvcpHybrid: ocp-4.17-vanilla-hybrid - <JobURL>
- [ ] TestvcpWorkload: preflight-green - <JobURL>
- [ ] TestBos2: virt - <JobURL>
- [ ] TestBos2Sno: sno - <JobURL>
- [ ] TestBos2SnoBaremetal: sno - <JobURL>
-->

---
