### PR TITLE
Increase retries in cluster compare

### DIFF
--- a/roles/cluster_compare/tasks/upstream.yml
+++ b/roles/cluster_compare/tasks/upstream.yml
@@ -11,7 +11,7 @@
     remote_src: true
     mode: '0755'
   register: _cc_extract
-  retries: 1
+  retries: 6
   delay: 10
   until: _cc_extract is not failed
   loop_control:


### PR DESCRIPTION
##### SUMMARY

The cluster compare tool downloads artifacts from GH, 1 retry is likely not enough under certain circumstances as experienced previously. Increasing to retry at least for 1 min.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDQtMjhUMTY6MDU6NTk=
Gitleaks-Hash: 328164498dfa2fb20d2ace8186bfebbdfaa08231

##### ISSUE TYPE

- Nominal change

##### Tests


- [x] Testvcp: ocp-4.21-vanilla - https://www.distributed-ci.io/jobs/21416362-b0c3-48a5-a7a2-4b849177d7d9

---

Test-hints: no-check