### PR TITLE
Hide long logs for hardware info

### DIFF
--- a/roles/node_info/tasks/main.yml
+++ b/roles/node_info/tasks/main.yml
@@ -61,6 +61,7 @@
         - item.rc == 0
         - item.stdout is defined
         - (item.stdout | length) > 0
+      no_log: true
 
     - name: Disconnected image
       when:
@@ -138,13 +139,6 @@
       no_log: true
       changed_when: false
 
-    - name: Debug hardware_info
-      ansible.builtin.debug:
-        msg: "{{ _ni_hardware_info.results }}"
-      when:
-        - _ni_hardware_info is defined
-        - _ni_hardware_info.results is defined
-
     - name: Save hardware information to files
       ansible.builtin.copy:
         content: >-
@@ -156,5 +150,6 @@
         dest: "{{ ni_job_logs_path }}/hardware.{{ item.node_name }}.json"
         mode: '0644'
       loop: "{{ _ni_hardware_info.results | default([]) }}"
+      no_log: true
 
 ...


### PR DESCRIPTION
##### SUMMARY

Logs are stored in files, there is no much value having them again in the ansible logs.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDQtMjhUMTg6Mjg6Mzk=
Gitleaks-Hash: 50dea1370b90192e21e2ceb2595c651b3e84756b

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/89d8e110-55ef-451c-a2c5-16ea217f909e

Test-Hints: no-check