### PR TITLE
eco-gotest: Add label to run specific test

### DIFF
--- a/roles/eco_gotests/README.md
+++ b/roles/eco_gotests/README.md
@@ -26,12 +26,16 @@ This role runs [eco-gotests](https://github.com/rh-ecosystem-edge/eco-gotests) f
 
 #### General Configuration
 - `eco_gotests_image` (default: `"quay.io/ocp-edge-qe/eco-gotests:latest"`): Container image for eco-gotests
-- `eco_gotests_skip_labels_ptp` (default: `[]`): List of test labels to skip for PTP tests. These labels will be excluded using Ginkgo label filter syntax (`!label`). Common PTP labels include: `node-reboot`, `process-restart`, `event-consumer`, `events-and-metrics`, `interfaces`, `leap-file`, `ntp-fallback`. Example: `['node-reboot', 'process-restart']` to skip node reboot and process restart tests.
+- `eco_gotests_run_labels_ptp` (default: `[]`): List of Ginkgo labels to **run** for PTP tests. When non-empty, only tests matching these labels are selected; multiple entries are combined with ` && ` (AND). When empty, no positive label filter is applied (all PTP tests in the suite are candidates, subject to skips). Common PTP labels include: `node-reboot`, `process-restart`, `event-consumer`, `events-and-metrics`, `interfaces`, `leap-file`, `ntp-fallback`. Example: `['events-and-metrics']` to run only that category.
+- `eco_gotests_skip_labels_ptp` (default: `[]`): List of test labels to skip for PTP tests. These labels will be excluded using Ginkgo label filter syntax (`!label`). When combined with `eco_gotests_run_labels_ptp`, the effective filter is `run_label_1 && ... && !skip_label_1 && ...`. Common PTP labels are the same as above. Example: `['node-reboot', 'process-restart']` to skip node reboot and process restart tests.
+- `eco_gotests_eco_test_features_ptp` (default: `"ptp"`): Value passed to the eco-gotests container as `ECO_TEST_FEATURES` for the PTP run. Override if you need a different feature selector supported by eco-gotests.
 - `eco_gotests_ptp_check_prerequisites` (default: `true`): Enable or disable PTP prerequisites validation (`PtpOperatorConfig` checks for `enableEventPublisher` and `apiVersion`).
+- `eco_gotests_ptp_run_timeout_sec` (default: `3600`): Maximum wall-clock time in **seconds** that the PTP test container is allowed to run. The role passes this to `containers.podman.podman_container` as `timeout` (Podman `--timeout`); the runtime stops the container when the limit is reached. The default is one hour.
 - `eco_gotests_path` (default: undefined): path where to find the source code to build the container. If this is specified, the `eco_gotests_image` is ignored.
-- `eco_gotests_dump_failed_tests` (default: `false`): When true, eco-gotests sets `ECO_DUMP_FAILED_TESTS` and writes per-failure logs and must-gather under the suite reports directory. 
+- `eco_gotests_dump_failed_tests` (default: `false`): When true, eco-gotests sets `ECO_DUMP_FAILED_TESTS` and writes per-failure logs and must-gather under the suite reports directory.
 
 #### SRIOV Test Configuration
+- `eco_gotests_eco_test_features_sriov` (default: `"sriov"`): Value passed to the eco-gotests container as `ECO_TEST_FEATURES` for the SRIOV run.
 - `eco_gotests_sriov_labels` (default: `"sriov-hw-enabled"`): Test labels for SRIOV tests
 - `eco_gotests_worker_label` (default: `"worker"`): Worker node label
 - `eco_gotests_sriov_interface_list` (default: `"ens3f0np0,ens3f1np1"`): SRIOV interface list

--- a/roles/eco_gotests/defaults/main.yml
+++ b/roles/eco_gotests/defaults/main.yml
@@ -8,6 +8,7 @@ eco_gotests_registry_auth_file: ""
 eco_gotests_dump_failed_tests: false
 
 # SRIOV test configuration
+eco_gotests_eco_test_features_sriov: "sriov"
 eco_gotests_sriov_labels: "sriov-hw-enabled"
 eco_gotests_worker_label: "worker"
 eco_gotests_sriov_interface_list: "ens3f0np0,ens3f1np1"
@@ -18,5 +19,10 @@ eco_gotests_sriov_timeout: "12h"
 eco_gotests_verbose_level: 100
 eco_gotests_test_verbose: true
 
+# PTP test configuration
+eco_gotests_eco_test_features_ptp: "ptp"
+eco_gotests_run_labels_ptp: []
 eco_gotests_skip_labels_ptp: []
 eco_gotests_ptp_check_prerequisites: true
+# Max wall-clock time (seconds) for the PTP eco-gotests podman run; Ansible stops the task after this (default 1h).
+eco_gotests_ptp_run_timeout_sec: 3600

--- a/roles/eco_gotests/tasks/ptp.yml
+++ b/roles/eco_gotests/tasks/ptp.yml
@@ -31,9 +31,27 @@
         fail_msg: "PTP prerequisite check failed: spec.ptpEventConfig.apiVersion must be '2.0'"
         success_msg: "PTP prerequisite check passed: apiVersion is '2.0'"
 
+- name: "Show relevant PTP variables for verification"
+  ansible.builtin.debug:
+    msg:
+      eco_gotests_image: "{{ eco_gotests_image }}"
+      eco_gotests_kubconfig_dir: "{{ eco_gotests_kubconfig_dir }}"
+      eco_gotests_log_dir: "{{ eco_gotests_log_dir }}"
+      eco_gotests_eco_test_features_ptp: "{{ eco_gotests_eco_test_features_ptp }}"
+      eco_gotests_registry_auth_file: "{{ eco_gotests_registry_auth_file }}"
+      eco_gotests_run_labels_ptp: "{{ eco_gotests_run_labels_ptp | default([]) }}"
+      eco_gotests_skip_labels_ptp: "{{ eco_gotests_skip_labels_ptp | default([]) }}"
+      eco_gotests_ptp_run_timeout_sec: "{{ eco_gotests_ptp_run_timeout_sec }}"
+
 - name: "Run PTP tests with eco-gotests"
   vars:
-    _eco_gotests_ptp_test_labels: "{{ eco_gotests_skip_labels_ptp | map('regex_replace', '^', '!') | join(' && ') | default('', true) }}"
+    _eco_gotests_ptp_test_labels: >-
+      {{
+        [
+          eco_gotests_run_labels_ptp | default([]) | join(' && '),
+          eco_gotests_skip_labels_ptp | default([]) | map('regex_replace', '^', '!') | join(' && ')
+        ] | map('trim') | reject('equalto', '') | join(' && ')
+      }}
   containers.podman.podman_container:
     name: "eco-gotests-ptp-{{ eco_gotests_date }}"
     image: "{{ eco_gotests_image }}"
@@ -46,7 +64,7 @@
       - "1000:0:1"
     env:
       KUBECONFIG: "/kubeconfig/kubeconfig"
-      ECO_TEST_FEATURES: "ptp"
+      ECO_TEST_FEATURES: "{{ eco_gotests_eco_test_features_ptp }}"
       REGISTRY_AUTH_FILE: "{{ eco_gotests_registry_auth_file }}"
       ECO_TEST_LABELS: "{{ _eco_gotests_ptp_test_labels }}"
       ECO_REPORTS_DUMP_DIR: "/tmp/reports"
@@ -56,6 +74,7 @@
       - "{{ eco_gotests_log_dir }}/eco_gotests/ptp:/tmp/reports:Z"
     detach: false
     remove: true
+    timeout: "{{ eco_gotests_ptp_run_timeout_sec }}"
   failed_when: false
 
 - name: "Stat failed PTP suite dump directory"

--- a/roles/eco_gotests/tasks/sriov.yml
+++ b/roles/eco_gotests/tasks/sriov.yml
@@ -16,7 +16,7 @@
       ECO_VERBOSE_LEVEL: "{{ eco_gotests_verbose_level }}"
       ECO_TEST_VERBOSE: "{{ eco_gotests_test_verbose | lower }}"
       ECO_DUMP_FAILED_TESTS: "{{ eco_gotests_dump_failed_tests | bool }}"
-      ECO_TEST_FEATURES: "sriov"
+      ECO_TEST_FEATURES: "{{ eco_gotests_eco_test_features_sriov }}"
       ECO_TEST_LABELS: "{{ eco_gotests_sriov_labels }}"
       ECO_WORKER_LABEL: "{{ eco_gotests_worker_label }}"
       ECO_CNF_CORE_NET_CNF_MCP_LABEL: "{{ eco_gotests_worker_label }}"


### PR DESCRIPTION
##### SUMMARY

Add eco_gotests_run_labels_ptp variable to run specific ptp test

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x] https://www.distributed-ci.io/jobs/a953a31a-6d47-4bde-b446-c89ffcd49221

