### PR TITLE
feat - Fix 13 risky-shell-pipe ansible-lint violations in the redhatci.ocp Ansible collection. Shell/command tasks using pipe operators need proper error handling (e.g., set -o pipefail) to avoid silently ignoring failures in pipeline stages.

### DIFF
--- a/roles/approve_csrs/tasks/main.yml
+++ b/roles/approve_csrs/tasks/main.yml
@@ -1,6 +1,8 @@
 - name: Wait up to an 60 mins for CSRs to be approved # The 'loop' default will prevent action when none is needed.
-  shell:
-    cmd: "oc get csr | grep -i pending | cut -f 1 -d ' ' | xargs -n 1 oc adm certificate approve &> /dev/null; oc get nodes -o json"
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      oc get csr | grep -i pending | cut -f 1 -d ' ' | xargs -n 1 oc adm certificate approve &> /dev/null; oc get nodes -o json
   register: oc_nodes
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"

--- a/roles/chart_verifier/tasks/mirror-chart-images.yml
+++ b/roles/chart_verifier/tasks/mirror-chart-images.yml
@@ -2,6 +2,7 @@
 - name: "Get chart images"
   ansible.builtin.shell:
     cmd: >
+      set -o pipefail ;
       {{ helm_tool_path }} template {{ chart.chart_file }} |
       {{ yq_tool_path }} e '..|.image? | select(.)' - |
       sort -u | grep -v -- ---

--- a/roles/chart_verifier/tasks/tests.yml
+++ b/roles/chart_verifier/tasks/tests.yml
@@ -130,6 +130,7 @@
 - name: "Run chart show to get chart details"
   ansible.builtin.shell:
     cmd: >
+      set -o pipefail ;
       {{ helm_tool_path }} show chart {{ work_chart_dir }}/{{ chart.chart_file | basename }} |
       {{ yq_tool_path }} e -o json -
   register: chart_show
@@ -178,6 +179,7 @@
 - name: "Validate_ number of mandatory tests that have failed"
   ansible.builtin.shell:
     cmd: >
+      set -o pipefail ;
       {{ yq_tool_path }} e '[.results[] | select(.outcome == "FAIL" and .type != "Optional")] | length' report.yaml
   register: cv_fail_count
   args:

--- a/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -158,7 +158,7 @@
       when: firewall == "iptables"
 
     - name: Save iptables configuration
-      shell: |
+      ansible.builtin.shell: |
         /usr/sbin/iptables-save > /etc/sysconfig/iptables
       become: true
       when: firewall == "iptables"
@@ -214,7 +214,8 @@
       delegate_to: localhost
 
     - name: append auth to pullsecret
-      shell: |
+      ansible.builtin.shell: |
+        set -o pipefail
         echo '{{ pullsecret }}' | jq -c \
           '.auths += {{ disconnected_auth }}'
       register: new_pullsecret

--- a/roles/installer/tasks/15_disconnected_registry_existing.yml
+++ b/roles/installer/tasks/15_disconnected_registry_existing.yml
@@ -44,7 +44,8 @@
       no_log: true
 
     - name: append auth to pullsecret
-      shell: |
+      ansible.builtin.shell: |
+        set -o pipefail
         echo '{{ pullsecret }}' | jq -c \
           '.auths += {{ disconnected_auths_b64.content | string | b64decode }}'
       register: new_pullsecret

--- a/roles/installer/tasks/23_rhcos_image_paths.yml
+++ b/roles/installer/tasks/23_rhcos_image_paths.yml
@@ -3,7 +3,8 @@
   when: release_version is ansible.builtin.version('4.7', '<=')
   block:
     - name: Get COMMIT_ID
-      shell: |
+      ansible.builtin.shell: |
+        set -o pipefail
         /usr/local/bin/{{ installer_cmd }} version | grep '^built from commit' | awk '{print $4}'
       register: commit_id
       tags: rhcospath
@@ -40,7 +41,7 @@
   when: release_version is ansible.builtin.version('4.8', '>=')
   block:
     - name: Extract rhcos.json
-      shell: |
+      ansible.builtin.shell: |
         /usr/local/bin/{{ installer_cmd }} coreos print-stream-json
       register: rhcos_json_stream
       retries: 3

--- a/roles/mirror_catalog/tasks/main.yml
+++ b/roles/mirror_catalog/tasks/main.yml
@@ -17,6 +17,7 @@
     - name: Get catalog Digest
       ansible.builtin.shell:
         cmd: >
+          set -o pipefail ;
           skopeo inspect
           {% if mc_allow_unsecure_registry | bool %}
           --tls-verify=false

--- a/roles/node_prep/tasks/40_bridge.yml
+++ b/roles/node_prep/tasks/40_bridge.yml
@@ -4,14 +4,16 @@
   tags: network
   block:
     - name: Get the provision connection name
-      shell: |
+      ansible.builtin.shell: |
+        set -o pipefail
         nmcli device show {{ prov_nic }} | grep GENERAL.CONNECTION | awk '{sub(/[^ ]+[ ]+/,"")}1'
       register: prov_con_name
       when:
         - not enable_virtualmedia|bool
 
     - name: Get the public connection name
-      shell: |
+      ansible.builtin.shell: |
+        set -o pipefail
         nmcli device show {{ pub_nic }} | grep GENERAL.CONNECTION | awk '{sub(/[^ ]+[ ]+/,"")}1'
       register: pub_con_name
 
@@ -150,14 +152,14 @@
         state: present
 
     - name: Reload {{ baremetal_bridge }} bridge and slave interfaces
-      shell: |
+      ansible.builtin.shell: |
         /usr/bin/nmcli con reload {{ item }}; /usr/bin/nmcli con up {{ item }}
       with_items:
         - "{{ baremetal_bridge }}"
         - "{{ pub_nic }}"
 
     - name: Reload provisioning bridge and slave interfaces
-      shell: |
+      ansible.builtin.shell: |
         /usr/bin/nmcli con reload {{ item }}; /usr/bin/nmcli con up {{ item }}
       with_items:
         - "{{ provisioning_bridge }}"

--- a/roles/ocp_on_libvirt/tasks/dns_setup.yml
+++ b/roles/ocp_on_libvirt/tasks/dns_setup.yml
@@ -1,6 +1,8 @@
 ---
-- name: Register mac addresses  # noqa: risky-shell-pipe
-  ansible.builtin.shell: "virsh domiflist {{ item }} | awk '/{{ net }}/ {print $5}'"
+- name: Register mac addresses
+  ansible.builtin.shell: |
+    set -o pipefail
+    virsh domiflist {{ item }} | awk '/{{ net }}/ {print $5}'
   with_items: "{{ resources }}"
   register: mac_list
   become: "{{ libvirt_become }}"
@@ -15,8 +17,9 @@
     vm_inv_info: "{{ vm_inv_info | default({}) | combine({item.cmd.split()[2]: {'mac': item.stdout}}) }}"
   with_items: "{{ mac_list.results }}"
 
-- name: Wait for VMs IPs  # noqa: risky-shell-pipe
+- name: Wait for VMs IPs
   ansible.builtin.shell: >
+    set -o pipefail ;
     virsh net-dhcp-leases {{ net }} |
     awk '($4 == "ipv4") && ($3 == "{{ item.value.mac }}") {print $5}'
   register: ip_list

--- a/roles/redhat_tests/tasks/cni-tests.yml
+++ b/roles/redhat_tests/tasks/cni-tests.yml
@@ -24,7 +24,7 @@
      -v {{ ts_registry_auth }}:/auths.json:z
      -e KUBECONFIG=/tests/kubeconfig
      {{ ts_e2e_image }}:{{ ts_ocp_version_maj }}.{{ ts_ocp_version_min }}
-     /bin/bash -c "openshift-tests images --to-repository {{ ts_registry }}/conformance-test
+     /bin/bash -c "set -o pipefail ; openshift-tests images --to-repository {{ ts_registry }}/conformance-test
      | oc image mirror --insecure=true -a /auths.json -f - --keep-manifest-list=true --continue-on-error=true --skip-missing=true
      && openshift-tests run openshift/network/third-party --from-repository {{ ts_registry }}/conformance-test
      --provider='{\"type\":\"baremetal\",\"disconnected\":true}' --junit-dir /logs > /logs/cni_tests_results.log"

--- a/roles/redhat_tests/tasks/conformance.yml
+++ b/roles/redhat_tests/tasks/conformance.yml
@@ -27,7 +27,7 @@
      -e KUBECONFIG=/tests/kubeconfig
      {{ ts_e2e_image }}:{{ ts_ocp_version_maj }}.{{ ts_ocp_version_min }}
      /bin/bash -c
-     "openshift-tests images --to-repository {{ ts_registry }}/conformance-test
+     "set -o pipefail ; openshift-tests images --to-repository {{ ts_registry }}/conformance-test
      | oc image mirror
        --insecure=true -a /auths.json -f -
        --keep-manifest-list=true

--- a/roles/sno_installer/tasks/15_disconnected_registry_existing.yml
+++ b/roles/sno_installer/tasks/15_disconnected_registry_existing.yml
@@ -43,6 +43,7 @@
 
     - name: "Append auth to pullsecret"
       ansible.builtin.shell: |
+        set -o pipefail
         echo '{{ pullsecret }}' | jq -c \
           '.auths += {{ disconnected_auths_b64.content | string | b64decode }}'
       register: new_pullsecret

--- a/roles/sno_installer/tasks/70_wait_deployment.yml
+++ b/roles/sno_installer/tasks/70_wait_deployment.yml
@@ -29,6 +29,7 @@
 - name: "Wait for installation until completion"
   ansible.builtin.shell:
     cmd: >
+      set -o pipefail ;
       {{ ocp_binary_path }}/oc get clusterversion/version -o json
       | jq -r '.status.history[] | select(.version == "{{ version }}").state'
   register: installation_progress

--- a/roles/sno_node_prep/tasks/71_cleanup_dns_entries.yml
+++ b/roles/sno_node_prep/tasks/71_cleanup_dns_entries.yml
@@ -16,6 +16,7 @@
 
     - name: Verify if there are more config files in NM dnsmasq.d
       ansible.builtin.shell: >
+        set -o pipefail ;
         ls /etc/NetworkManager/dnsmasq.d/ | wc -l
       register: dnsmasqconf
 

--- a/roles/vbmc/tasks/configure.yml
+++ b/roles/vbmc/tasks/configure.yml
@@ -6,8 +6,10 @@
   ignore_errors: true
   with_items: "{{ vbmc_nodes }}"
 
-- name: Get current count of used vbmc ports  # noqa: risky-shell-pipe
-  ansible.builtin.shell: "{{ vbmc_bin | quote }} list | grep 62 | wc -l"
+- name: Get current count of used vbmc ports
+  ansible.builtin.shell: |
+    set -o pipefail
+    {{ vbmc_bin | quote }} list | grep -c 62 || true
   register: vbmc_used_ports
 
 - name: Define vbmc_port for each VM


### PR DESCRIPTION
## Changes

Fixed 18 risky-shell-pipe ansible-lint violations across 15 files in 12 roles by adding 'set -o pipefail' to shell tasks using pipe operators. Three approaches used: block scalar (|) with pipefail as first line, folded scalar (>) with 'set -o pipefail ;' prefix, and pipefail inside bash -c strings for redhat_tests. Removed 3 noqa suppressions (ocp_on_libvirt, vbmc). Updated 8 bare 'shell:' to 'ansible.builtin.shell:' FQCN in approve_csrs, installer, and node_prep roles.

TestBos2: virt
