### PR TITLE
Add retries to argocd cli

### DIFF
--- a/roles/argocd_config/tasks/config-repo.yml
+++ b/roles/argocd_config/tasks/config-repo.yml
@@ -33,6 +33,10 @@
         url: "https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64"
         dest: "{{ _ac_tmp_dir.path }}/argocd"
         mode: "0750"
+      register: _ac_cli
+      retries: 6
+      delay: 10
+      until: _ac_cli is not failed
 
     - name: Get ArgoCD password
       kubernetes.core.k8s_info:


### PR DESCRIPTION
##### SUMMARY

Retry some when attempting to download the argocd CLI

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDQtMzBUMTU6NDQ6NTE=
Gitleaks-Hash: f3a0610cd5077951b69e7a522f5b73371b483e53

##### ISSUE TYPE

- Nominal change

##### Tests

Test-Hint: no-check