### PR TITLE
Move patching of assistedserviceconfig to acm.utils

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        3.0.EPOCH
+Version:        3.1.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -54,6 +54,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Mon May 11 2026 Tony Garcia <tonyg@redhat.com> - 3.1.EPOCH-VERS
+- Move functionality from acm_setup to acm.utils
+
 * Tue May  5 2026 Beto Rdz  <josearod@redhat.com> - 3.0.EPOCH-VERS
 - Renamed imageset_mirroring to oci_mirror
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 3.0.0
+version: 3.1.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/acm/utils/README.md
+++ b/roles/acm/utils/README.md
@@ -50,6 +50,12 @@ into the `registries.conf` format using a custom registry.
 Disconnects the Assisted Service Agent by using a ConfigMap with the `registries.conf` content and CA bundle, as
 well as information about the OpenShift version and the ISO and rootfs images to use.
 
+
+### Assisted Service custom Config
+
+Allow the AgentServiceConfig to use a ConfigMap with custom env vars to modify its behavior like to disable Image Policy.
+The disable Image Policy allows spoke clusters to not enforce the verification of signatures on images. This is useful for images that are not signed, as custom builds or nightly builds.
+
 ## Usage example
 
 See below some examples of how to use the redhatci.ocp.acm.utils role 
@@ -139,4 +145,13 @@ This task generates the `utils_acm_registries` variable containing the transform
   ansible.builtin.include_role:
     name: redhatci.ocp.acm.utils
     tasks_from: validate-policies
+```
+
+### Example: Assisted Service custom Config
+
+```yaml
+- name: Disable signature verification
+  ansible.builtin.include_role:
+    name: redhatci.ocp.acm.utils
+    tasks_from: assisted-service-custom-config
 ```

--- a/roles/acm/utils/tasks/assisted-service-custom-config.yml
+++ b/roles/acm/utils/tasks/assisted-service-custom-config.yml
@@ -1,0 +1,23 @@
+---
+- name: Use Assisted Service ConfigMap (disable image policy)
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: assisted-service-config
+        namespace: multicluster-engine
+      data:
+        OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY: "true"
+
+- name: Patch AgentServiceConfig to use custom config
+  kubernetes.core.k8s:
+    api_version: agent-install.openshift.io/v1beta1
+    state: patched
+    kind: AgentServiceConfig
+    name: agent
+    namespace: multicluster-engine
+    definition:
+      metadata:
+        annotations:
+          unsupported.agent-install.openshift.io/assisted-service-configmap: assisted-service-config

--- a/roles/acm/utils/tasks/disconnect-agent.yml
+++ b/roles/acm/utils/tasks/disconnect-agent.yml
@@ -57,12 +57,14 @@
     kind: Pod
     label_selectors:
       - "app=assisted-image-service"
-    field_selectors:
-      - status.phase=Running
     namespace: multicluster-engine
-    wait: true
   register: pod_list
-  until: pod_list | json_query('resources[*].status.phase') | unique == ["Running"]
+  until:
+    - pod_list.resources | length > 0
+    - >
+      pod_list.resources
+      | json_query('[?status.conditions[?type==`Ready` && status==`True`]]')
+      | length == pod_list.resources | length
   retries: 20
   delay: 15
   no_log: true
@@ -73,12 +75,14 @@
     kind: Pod
     label_selectors:
       - "app=assisted-service"
-    field_selectors:
-      - status.phase=Running
     namespace: multicluster-engine
-    wait: true
   register: pod_list
-  until: pod_list | json_query('resources[*].status.phase') | unique == ["Running"]
+  until:
+    - pod_list.resources | length > 0
+    - >
+      pod_list.resources
+      | json_query('[?status.conditions[?type==`Ready` && status==`True`]]')
+      | length == pod_list.resources | length
   retries: 20
   delay: 15
   no_log: true

--- a/roles/acm_setup/README.md
+++ b/roles/acm_setup/README.md
@@ -26,7 +26,6 @@ The configuration of the ACM hub can be customized by using the following variab
 | hub_img_volume_size          | 80Gi                     | No        | This value specifies how much storage is allocated for the images of the clusters. You need to allow 1 GB of image storage for each instance of Red Hat Enterprise Linux CoreOS
 | hub_img_svc_skip_tls_verify  | false                    | No        | Skip TLS verification in the AgentServiceConfig for image service operations. Useful in environments with self-signed certificates or certificate issues.
 | hub_os_images                | <Undefined>              | No        | Locations of OS Images to be used when generating the discovery ISOs for different OpenShift versions. See [OS images](./README.md#os-images). It is mandatory for disconnected environments.
-| hub_use_configmap            | false                    | No        | Allow the AgentServiceConfig to use a ConfigMap with custom env vars to modify its behavior like to disable Image Policy.
 
 ## Requirements
 1. An OpenShift Cluster with a subscription for the ACM operator.

--- a/roles/acm_setup/tasks/main.yml
+++ b/roles/acm_setup/tasks/main.yml
@@ -341,18 +341,6 @@
     namespace: multicluster-engine
   register: _asg
 
-- name: Use Assisted Service ConfigMap (disable image policy)
-  when: hub_use_configmap | bool
-  kubernetes.core.k8s:
-    definition:
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: assisted-service-config
-        namespace: multicluster-engine
-      data:
-        OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY: "true"
-
 - name: "Get Hub Cluster mirroring configuration"
   ansible.builtin.include_tasks: get-mirroring-config.yml
   when:
@@ -372,13 +360,6 @@
           (hub_disconnected | bool) |
           ternary(
             {'unsupported.agent-install.openshift.io/assisted-service-allow-unrestricted-image-pulls': 'true'},
-            {}
-          )
-        ) |
-        combine(
-          (hub_use_configmap | bool) |
-          ternary(
-            {'unsupported.agent-install.openshift.io/assisted-service-configmap': 'assisted-service-config'},
             {}
           )
         )


### PR DESCRIPTION
##### SUMMARY

Patching the agent, is more likely to be a common action that not necessarily needs to be done during ACM configuration. Thus moving to a more generic location.

Also this is expected to be used by spoke deployments and not hub deployments, to allow the installation of non-public builds.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDUtMTFUMTg6MjI6NTU=
Gitleaks-Hash: 968eca9ed461861d875a7269ce397c417b8f9235

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x]   ocp-4.22-spoke-ztp - https://www.distributed-ci.io/jobs/b3d4d2b2-5827-46db-8aaa-faf469e0a5f6

---

Test-Hints: no-check