### PR TITLE
eco_gotests: enable failed-test dump handling for PTP and archive art…

### DIFF
--- a/roles/eco_gotests/README.md
+++ b/roles/eco_gotests/README.md
@@ -28,6 +28,7 @@ This role runs [eco-gotests](https://github.com/rh-ecosystem-edge/eco-gotests) f
 - `eco_gotests_image` (default: `"quay.io/ocp-edge-qe/eco-gotests:latest"`): Container image for eco-gotests
 - `eco_gotests_skip_labels_ptp` (default: `[]`): List of test labels to skip for PTP tests. These labels will be excluded using Ginkgo label filter syntax (`!label`). Common PTP labels include: `node-reboot`, `process-restart`, `event-consumer`, `events-and-metrics`, `interfaces`, `leap-file`, `ntp-fallback`. Example: `['node-reboot', 'process-restart']` to skip node reboot and process restart tests.
 - `eco_gotests_path` (default: undefined): path where to find the source code to build the container. If this is specified, the `eco_gotests_image` is ignored.
+- `eco_gotests_dump_failed_tests` (default: `false`): When true, eco-gotests sets `ECO_DUMP_FAILED_TESTS` and writes per-failure logs and must-gather under the suite reports directory. 
 
 #### SRIOV Test Configuration
 - `eco_gotests_sriov_labels` (default: `"sriov-hw-enabled"`): Test labels for SRIOV tests
@@ -37,10 +38,10 @@ This role runs [eco-gotests](https://github.com/rh-ecosystem-edge/eco-gotests) f
 - `eco_gotests_dpdk_test_container` (default: `"quay.io/ocp-edge-qe/eco-gotests-rootless-dpdk:v4.16.0"`): DPDK test container
 - `eco_gotests_frr_image` (default: `"quay.io/ocp-edge-qe/frr:stable_7.5"`): FRR image
 - `eco_gotests_sriov_timeout` (default: `"12h"`): Timeout for SRIOV tests
-- `eco_gotests_reports_dump_dir` (default: `"/tmp/reports"`): Directory for dumping reports
 - `eco_gotests_verbose_level` (default: `100`): Verbosity level
 - `eco_gotests_test_verbose` (default: `true`): Enable verbose test output
-- `eco_gotests_dump_failed_tests` (default: `true`): Dump failed test information
+
+SRIOV uses the same `eco_gotests_dump_failed_tests` toggle; reports are written at `/tmp/reports` in the container, mapped to `{{ eco_gotests_log_dir }}/eco_gotests/sriov` on the host.
 
 ## Example Playbook
 

--- a/roles/eco_gotests/defaults/main.yml
+++ b/roles/eco_gotests/defaults/main.yml
@@ -5,6 +5,7 @@ eco_gotests_image: "quay.io/ocp-edge-qe/eco-gotests:latest"
 eco_gotests_test_suites: []  # ['ptp', 'sriov']
 eco_gotests_log_dir: "/tmp/gotests_log"
 eco_gotests_registry_auth_file: ""
+eco_gotests_dump_failed_tests: false
 
 # SRIOV test configuration
 eco_gotests_sriov_labels: "sriov-hw-enabled"
@@ -16,6 +17,5 @@ eco_gotests_frr_image: "quay.io/ocp-edge-qe/frr:stable_7.5"
 eco_gotests_sriov_timeout: "12h"
 eco_gotests_verbose_level: 100
 eco_gotests_test_verbose: true
-eco_gotests_dump_failed_tests: true
 
 eco_gotests_skip_labels_ptp: []

--- a/roles/eco_gotests/tasks/ptp.yml
+++ b/roles/eco_gotests/tasks/ptp.yml
@@ -46,9 +46,41 @@
       ECO_TEST_FEATURES: "ptp"
       REGISTRY_AUTH_FILE: "{{ eco_gotests_registry_auth_file }}"
       ECO_TEST_LABELS: "{{ _eco_gotests_ptp_test_labels }}"
+      ECO_REPORTS_DUMP_DIR: "/tmp/reports"
+      ECO_DUMP_FAILED_TESTS: "{{ eco_gotests_dump_failed_tests | bool }}"
     volumes:
       - "{{ eco_gotests_kubconfig_dir }}/:/kubeconfig:Z"
       - "{{ eco_gotests_log_dir }}/eco_gotests/ptp:/tmp/reports:Z"
     detach: false
     remove: true
   failed_when: false
+
+- name: "Stat failed PTP suite dump directory"
+  ansible.builtin.stat:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/ptp/failed_ptp_suite_test"
+  register: _eco_gotests_ptp_failed_dump_stat
+
+- name: "Compress failed PTP suite dumps to failed_ptp_suite_test.tar.gz"
+  ansible.builtin.archive:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/ptp/failed_ptp_suite_test"
+    dest: "{{ eco_gotests_log_dir }}/failed_ptp_suite_test.tar.gz"
+    format: gz
+    mode: "0644"
+  when:
+    - eco_gotests_dump_failed_tests | bool
+    - _eco_gotests_ptp_failed_dump_stat.stat.exists | default(false)
+    - _eco_gotests_ptp_failed_dump_stat.stat.isdir | default(false)
+
+- name: "Remove failed PTP suite dump directory after compression"
+  ansible.builtin.file:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/ptp/failed_ptp_suite_test"
+    state: absent
+  when:
+    - eco_gotests_dump_failed_tests | bool
+    - _eco_gotests_ptp_failed_dump_stat.stat.exists | default(false)
+    - _eco_gotests_ptp_failed_dump_stat.stat.isdir | default(false)
+
+- name: "Remove temporary PTP testrun report file"
+  ansible.builtin.file:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/ptp/report_testrun.xml"
+    state: absent

--- a/roles/eco_gotests/tasks/sriov.yml
+++ b/roles/eco_gotests/tasks/sriov.yml
@@ -15,7 +15,7 @@
       ECO_REPORTS_DUMP_DIR: "/tmp/reports"
       ECO_VERBOSE_LEVEL: "{{ eco_gotests_verbose_level }}"
       ECO_TEST_VERBOSE: "{{ eco_gotests_test_verbose | lower }}"
-      ECO_DUMP_FAILED_TESTS: "{{ eco_gotests_dump_failed_tests | lower }}"
+      ECO_DUMP_FAILED_TESTS: "{{ eco_gotests_dump_failed_tests | bool }}"
       ECO_TEST_FEATURES: "sriov"
       ECO_TEST_LABELS: "{{ eco_gotests_sriov_labels }}"
       ECO_WORKER_LABEL: "{{ eco_gotests_worker_label }}"
@@ -32,3 +32,33 @@
     remove: true
     command: ["--timeout={{ eco_gotests_sriov_timeout }}", "--keep-going"]
   failed_when: false
+
+- name: "Stat failed SRIOV suite dump directory"
+  ansible.builtin.stat:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/sriov/failed_sriov_suite_test"
+  register: _eco_gotests_sriov_failed_dump_stat
+
+- name: "Compress failed SRIOV suite dumps to failed_sriov_suite_test.tar.gz"
+  ansible.builtin.archive:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/sriov/failed_sriov_suite_test"
+    dest: "{{ eco_gotests_log_dir }}/failed_sriov_suite_test.tar.gz"
+    format: gz
+    mode: "0644"
+  when:
+    - eco_gotests_dump_failed_tests | bool
+    - _eco_gotests_sriov_failed_dump_stat.stat.exists | default(false)
+    - _eco_gotests_sriov_failed_dump_stat.stat.isdir | default(false)
+
+- name: "Remove failed SRIOV suite dump directory after compression"
+  ansible.builtin.file:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/sriov/failed_sriov_suite_test"
+    state: absent
+  when:
+    - eco_gotests_dump_failed_tests | bool
+    - _eco_gotests_sriov_failed_dump_stat.stat.exists | default(false)
+    - _eco_gotests_sriov_failed_dump_stat.stat.isdir | default(false)
+
+- name: "Remove temporary SRIOV testrun report file"
+  ansible.builtin.file:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/sriov/report_testrun.xml"
+    state: absent


### PR DESCRIPTION
##### SUMMARY

This patch improves eco-gotests artifact collection by enabling per-failure dumps (logs and must-gather data) so each issue is easier to investigate, especially in PTP runs. It also packages the generated failed_*_suite_test output into a .tar.gz archive, making it much simpler to share complete failure evidence for debugging.

##### ISSUE TYPE

- Enhanced Feature

##### Tests
- [x] https://www.distributed-ci.io/jobs/fb458eb9-4e57-42cd-bab1-61106d39980c

Test-Hint: no-check
