### PR TITLE
feat: Remove obsolete clusterosimage variable

### DIFF
--- a/roles/installer/tasks/24_rhcos_image_cache.yml
+++ b/roles/installer/tasks/24_rhcos_image_cache.yml
@@ -1,7 +1,7 @@
 ---
 # If we're executing these plays, then:
 # 1. cache_enabled is true
-# 2. Either one or both bootstraposimage/clusterosimage variables are unset
+# 2. bootstraposimage variable is unset
 
 - name: Confirm whether or not internet connectivity on provisioner host
   uri:
@@ -91,7 +91,6 @@
   set_fact:
     rhcos_qemu_sha256: "{{ rhcos_json.json | json_query('images.qemu.sha256') }}"
     rhcos_qemu_sha256_unzipped: '{{ rhcos_json.json | json_query(''images.qemu."uncompressed-sha256"'') }}'
-    rhcos_sha256: "{{ rhcos_json.json | json_query('images.openstack.sha256') }}"
   tags: cache
   when: release_version is ansible.builtin.version('4.7', '<=')
 
@@ -99,11 +98,9 @@
   set_fact:
     rhcos_qemu_sha256: "{{ rhcos_json | json_query(rhcos_qemu_sha_key) }}"
     rhcos_qemu_sha256_unzipped: "{{ rhcos_json | json_query(rhcos_qemu_sha_unzip_key) }}"
-    rhcos_sha256: "{{ rhcos_json | json_query(rhcos_openstack_sha_key) }}"
   vars:
     rhcos_qemu_sha_key: 'architectures.x86_64.artifacts.qemu.formats."qcow2.gz".disk.sha256'
     rhcos_qemu_sha_unzip_key: 'architectures.x86_64.artifacts.qemu.formats."qcow2.gz".disk."uncompressed-sha256"'
-    rhcos_openstack_sha_key: 'architectures.x86_64.artifacts.openstack.formats."qcow2.gz".disk.sha256'
   tags: cache
   when: release_version is ansible.builtin.version('4.8', '>=')
 
@@ -121,23 +118,6 @@
   delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
   tags: cache
 
-- name: Download {{ rhcos_uri }} for cache
-  get_url:
-    url: "{{ rhcos_path }}{{ rhcos_uri }}"
-    dest: "{{ provision_cache_store }}{{ rhcos_uri }}"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0644'
-    setype: httpd_sys_content_t
-    checksum: "sha256:{{ rhcos_sha256 }}"
-    timeout: 3600
-  when: (clusterosimage is not defined or clusterosimage|length < 1)
-  delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
-  tags: cache
-
-  # use the hostname from the inventory to groups[registry][0] or provisioner[0] as the http://URL
-  # use a ternary to toggle between the url status
-  # use a ternary for the delegate_to
 - name: Get URL of host providing the webserver
   set_fact:
     host_url: "{{ (the_url.status in [200,301]) | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
@@ -150,21 +130,9 @@
   delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
   tags: cache
 
-- name: Set cluster image URL override if not provided by the user
-  set_fact:
-    clusterosimage: "http://{{ the_host_url }}:{{ webserver_caching_port }}/{{ rhcos_uri }}?sha256={{ rhcos_sha256 }}"
-  when: clusterosimage is not defined or clusterosimage|length < 1
-  delegate_to: "{{ url_passed | ternary(groups['provisioner'][0], groups['registry_host'][0]) }}"
-  tags: cache
-
 - name: BootstrapOSImage Details
   debug:
     msg: "{{ bootstraposimage }}"
-    verbosity: 2
-
-- name: ClusterOSImage Details
-  debug:
-    msg: "{{ clusterosimage }}"
     verbosity: 2
 
 # Leaving SELinux details alone and not using ":z"

--- a/roles/installer/templates/metal3-config.j2
+++ b/roles/installer/templates/metal3-config.j2
@@ -13,8 +13,4 @@ data:
   ironic_inspector_endpoint: http://{{ prov_ip|ipwrap }}:5050/v1/
   provisioning_interface: {{ masters_prov_nic }}
   provisioning_ip: {{ prov_ip }}/24
-{% if clusterosimage is defined and clusterosimage|length %}
-  rhcos_image_url: {{ clusterosimage }}
-{% else %}
   rhcos_image_url: {{ rhcos_path }}{{ rhcos_uri }}
-{% endif %}

--- a/roles/mirror_ocp_release/tasks/facts.yml
+++ b/roles/mirror_ocp_release/tasks/facts.yml
@@ -104,7 +104,6 @@
 - name: "Set facts for *osimage URL overrides"
   ansible.builtin.set_fact:
     bootstraposimage: "{{ mor_webserver_url }}/{{ ocp_release_data['rhcos_images']['qemu_location'] | basename }}?sha256={{ ocp_release_data['rhcos_images']['qemu_uncompressed_sha256'] }}"
-    clusterosimage: "{{ mor_webserver_url }}/{{ ocp_release_data['rhcos_images']['openstack_location'] | basename }}?sha256={{ ocp_release_data['rhcos_images']['openstack_sha256'] }}"
     metalosimage: "{{ mor_webserver_url }}/{{ ocp_release_data['rhcos_images']['metal_iso_location'] | basename }}?sha256={{ ocp_release_data['rhcos_images']['metal_iso_sha256'] }}"
   when:
     - mor_write_custom_config | bool

--- a/roles/node_prep/tasks/10_validation.yml
+++ b/roles/node_prep/tasks/10_validation.yml
@@ -57,12 +57,11 @@
     - always
     - validation
 
-- name: Fail if both bootstraposimage and clusterosimage variables are empty.
+- name: Fail if bootstraposimage variable is empty.
   fail:
-    msg: "Both bootraposimage and clusterosimage are empty. Please provide a URL or comment out."
+    msg: "bootstraposimage is defined but empty. Please provide a URL or comment out."
   when:
     - bootstraposimage is defined and bootstraposimage|length == 0
-    - clusterosimage is defined and clusterosimage|length == 0
   tags:
     - always
     - validation
@@ -71,10 +70,7 @@
   set_fact:
     cache_enabled: true
   when: (cache_enabled|bool) or
-        (bootstraposimage is undefined and clusterosimage is defined) or
-        (bootstraposimage is defined and clusterosimage is undefined) or
-        (clusterosimage is defined and bootstraposimage|length == 0) or
-        (bootstraposimage is defined and clusterosimage|length == 0)
+        (bootstraposimage is undefined)
   tags:
     - always
     - validation
@@ -83,7 +79,7 @@
   set_fact:
     cache_enabled: false
   when: (not cache_enabled|bool) or
-        (bootstraposimage is defined and clusterosimage is defined)
+        (bootstraposimage is defined)
   tags:
     - always
     - validation


### PR DESCRIPTION
## Summary

- Remove the obsolete `clusterosimage` variable which is no longer needed since the OpenStack RHCOS image was replaced by the direct RHCOS path in the metal3 config.
- Simplify cache logic and validation by removing all `clusterosimage`-related conditions and download tasks.
- Clean up related SHA256 computation, template conditionals, and debug output.

## Changes

- **roles/installer/tasks/24_rhcos_image_cache.yml**: Removed `rhcos_sha256` (OpenStack SHA) computation, the RHCOS download task for `clusterosimage`, the `clusterosimage` fact override, and the `ClusterOSImage Details` debug task.
- **roles/installer/templates/metal3-config.j2**: Removed conditional block for `clusterosimage`; always use `rhcos_path/rhcos_uri` directly.
- **roles/mirror_ocp_release/tasks/facts.yml**: Removed `clusterosimage` from the `set_fact` for OS image URL overrides.
- **roles/node_prep/tasks/10_validation.yml**: Simplified validation to only check `bootstraposimage`, removed `clusterosimage` from cache-enable/disable logic.


---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)

TestBos2: abi
TestBos2Sno: abi-sno
Testvcp: ocp-5.0-vanilla
