### PR TITLE
Allow the use of unsigned images

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        2.21.EPOCH
+Version:        2.22.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -54,8 +54,10 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Fri May  1 2026 Tony Garcia <tonyg@redhat.com> - 2.22.EPOCH-VERS
+- Version bump due to changes in acm_setup
 
-* Thu Mar 5 2026 Beto Rdz <josearod@redhat.com> - 2.21.EPOCH-VERS
+* Thu Mar  5 2026 Beto Rdz <josearod@redhat.com> - 2.21.EPOCH-VERS
 - Use oc-mirror in mirror_ocp_release
 
 * Thu Feb  5 2026 Frederic Lepied <flepied@redhat.com> - 2.20.EPOCH-VERS

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 2.21.0
+version: 2.22.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/acm_setup/README.md
+++ b/roles/acm_setup/README.md
@@ -11,21 +11,22 @@ The configuration of the ACM hub can be customized by using the following variab
 
 ## Variables
 
-| Variable                           | Default                       | Required    | Description
-| ---------------------------------- | ----------------------------- | ----------- | ----------------------------------------------
-|hub_availability                    |High                           |No           | Multicluster hub High Availability configuration
-|hub_disable_selfmanagement          |False                          |No           | Do not import the hub cluster as managed in ACM
-|hub_namespace                       |open-cluster-management        |No           | Namespace where ACM has been installed and will be configured
-|hub_instance                        |multiclusterhub                |No           | Name of the multiclusterhub instance to be created (fail if already exists)
-|hub_disconnected                    |false                          |No           | If true, it will create custom ClusterImageSets and remove the Channel subscriptions
-|hub_sc                              |Undefined                      |If no default StorageClass is available | Desired storage class for ACM resources. If undefined, the default SC will be used
-|hub_hugepages_type                  |hugepages-2Mi                  |No           | Hugepages type to be configured for Postgres search pods. x86_64 support hugepages-2Mi and hugepages-1Gi
-|hub_hugepages_size                  |1024Mi                         |No           | Hugepages `hub_hugepages_type` size
-|hub_db_volume_size                  |40Gi                           |No           | This value specifies how much storage it is allocated for storing files like database tables and database views for the clusters. You might need to use a higher value if there are many clusters
-|hub_fs_volume_size                  |50Gi                           |No           | This value specifies how much storage is allocated for storing logs, manifests, and kubeconfig files for the clusters. You might need to use a higher value if there are many clusters
-|hub_img_volume_size                 |40Gi                           |No           | This value specifies how much storage is allocated for the images of the clusters. You need to allow 1 GB of image storage for each instance of Red Hat Enterprise Linux CoreOS
-|hub_img_svc_skip_tls_verify     |false                          |No           | Skip TLS verification in the AgentServiceConfig for image service operations. Useful in environments with self-signed certificates or certificate issues.
-|hub_os_images                       |<Undefined>                    |No           | Locations of OS Images to be used when generating the discovery ISOs for different OpenShift versions. See [OS images](./README.md#os-images). It is mandatory for disconnected environments.
+| Variable                     | Default                  | Required  | Description
+| ---------------------------- | ------------------------ | --------- | ----------------------------------------------
+| hub_availability             | High                     | No        | Multicluster hub High Availability configuration
+| hub_disable_selfmanagement   | False                    | No        | Do not import the hub cluster as managed in ACM
+| hub_namespace                | open-cluster-management  | No        | Namespace where ACM has been installed and will be configured
+| hub_instance                 | multiclusterhub          | No        | Name of the multiclusterhub instance to be created (fail if already exists)
+| hub_disconnected             | false                    | No        | If true, it will create custom ClusterImageSets and remove the Channel subscriptions
+| hub_sc                       | Undefined                | No        | Desired storage class for ACM resources. If undefined, the default SC will be used
+| hub_hugepages_type           | hugepages-2Mi            | No        | Hugepages type to be configured for Postgres search pods. x86_64 support hugepages-2Mi and hugepages-1Gi
+| hub_hugepages_size           | 1024Mi                   | No        | Hugepages `hub_hugepages_type` size
+| hub_db_volume_size           | 40Gi                     | No        | This value specifies how much storage it is allocated for storing files like database tables and database views for the clusters. You might need to use a higher value if there are many clusters
+| hub_fs_volume_size           | 50Gi                     | No        | This value specifies how much storage is allocated for storing logs, manifests, and kubeconfig files for the clusters. You might need to use a higher value if there are many clusters
+| hub_img_volume_size          | 80Gi                     | No        | This value specifies how much storage is allocated for the images of the clusters. You need to allow 1 GB of image storage for each instance of Red Hat Enterprise Linux CoreOS
+| hub_img_svc_skip_tls_verify  | false                    | No        | Skip TLS verification in the AgentServiceConfig for image service operations. Useful in environments with self-signed certificates or certificate issues.
+| hub_os_images                | <Undefined>              | No        | Locations of OS Images to be used when generating the discovery ISOs for different OpenShift versions. See [OS images](./README.md#os-images). It is mandatory for disconnected environments.
+| hub_use_configmap            | false                    | No        | Allow the AgentServiceConfig to use a ConfigMap with custom env vars to modify its behavior like to disable Image Policy.
 
 ## Requirements
 1. An OpenShift Cluster with a subscription for the ACM operator.

--- a/roles/acm_setup/defaults/main.yml
+++ b/roles/acm_setup/defaults/main.yml
@@ -11,4 +11,5 @@ hub_fs_volume_size: 50Gi
 hub_img_volume_size: 80Gi
 hub_vm_external_network: true
 hub_img_svc_skip_tls_verify: false
+hub_use_configmap: false
 ...

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -341,6 +341,18 @@
     namespace: multicluster-engine
   register: _asg
 
+- name: Use Assisted Service ConfigMap (disable image policy)
+  when: hub_use_configmap | bool
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: assisted-service-config
+        namespace: multicluster-engine
+      data:
+        OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY: "true"
+
 - name: "Get Hub Cluster mirroring configuration"
   ansible.builtin.include_tasks: get-mirroring-config.yml
   when:
@@ -360,6 +372,13 @@
           (hub_disconnected | bool) |
           ternary(
             {'unsupported.agent-install.openshift.io/assisted-service-allow-unrestricted-image-pulls': 'true'},
+            {}
+          )
+        ) |
+        combine(
+          (hub_use_configmap | bool) |
+          ternary(
+            {'unsupported.agent-install.openshift.io/assisted-service-configmap': 'assisted-service-config'},
             {}
           )
         )
@@ -464,9 +483,9 @@
           channel: "{{ cluster_version.resources[0].spec.channel }}"
           visible: 'true'
         name: "img-{{ cluster_version.resources[0].status.desired.version }}"
-        namespace: open-cluster-management
       spec:
         releaseImage: "{{ cluster_version.resources[0].status.desired.image }}"
   when:
     - hub_disconnected | bool
+
 ...


### PR DESCRIPTION
##### SUMMARY

New deployments of OCP require images to be signed, some builds may not
be signed (custom builds, nightly builds), through the AgentServiceConfig it
is possible to disable the ClusterImagePolicy that enforces the validation of
signed images.
 
Gitleaks-Sign: OC4zMC4wfDIwMjYtMDUtMDFUMTc6MDg6MTI=
Gitleaks-Hash: 85175aa8fde533973894f8426b1da1b3096d7a0b

##### ISSUE TYPE

- Nominal change


##### Tests


- [x] https://www.distributed-ci.io/jobs/5c2adfac-3782-4d48-b89e-0c1749c7d6af
- [x] https://www.distributed-ci.io/jobs/40f4e2a5-6bea-4031-90f0-4fecf0a5b2ea

Test-Hint: no-check
