### PR TITLE
add labels to vm template

### DIFF
--- a/roles/kvirt_vm/README.md
+++ b/roles/kvirt_vm/README.md
@@ -41,6 +41,7 @@ Always, Halted, Manual, RerunOnFailure.
 | running                       | Undefined                     | no          | `DEPRECATED`, use `run_strategy` instead. Set the initial VM power state. Takes precedence over `run_strategy` when defined.
 | node_selector                 |                               | no          | Configure nodes selector
 | interfaces                    | virtio/masquerade             | no          | Network interface definitions
+| labels                        |                               | no          | A dictionary with labels for the VM
 | networks                      | Pod network                   | no          | VM network definitions
 
 ## Usage examples

--- a/roles/kvirt_vm/templates/vm-template.yml.j2
+++ b/roles/kvirt_vm/templates/vm-template.yml.j2
@@ -3,6 +3,10 @@ kind: "VirtualMachine"
 metadata:
   name: "{{ vm.name }}"
   namespace: "{{ vm.namespace | default(kvirt_vm_namespace) }}"
+  labels:
+{% if vm.labels is defined %}
+{{ vm.labels | to_nice_yaml | indent(4, True) }}
+{% endif %}
 spec:
   dataVolumeTemplates:
     - apiVersion: cdi.kubevirt.io/v1beta1
@@ -33,6 +37,9 @@ spec:
         vm.kubevirt.io/os: "{{ vm.os | default(kvirt_vm_os) }}"
       labels:
         kubevirt.io/domain: "{{ vm.namespace | default(kvirt_vm_namespace) }}"
+{% if vm.labels is defined %}
+{{ vm.labels | to_nice_yaml | indent(8, True) | trim }}
+{% endif %}
     spec:
 {% if vm.node_selector is defined %}
       nodeSelector: {{ vm.node_selector }}


### PR DESCRIPTION
##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->
This PR adds labels as a dictionary that can be defined as a vm template variable. 

```
    labels:
      redfish-enabled: "true"
      datacenter: "bos2"
```
<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- New or Enhanced Feature

##### Tests

<!-- Document the tests for this change, if any -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

https://www.distributed-ci.io/jobs/d337d5c7-1b99-4b8c-9aa4-eed49df5bac5/jobStates?sort=date

```
-> oc get vm openshift-master-0 -ojsonpath={.spec.template.metadata.labels} | jq .
{
  "datacenter": "bos2",
  "kubevirt.io/domain": "hub2",
  "redfish-enabled": "true"
}
```
TestBos2: virt 
<!-- Examples:
- [ ] Testvcp: ocp-4.17-vanilla - <JobURL>
- [ ] TestvcpHybrid: ocp-4.17-vanilla-hybrid - <JobURL>
- [ ] TestvcpWorkload: preflight-green - <JobURL>
- [x] TestBos2: virt - <JobURL>
- [ ] TestBos2Sno: sno - <JobURL>
- [ ] TestBos2SnoBaremetal: sno - <JobURL>
-->

---

<!-- Include the test and dependencies for this change -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->


<!-- Examples:

Test-Hint: no-check
Depends-on: https://path/to/depending/change

-->
