### PR TITLE
Update certsuite default version to v5.5.18

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.17
+kbpc_version: v5.5.18
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
SUMMARY
Update certsuite default version to v5.5.18

ISSUE TYPE
Nominal change

Tests

- [x] TestBos2Workload: certsuite-green certsuite-green:ansible_extravars=kbpc_version:v5.5.18 - https://www.distributed-ci.io/jobs/6b330aa5-6545-4b9e-a6f2-1657071a4f75

---


Test-Hints: no-check