### PR TITLE
feat: Move the cmdline_to_json filter plugin from distributedci/dci-ansible into the redhatci.ocp Ansible collection (dci-labs/ansible-collection-redhatci-ocp) so the collection is self-sufficient and does not depend on dci-ansible for this filter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Name | Type | Description
 [redhatci.ocp.junit2obj]() | Filter | Transforms a JUnit XML into a corresponding JSON text
 [redhatci.ocp.nmcli]() | Module | A modified module to manage networking based on [community.general.nmcli](https://github.com/ansible-collections/community.general)
 [redhatci.ocp.ocp_compatibility]() | Filter | Parse the deprecated and to-be-deprecated API after the workload installation
+[redhatci.ocp.cmdline_to_json]() | Filter | Convert a kernel command line string to a JSON object
 [redhatci.ocp.redact]() | Filter | Redact sensitive values from a dictionary
 [redhatci.ocp.regex_diff]() | Filter | Obtain differences between two lists
 

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        3.3.EPOCH
+Version:        3.4.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -54,6 +54,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Thu Jun  5 2026 Frederic Lepied <flepied@redhat.com> - 3.4.EPOCH-VERS
+- Add cmdline_to_json filter plugin
+
 * Tue Jun  2 2026 Tony Garcia <tonyg@redhat.com> - 3.3.EPOCH-VERS
 - Add find_available_port module
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 3.3.0
+version: 3.4.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/plugins/filter/cmdline_to_json.py
+++ b/plugins/filter/cmdline_to_json.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from json import dumps
+
+DOCUMENTATION = r"""
+    name: cmdline_to_json
+    version_added: "2.10"
+    short_description: Convert a kernel command line string to a JSON object
+    description:
+        - Parses a kernel command line string (space-separated key=value pairs)
+          and returns a JSON string representation.
+        - Handles bare flags (tokens without C(=)) by assigning them an empty
+          string value.
+        - Splits comma-separated values into lists, except for the C(BOOT_IMAGE) key.
+        - Supports dot-separated keys to create nested dictionary structures.
+    positional: _input
+    options:
+        _input:
+            description: The kernel command line string to parse.
+            type: str
+            required: true
+"""
+
+EXAMPLES = r"""
+    - name: Parse kernel cmdline into JSON
+      ansible.builtin.debug:
+        msg: "{{ ansible_cmdline_string | redhatci.ocp.cmdline_to_json }}"
+"""
+
+RETURN = r"""
+    _value:
+        description: JSON string representing the parsed kernel command line.
+        type: str
+"""
+
+
+def cmdline_to_json(cmdline=""):
+    """Convert a kernel command line string to a JSON object.
+
+    Args:
+        cmdline (str): The kernel command line string to parse.
+
+    Returns:
+        str: A JSON string representing the parsed kernel command line.
+    """
+    kernel = {}
+
+    for item in cmdline.split():
+        if "=" in item:
+            k, v = item.split("=", 1)
+            # Handle comma-separated values for specific keys
+            if "," in v and k not in ["BOOT_IMAGE"]:
+                v = v.split(",")
+        else:
+            k = item
+            v = ""
+
+        # Handle nested keys - any key with dots creates nested structure
+        if "." in k:
+            parts = k.split(".")
+            current = kernel
+            for part in parts[:-1]:
+                if part not in current:
+                    current[part] = {}
+                current = current[part]
+            current[parts[-1]] = v
+        else:
+            kernel[k] = v
+
+    return dumps(kernel)
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            "cmdline_to_json": cmdline_to_json,
+        }

--- a/roles/node_info/tasks/main.yml
+++ b/roles/node_info/tasks/main.yml
@@ -50,7 +50,7 @@
           {{ { 'kernel': {
             'node': (item.stdout | from_json).node,
             'version': (item.stdout | from_json).version,
-            'params': (((item.stdout | from_json).params | default('') | cmdline_to_json | from_json))
+            'params': (((item.stdout | from_json).params | default('') | redhatci.ocp.cmdline_to_json | from_json))
           } } | to_json }}
         dest: "{{ ni_job_logs_path }}/kernel.{{ item.node_name }}.json"
         mode: '0644'

--- a/tests/unit/filter/test_cmdline_to_json.py
+++ b/tests/unit/filter/test_cmdline_to_json.py
@@ -1,0 +1,135 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from ansible_collections.redhatci.ocp.plugins.filter import cmdline_to_json
+
+
+class TestCmdlineToJson:
+    def test_basic_key_value(self):
+        """Test basic key=value parsing"""
+        result = json.loads(cmdline_to_json.cmdline_to_json("root=/dev/sda1"))
+        assert result == {"root": "/dev/sda1"}
+
+    def test_multiple_key_value(self):
+        """Test multiple key=value pairs"""
+        result = json.loads(
+            cmdline_to_json.cmdline_to_json("root=/dev/sda1 console=ttyS0")
+        )
+        assert result == {"root": "/dev/sda1", "console": "ttyS0"}
+
+    def test_bare_flags(self):
+        """Test bare flags without values"""
+        result = json.loads(cmdline_to_json.cmdline_to_json("ro quiet"))
+        assert result == {"ro": "", "quiet": ""}
+
+    def test_mixed_flags_and_values(self):
+        """Test mix of bare flags and key=value pairs"""
+        result = json.loads(
+            cmdline_to_json.cmdline_to_json("ro root=/dev/sda1 quiet")
+        )
+        assert result == {"ro": "", "root": "/dev/sda1", "quiet": ""}
+
+    def test_dot_separated_nested_keys(self):
+        """Test dot-separated keys create nested dictionaries"""
+        result = json.loads(
+            cmdline_to_json.cmdline_to_json("systemd.unit=multi-user.target")
+        )
+        assert result == {"systemd": {"unit": "multi-user.target"}}
+
+    def test_deeply_nested_dot_keys(self):
+        """Test deeply nested dot-separated keys"""
+        result = json.loads(
+            cmdline_to_json.cmdline_to_json("a.b.c=value")
+        )
+        assert result == {"a": {"b": {"c": "value"}}}
+
+    def test_comma_separated_values(self):
+        """Test comma-separated values are split into lists"""
+        result = json.loads(
+            cmdline_to_json.cmdline_to_json("isolcpus=1,2,3")
+        )
+        assert result == {"isolcpus": ["1", "2", "3"]}
+
+    def test_boot_image_exception(self):
+        """Test BOOT_IMAGE with commas is NOT split"""
+        result = json.loads(
+            cmdline_to_json.cmdline_to_json(
+                "BOOT_IMAGE=(hd0,gpt2)/vmlinuz-5.14.0"
+            )
+        )
+        assert result == {"BOOT_IMAGE": "(hd0,gpt2)/vmlinuz-5.14.0"}
+
+    def test_empty_input(self):
+        """Test empty string input returns empty JSON object"""
+        result = json.loads(cmdline_to_json.cmdline_to_json(""))
+        assert result == {}
+
+    def test_default_argument(self):
+        """Test calling without arguments uses default empty string"""
+        result = json.loads(cmdline_to_json.cmdline_to_json())
+        assert result == {}
+
+    def test_full_cmdline(self):
+        """Test a realistic full kernel command line"""
+        cmdline = (
+            "BOOT_IMAGE=(hd0,gpt2)/vmlinuz-5.14.0-362.el9.x86_64 "
+            "root=/dev/mapper/rhel-root ro crashkernel=1G-4G:192M,4G-64G:256M "
+            "resume=/dev/mapper/rhel-swap rd.lvm.lv=rhel/root "
+            "rd.lvm.lv=rhel/swap quiet"
+        )
+        result = json.loads(cmdline_to_json.cmdline_to_json(cmdline))
+
+        assert result["BOOT_IMAGE"] == "(hd0,gpt2)/vmlinuz-5.14.0-362.el9.x86_64"
+        assert result["root"] == "/dev/mapper/rhel-root"
+        assert result["ro"] == ""
+        assert result["quiet"] == ""
+        # crashkernel has commas so it becomes a list
+        assert isinstance(result["crashkernel"], list)
+        assert result["crashkernel"] == ["1G-4G:192M", "4G-64G:256M"]
+        # resume is a plain key=value
+        assert result["resume"] == "/dev/mapper/rhel-swap"
+        # rd.lvm.lv uses dot notation -> nested dict
+        assert result["rd"]["lvm"]["lv"] == "rhel/swap"
+
+    def test_value_with_equals_sign(self):
+        """Test value containing an equals sign"""
+        result = json.loads(
+            cmdline_to_json.cmdline_to_json("key=val=ue")
+        )
+        assert result == {"key": "val=ue"}
+
+
+class TestFilterModule:
+    def test_filter_module_returns_cmdline_to_json_filter(self):
+        """Test that FilterModule properly exposes the filter"""
+        filter_module = cmdline_to_json.FilterModule()
+        filters = filter_module.filters()
+        assert "cmdline_to_json" in filters
+        assert filters["cmdline_to_json"] == cmdline_to_json.cmdline_to_json
+
+    def test_filter_module_can_be_called(self):
+        """Test that the filter can be called through FilterModule"""
+        filter_module = cmdline_to_json.FilterModule()
+        filters = filter_module.filters()
+        func = filters["cmdline_to_json"]
+
+        result = json.loads(func("key=value"))
+        assert result == {"key": "value"}


### PR DESCRIPTION
## Summary

Move the cmdline_to_json filter plugin from distributedci/dci-ansible into the redhatci.ocp Ansible collection (dci-labs/ansible-collection-redhatci-ocp) so the collection is self-sufficient and does not depend on dci-ansible for this filter.

## Changes

Created plugins/filter/cmdline_to_json.py (filter plugin ported from dci-ansible with Apache 2.0 header, DOCUMENTATION/EXAMPLES/RETURN blocks, __future__ imports), created tests/unit/filter/test_cmdline_to_json.py (14 unit tests covering key=value, bare flags, nested dot keys, comma-separated values, BOOT_IMAGE exception, empty input, full cmdline, FilterModule class), modified roles/node_info/tasks/main.yml line 53 (cmdline_to_json → redhatci.ocp.cmdline_to_json FQCN). All 14 tests pass. GPG-signed commit.

TestHints: no-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `cmdline_to_json` filter plugin that converts Linux kernel command lines into JSON objects, enabling structured processing of kernel parameters.

* **Documentation**
  * Updated plugin documentation to include the new filter.

* **Tests**
  * Added comprehensive unit test coverage for the filter plugin, including edge cases and nested parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->