### PR TITLE
Render properly labels in kvirt_vm role

### DIFF
--- a/roles/kvirt_vm/templates/vm-template.yml.j2
+++ b/roles/kvirt_vm/templates/vm-template.yml.j2
@@ -3,9 +3,11 @@ kind: "VirtualMachine"
 metadata:
   name: "{{ vm.name }}"
   namespace: "{{ vm.namespace | default(kvirt_vm_namespace) }}"
-  labels:
 {% if vm.labels is defined %}
-{{ vm.labels | to_nice_yaml | indent(4, True) }}
+  labels:
+{% for key, value in vm.labels.items() %}
+    {{ key }}: "{{ value }}"
+{% endfor %}
 {% endif %}
 spec:
   dataVolumeTemplates:
@@ -38,7 +40,9 @@ spec:
       labels:
         kubevirt.io/domain: "{{ vm.namespace | default(kvirt_vm_namespace) }}"
 {% if vm.labels is defined %}
-{{ vm.labels | to_nice_yaml | indent(8, True) | trim }}
+{% for key, value in vm.labels.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
 {% endif %}
     spec:
 {% if vm.node_selector is defined %}


### PR DESCRIPTION
##### SUMMARY

Replace label blocks with loops to produce valid idented output, avoid letting label sitting alone if not defined.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDUtMDhUMjE6NDM6NDg=
Gitleaks-Hash: 4f5db9326a954f689c8a13f21122b3fc7dec122d

##### ISSUE TYPE

- Bug

##### Tests

- [x] ocp-4.22-spoke-ztp - https://www.distributed-ci.io/jobs/a4cfadf8-fbd5-43b1-aee0-d3308d6d79d6

---

Test-Hint: no-check