### PR TITLE
Add toggle for PTP prerequisite checks in eco_gotests role

### DIFF
--- a/roles/eco_gotests/README.md
+++ b/roles/eco_gotests/README.md
@@ -27,6 +27,7 @@ This role runs [eco-gotests](https://github.com/rh-ecosystem-edge/eco-gotests) f
 #### General Configuration
 - `eco_gotests_image` (default: `"quay.io/ocp-edge-qe/eco-gotests:latest"`): Container image for eco-gotests
 - `eco_gotests_skip_labels_ptp` (default: `[]`): List of test labels to skip for PTP tests. These labels will be excluded using Ginkgo label filter syntax (`!label`). Common PTP labels include: `node-reboot`, `process-restart`, `event-consumer`, `events-and-metrics`, `interfaces`, `leap-file`, `ntp-fallback`. Example: `['node-reboot', 'process-restart']` to skip node reboot and process restart tests.
+- `eco_gotests_ptp_check_prerequisites` (default: `true`): Enable or disable PTP prerequisites validation (`PtpOperatorConfig` checks for `enableEventPublisher` and `apiVersion`).
 - `eco_gotests_path` (default: undefined): path where to find the source code to build the container. If this is specified, the `eco_gotests_image` is ignored.
 
 #### SRIOV Test Configuration

--- a/roles/eco_gotests/defaults/main.yml
+++ b/roles/eco_gotests/defaults/main.yml
@@ -19,3 +19,4 @@ eco_gotests_test_verbose: true
 eco_gotests_dump_failed_tests: true
 
 eco_gotests_skip_labels_ptp: []
+eco_gotests_ptp_check_prerequisites: true

--- a/roles/eco_gotests/tasks/ptp.yml
+++ b/roles/eco_gotests/tasks/ptp.yml
@@ -1,32 +1,35 @@
 ---
-- name: "Check PTP prerequisites - PtpOperatorConfig"
-  kubernetes.core.k8s_info:
-    api_version: ptp.openshift.io/v1
-    kind: PtpOperatorConfig
-    name: default
-    namespace: openshift-ptp
-  register: _eco_gotests_ptp_operator_config
-  failed_when: false
+- name: "PTP prerequisites checks"
+  when: eco_gotests_ptp_check_prerequisites | bool
+  block:
+    - name: "Check PTP prerequisites - PtpOperatorConfig"
+      kubernetes.core.k8s_info:
+        api_version: ptp.openshift.io/v1
+        kind: PtpOperatorConfig
+        name: default
+        namespace: openshift-ptp
+      register: _eco_gotests_ptp_operator_config
+      failed_when: false
 
-- name: "Validate PTP prerequisites - enableEventPublisher"
-  ansible.builtin.assert:
-    that:
-      - _eco_gotests_ptp_operator_config.resources is defined
-      - _eco_gotests_ptp_operator_config.resources | length > 0
-      - _eco_gotests_ptp_operator_config.resources[0].spec.ptpEventConfig is defined
-      - _eco_gotests_ptp_operator_config.resources[0].spec.ptpEventConfig.enableEventPublisher | default(false) == true
-    fail_msg: "PTP prerequisite check failed: spec.ptpEventConfig.enableEventPublisher must be true"
-    success_msg: "PTP prerequisite check passed: enableEventPublisher is true"
+    - name: "Validate PTP prerequisites - enableEventPublisher"
+      ansible.builtin.assert:
+        that:
+          - _eco_gotests_ptp_operator_config.resources is defined
+          - _eco_gotests_ptp_operator_config.resources | length > 0
+          - _eco_gotests_ptp_operator_config.resources[0].spec.ptpEventConfig is defined
+          - _eco_gotests_ptp_operator_config.resources[0].spec.ptpEventConfig.enableEventPublisher | default(false) == true
+        fail_msg: "PTP prerequisite check failed: spec.ptpEventConfig.enableEventPublisher must be true"
+        success_msg: "PTP prerequisite check passed: enableEventPublisher is true"
 
-- name: "Validate PTP prerequisites - apiVersion"
-  ansible.builtin.assert:
-    that:
-      - _eco_gotests_ptp_operator_config.resources is defined
-      - _eco_gotests_ptp_operator_config.resources | length > 0
-      - _eco_gotests_ptp_operator_config.resources[0].spec.ptpEventConfig is defined
-      - _eco_gotests_ptp_operator_config.resources[0].spec.ptpEventConfig.apiVersion | default("") == "2.0"
-    fail_msg: "PTP prerequisite check failed: spec.ptpEventConfig.apiVersion must be '2.0'"
-    success_msg: "PTP prerequisite check passed: apiVersion is '2.0'"
+    - name: "Validate PTP prerequisites - apiVersion"
+      ansible.builtin.assert:
+        that:
+          - _eco_gotests_ptp_operator_config.resources is defined
+          - _eco_gotests_ptp_operator_config.resources | length > 0
+          - _eco_gotests_ptp_operator_config.resources[0].spec.ptpEventConfig is defined
+          - _eco_gotests_ptp_operator_config.resources[0].spec.ptpEventConfig.apiVersion | default("") == "2.0"
+        fail_msg: "PTP prerequisite check failed: spec.ptpEventConfig.apiVersion must be '2.0'"
+        success_msg: "PTP prerequisite check passed: apiVersion is '2.0'"
 
 - name: "Run PTP tests with eco-gotests"
   vars:


### PR DESCRIPTION
##### SUMMARY

Introduce `eco_gotests_ptp_check_prerequisites` (default `true`) to control whether PTP pre-check assertions run, and document the new variable in the role README.

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x] https://www.distributed-ci.io/jobs/fb458eb9-4e57-42cd-bab1-61106d39980c

Test-Hint: no-check