### PR TITLE
certsuite | improve teardown of cnf-suite namespace

### DIFF
--- a/roles/k8s_best_practices_certsuite/tasks/teardown.yml
+++ b/roles/k8s_best_practices_certsuite/tasks/teardown.yml
@@ -25,6 +25,15 @@
 - name: Clean certsuite resources
   when: kbpc_postrun_delete_resources|bool
   block:
+    - name: Delete certsuite-probe DaemonSet
+      kubernetes.core.k8s:
+        api_version: apps/v1
+        kind: DaemonSet
+        name: certsuite-probe
+        namespace: cnf-suite
+        state: absent
+        wait: true
+
     - name: Delete cnf-suite Namespace
       kubernetes.core.k8s:
         api_version: v1


### PR DESCRIPTION
##### SUMMARY

Sometimes, the deletion of cnf-suite namespace gets stuck because there are some pods that are still running and are not deleted. [Example](https://www.distributed-ci.io/jobs/45dc33f8-7bef-479f-b349-d2f18dd4d631/jobStates?sort=date&task=584e12d9-d488-4ee0-98c8-3baa23a5d061).

Let's remove the pods firstly, then remove the namespace.

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestBos2: ocp-4.22-vanilla-abi tnf-test tnf-test:ansible_extravars=kbpc_version:HEAD

- SUCCESS https://www.distributed-ci.io/jobs/4d138a10-99ac-4f4f-a098-3360ecdfb942/jobStates
- SUCCESS https://www.distributed-ci.io/jobs/3e9ec729-8119-4265-832f-c58ab942bf45/jobStates

Test-Hints: no-check