### PR TITLE
Add kubevirt_redfish role

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Name | Description
 [redhatci.ocp.jenkins_job_launcher](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/jenkins_job_launcher/README.md) | Launch Jenkins jobs
 [redhatci.ocp.junit2json](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/junit2json/README.md) | Convert JUnit XML files into JSON for reporting/observability role
 [redhatci.ocp.k8s_best_practices_certsuite](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/k8s_best_practices_certsuite/README.md) | Executes the [Red Hat Best Practices Test Suite for Kubernetes](https://github.com/redhat-best-practices-for-k8s/certsuite) tool.
+[redhatci.ocp.kubevirt_redfish](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/kubevirt_redfish/README.md) | Deploy kubevirt-redfish, a Redfish BMC emulator for KubeVirt virtual machines on OpenShift.
 [redhatci.ocp.kvirt_vm](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/kvirt_vm/README.md) | Deployment of Kubevirt virtual machines.
 [redhatci.ocp.label_nodes](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/label_nodes/README.md) | Applies labels defined at inventory level to the OCP cluster nodes.
 [redhatci.ocp.manage_firewalld_zone](roles/manage_firewalld_zone/README.md) | Manage a FirewallD zone.

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        3.1.EPOCH
+Version:        3.2.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -54,6 +54,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Tue May 21 2026 Tony Garcia <tonyg@redhat.com> - 3.2.EPOCH-VERS
+- Add kubevirt_redfish role
+
 * Mon May 11 2026 Tony Garcia <tonyg@redhat.com> - 3.1.EPOCH-VERS
 - Move functionality from acm_setup to acm.utils
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 3.1.0
+version: 3.2.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/kubevirt_redfish/README.md
+++ b/roles/kubevirt_redfish/README.md
@@ -1,0 +1,197 @@
+# kubevirt_redfish
+
+A role to deploy the kubevirt-redfish Redfish BMC emulator for KubeVirt virtual machines on OpenShift.
+
+## Description
+
+This role deploys kubevirt-redfish, which provides a Redfish BMC interface for managing KubeVirt virtual machines. It creates all required Kubernetes resources:
+
+- Namespace
+- ServiceAccount, Role, and RoleBinding (RBAC)
+- Configuration Secret
+- Deployment with health probes
+- Service
+- OpenShift Route (optional)
+
+The role also supports teardown by setting `kr_state: absent`.
+
+## Requirements
+
+- An OpenShift cluster with KubeVirt installed
+- Ansible collection: [kubernetes.core](https://galaxy.ansible.com/kubernetes/core)
+- The kubevirt-redfish container image must be accessible from the cluster
+
+## Role Variables
+
+### Core Settings
+
+| Variable            | Default                                                                   | Required | Description
+| --------            | -------                                                                   | -------- | -----------
+| kr_delete_namespace | false                                                                     | No       | Delete the namespace where kubevirt-redfish was deployed, used when kr_state is absent.
+| kr_image            | registry.redhat.io/container-native-virtualization/kubevirt-redfish-rhel9 | No       | Container image for the server
+| kr_helper_image     | registry.access.redhat.com/ubi10/ubi-minimal:latest                       | No       | Helper image for datavolume operations
+| kr_namespace        | kubevirt-redfish                                                          | No       | Target namespace
+| kr_sa_name          | kubevirt-redfish-sa                                                       | No       | ServiceAccount name
+| kr_scope            | namespaced                                                                | No       | Deployment scope (namespaced/cluster)
+| kr_state            | present                                                                   | No       | Desired state (present/absent)
+| kr_version          | v4.22                                                                     | No       | The tag of the image to use
+
+### Configuration
+
+The role supports two mutually exclusive ways to provide the kubevirt-redfish configuration:
+
+1. **Config file** (`kr_config_file`) — provide a pre-built `config.yaml` file. All config-related variables (`kr_vm_configs`, `kr_server_*`, `kr_datavolume_*`, etc.) are ignored.
+2. **Variables** (`kr_vm_configs` + defaults) — the role builds the config from individual variables.
+
+| Variable       | Default | Required | Description
+| --------       | ------- | -------- | -----------
+| kr_config_file | ""      | No       | Path to a pre-built config.yaml file
+| kr_vm_configs  | []      | No       | List of VM configurations (required when kr_config_file is not set)
+
+VM configuration object structure (used when `kr_config_file` is not set):
+
+```yaml
+- name: string         # Required: VM name
+  namespace: string    # Required: VM namespace
+  bmc_password: string # Required: BMC password for Redfish auth
+```
+
+### Server Settings
+
+| Variable                | Default  | Required | Description
+| --------                | -------  | -------- | -----------
+| kr_server_host          | 0.0.0.0  | No       | Server bind address
+| kr_server_port          | 8443     | No       | Server port
+| kr_server_tls_enabled   | false    | No       | Enable TLS on the server
+| kr_system_id_convention | legacy   | No       | Default system ID convention
+
+### Logging
+
+| Variable                   | Default | Required | Description
+| --------                   | ------- | -------- | -----------
+| kr_log_level               | info    | No       | App log level (debug/info/warning/error)
+| kr_redfish_log_level       | INFO    | No       | Redfish log level (DEBUG/INFO/WARNING/ERROR)
+| kr_redfish_logging_enabled | true    | No       | Enable Redfish logging
+
+### Deployment Settings
+
+| Variable                   | Default | Required | Description
+| --------                   | ------- | -------- | -----------
+| kr_replicas                | 1       | No       | Number of replicas
+| kr_image_pull_policy       | Always  | No       | Image pull policy
+| kr_deployment_wait         | true    | No       | Wait for deployment readiness
+| kr_deployment_wait_timeout | 300     | No       | Wait timeout in seconds
+
+### Resource Limits
+
+| Variable                     | Default | Required | Description
+| --------                     | ------- | -------- | -----------
+| kr_resources_requests_memory | 512Mi   | No       | Memory request
+| kr_resources_requests_cpu    | 100m    | No       | CPU request
+| kr_resources_limits_memory   | 2Gi     | No       | Memory limit
+| kr_resources_limits_cpu      | 500m    | No       | CPU limit
+
+### Datavolume Settings
+
+| Variable                           | Default             | Required | Description
+| --------                           | -------             | -------- | -----------
+| kr_datavolume_storage_size         | 5Gi                 | No       | Storage size
+| kr_datavolume_allow_insecure_tls   | true                | No       | Allow insecure TLS
+| kr_datavolume_storage_class        | managed-nfs-storage | No       | Storage class
+| kr_datavolume_vm_update_timeout    | 2m                  | No       | VM update timeout
+| kr_datavolume_iso_download_timeout | 30m                 | No       | ISO download timeout
+
+### Networking
+
+| Variable                 | Default   | Required | Description
+| --------                 | -------   | -------- | -----------
+| kr_service_type          | ClusterIP | No       | Service type (ClusterIP/NodePort/LoadBalancer)
+| kr_create_route          | true      | No       | Create an OpenShift Route
+| kr_route_tls_termination | edge      | No       | TLS termination (edge/passthrough/reencrypt)
+| kr_route_insecure_policy | Redirect  | No       | Insecure edge policy (Allow/Redirect/None)
+
+## Usage Examples
+
+### Basic Deployment
+
+```yaml
+- name: Deploy kubevirt-redfish
+  ansible.builtin.include_role:
+    name: redhatci.ocp.kubevirt_redfish
+  vars:
+    kr_vm_configs:
+      - name: worker-0
+        namespace: kubevirt-redfish
+        bmc_password: "{{ vault_worker0_bmc_password }}"
+      - name: worker-1
+        namespace: kubevirt-redfish
+        bmc_password: "{{ vault_worker1_bmc_password }}"
+```
+
+### Deploy with a Config File
+
+```yaml
+- name: Deploy kubevirt-redfish with pre-built config
+  ansible.builtin.include_role:
+    name: redhatci.ocp.kubevirt_redfish
+  vars:
+    kr_config_file: "/path/to/kubevirt-redfish-config.yaml"
+```
+
+### Custom Configuration
+
+```yaml
+- name: Deploy kubevirt-redfish with custom settings
+  ansible.builtin.include_role:
+    name: redhatci.ocp.kubevirt_redfish
+  vars:
+    kr_namespace: "my-redfish"
+    kr_image: "my-registry.example.com/kubevirt-redfish:v1.0"
+    kr_replicas: 2
+    kr_datavolume_storage_class: "ceph-rbd"
+    kr_resources_limits_memory: "4Gi"
+    kr_create_route: false
+    kr_vm_configs:
+      - name: node-0
+        namespace: my-redfish
+        bmc_password: "{{ vault_node0_password }}"
+```
+
+### Cluster-Scoped Deployment
+
+```yaml
+- name: Deploy kubevirt-redfish monitoring all namespaces
+  ansible.builtin.include_role:
+    name: redhatci.ocp.kubevirt_redfish
+  vars:
+    kr_scope: cluster
+    kr_namespace: kubevirt-redfish
+    kr_vm_configs:
+      - name: worker-0
+        namespace: tenant-a
+        bmc_password: "{{ vault_worker0_password }}"
+      - name: worker-1
+        namespace: tenant-b
+        bmc_password: "{{ vault_worker1_password }}"
+```
+
+### Teardown
+
+```yaml
+- name: Remove kubevirt-redfish
+  ansible.builtin.include_role:
+    name: redhatci.ocp.kubevirt_redfish
+  vars:
+    kr_state: absent
+    kr_scope: cluster
+    kr_namespace: kubevirt-redfish
+```
+
+## Notes
+
+- RBAC rules are preconfigured for kubevirt-redfish's requirements (KubeVirt VMs, CDI datavolumes, core resources)
+- `kr_scope: namespaced` creates Role + RoleBinding scoped to `kr_namespace`
+- `kr_scope: cluster` creates ClusterRole + ClusterRoleBinding for cross-namespace access
+- The configuration Secret contains BMC passwords and is handled with `no_log`
+- Teardown deletes all created resources individually (Route, Service, Deployment, Secret, RBAC, ServiceAccount, Namespace)
+- The container runs with `runAsNonRoot` and drops all capabilities

--- a/roles/kubevirt_redfish/defaults/main.yml
+++ b/roles/kubevirt_redfish/defaults/main.yml
@@ -1,0 +1,51 @@
+---
+kr_version: v4.22
+kr_image: "registry.redhat.io/container-native-virtualization/kubevirt-redfish-rhel9:{{ kr_version }}"
+kr_helper_image: "registry.access.redhat.com/ubi10/ubi-minimal:latest"
+kr_namespace: "kubevirt-redfish"
+kr_sa_name: "kubevirt-redfish-sa"
+# Options: namespaced, cluster
+kr_scope: "namespaced"
+
+kr_delete_namespace: false
+
+kr_config_file: ""
+
+kr_vm_configs: []
+kr_vm_username: admin
+
+# Options: legacy, enhanced
+kr_system_id_convention: "legacy"
+
+kr_server_host: "0.0.0.0"
+kr_server_port: 8443
+kr_server_tls_enabled: false
+
+kr_log_level: "info"
+kr_redfish_log_level: "INFO"
+# This is a string evaluated by the server as it's passed in an env
+kr_redfish_logging_enabled: "true"
+
+kr_replicas: 1
+kr_image_pull_policy: "Always"
+
+kr_resources_requests_memory: "512Mi"
+kr_resources_requests_cpu: "100m"
+kr_resources_limits_memory: "2Gi"
+kr_resources_limits_cpu: "500m"
+
+kr_datavolume_storage_size: "5Gi"
+kr_datavolume_allow_insecure_tls: true
+kr_datavolume_storage_class: "managed-nfs-storage"
+kr_datavolume_vm_update_timeout: "2m"
+kr_datavolume_iso_download_timeout: "30m"
+
+kr_service_type: "ClusterIP"
+kr_create_route: true
+kr_route_tls_termination: "edge"
+kr_route_insecure_policy: "Redirect"
+
+kr_state: "present"
+
+kr_deployment_wait: true
+kr_deployment_wait_timeout: 300

--- a/roles/kubevirt_redfish/meta/argument_specs.yml
+++ b/roles/kubevirt_redfish/meta/argument_specs.yml
@@ -1,0 +1,289 @@
+---
+argument_specs:
+  main:
+    short_description: Deploy kubevirt-redfish on OpenShift
+    description: >
+      Deploys the kubevirt-redfish Redfish BMC emulator for KubeVirt
+      virtual machines. Creates namespace, RBAC, configuration secret,
+      deployment, service, and optionally an OpenShift route.
+    options:
+      kr_version:
+        type: str
+        required: false
+        default: v4.22
+        description: >
+          The tag with the version for the image to use to deploy
+          kubevirt-redfish.
+      kr_image:
+        type: str
+        required: false
+        default: "registry.redhat.io/container-native-virtualization/kubevirt-redfish-rhel9:{{ kr_version }}"
+        description: >
+          Container image for kubevirt-redfish server.
+          The user is responsible for ensuring this image is
+          accessible from the cluster (mirrored if needed).
+
+      kr_helper_image:
+        type: str
+        required: false
+        default: "registry.access.redhat.com/ubi10/ubi-minimal:latest"
+        description: >
+          Helper image used by datavolume operations. The user is
+          responsible for ensuring this image is accessible from the
+          cluster (mirrored if needed).
+
+      kr_namespace:
+        type: str
+        required: false
+        default: "kubevirt-redfish"
+        description: Kubernetes namespace for the deployment.
+
+      kr_sa_name:
+        type: str
+        required: false
+        default: "kubevirt-redfish-sa"
+        description: Name of the ServiceAccount to create.
+
+      kr_scope:
+        type: str
+        required: false
+        default: "namespaced"
+        choices:
+          - namespaced
+          - cluster
+        description: >
+          Deployment scope. namespaced creates a Role and RoleBinding
+          in kr_namespace. cluster creates a ClusterRole and
+          ClusterRoleBinding for monitoring VMs across all namespaces.
+
+      kr_config_file:
+        type: path
+        required: false
+        default: ""
+        description: >
+          Path to a pre-built kubevirt-redfish config.yaml file.
+          When set, this file is used as-is for the configuration
+          Secret, and kr_vm_configs and other config variables
+          (kr_server_*, kr_datavolume_*, etc.) are ignored.
+          Mutually exclusive with kr_vm_configs.
+
+      kr_vm_configs:
+        type: list
+        required: false
+        default: []
+        elements: dict
+        description: >
+          List of virtual machine configurations. Each entry defines
+          a VM that kubevirt-redfish will manage via Redfish API.
+          Required when kr_config_file is not set.
+        options:
+          name:
+            type: str
+            required: true
+            description: Name of the virtual machine.
+          namespace:
+            type: str
+            required: true
+            description: Namespace where the virtual machine resides.
+          username:
+            type: str
+            required: false
+            default: admin
+            description: The user for Redfish authentication.
+          bmc_password:
+            type: str
+            required: true
+            description: BMC password for Redfish authentication.
+
+      kr_system_id_convention:
+        type: str
+        required: false
+        default: "legacy"
+        choices:
+          - "legacy"
+          - "enhanced"
+        description: Default system ID convention for chassis.
+
+      kr_server_host:
+        type: str
+        required: false
+        default: "0.0.0.0"
+        description: Bind address for the kubevirt-redfish server.
+
+      kr_server_port:
+        type: int
+        required: false
+        default: 8443
+        description: Port for the kubevirt-redfish server.
+
+      kr_server_tls_enabled:
+        type: bool
+        required: false
+        default: false
+        description: Enable TLS on the kubevirt-redfish server.
+
+      kr_log_level:
+        type: str
+        required: false
+        default: "info"
+        choices:
+          - debug
+          - info
+          - warning
+          - error
+        description: Application log level.
+
+      kr_redfish_log_level:
+        type: str
+        required: false
+        default: "INFO"
+        choices:
+          - DEBUG
+          - INFO
+          - WARNING
+          - ERROR
+        description: Redfish protocol log level.
+
+      kr_redfish_logging_enabled:
+        type: str
+        required: false
+        default: "true"
+        choices:
+          - "true"
+          - "false"
+        description: Enable or disable Redfish protocol logging.
+
+      kr_replicas:
+        type: int
+        required: false
+        default: 1
+        description: Number of deployment replicas.
+
+      kr_image_pull_policy:
+        type: str
+        required: false
+        default: "Always"
+        choices:
+          - Always
+          - IfNotPresent
+          - Never
+        description: Image pull policy for the deployment.
+
+      kr_resources_requests_memory:
+        type: str
+        required: false
+        default: "512Mi"
+        description: Memory request for the container.
+
+      kr_resources_requests_cpu:
+        type: str
+        required: false
+        default: "100m"
+        description: CPU request for the container.
+
+      kr_resources_limits_memory:
+        type: str
+        required: false
+        default: "2Gi"
+        description: Memory limit for the container.
+
+      kr_resources_limits_cpu:
+        type: str
+        required: false
+        default: "500m"
+        description: CPU limit for the container.
+
+      kr_datavolume_storage_size:
+        type: str
+        required: false
+        default: "5Gi"
+        description: Storage size for datavolume operations.
+
+      kr_datavolume_allow_insecure_tls:
+        type: bool
+        required: false
+        default: true
+        description: Allow insecure TLS for datavolume operations.
+
+      kr_datavolume_storage_class:
+        type: str
+        required: false
+        default: "managed-nfs-storage"
+        description: Storage class for datavolume PVCs.
+
+      kr_datavolume_vm_update_timeout:
+        type: str
+        required: false
+        default: "2m"
+        description: Timeout for VM update operations.
+
+      kr_datavolume_iso_download_timeout:
+        type: str
+        required: false
+        default: "30m"
+        description: Timeout for ISO download operations.
+
+      kr_service_type:
+        type: str
+        required: false
+        default: "ClusterIP"
+        choices:
+          - ClusterIP
+          - NodePort
+          - LoadBalancer
+        description: Kubernetes Service type.
+
+      kr_create_route:
+        type: bool
+        required: false
+        default: true
+        description: Create an OpenShift Route for the service.
+
+      kr_route_tls_termination:
+        type: str
+        required: false
+        default: "edge"
+        choices:
+          - edge
+          - passthrough
+          - reencrypt
+        description: TLS termination type for the Route.
+
+      kr_route_insecure_policy:
+        type: str
+        required: false
+        default: "Redirect"
+        choices:
+          - Allow
+          - Redirect
+          - None
+        description: Insecure edge termination policy for the Route.
+
+      kr_state:
+        type: str
+        required: false
+        default: "present"
+        choices:
+          - present
+          - absent
+        description: >
+          Desired state. Set to absent to remove all
+          kubevirt-redfish resources.
+
+      kr_delete_namespace:
+        type: bool
+        required: false
+        description: >
+          Delete also the namespace where kubevirt-redfish was deployed.
+
+      kr_deployment_wait:
+        type: bool
+        required: false
+        default: true
+        description: Wait for deployment to become ready.
+
+      kr_deployment_wait_timeout:
+        type: int
+        required: false
+        default: 300
+        description: Timeout in seconds when waiting for deployment readiness.

--- a/roles/kubevirt_redfish/tasks/config-file.yml
+++ b/roles/kubevirt_redfish/tasks/config-file.yml
@@ -1,0 +1,20 @@
+---
+- name: Read configuration file
+  ansible.builtin.slurp:
+    src: "{{ kr_config_file }}"
+  register: _kr_config_file_content
+  no_log: true
+
+- name: Create configuration Secret from file
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kubevirt-redfish-config
+        namespace: "{{ kr_namespace }}"
+      type: Opaque
+      data:
+        config.yaml: "{{ _kr_config_file_content.content }}"
+  no_log: true

--- a/roles/kubevirt_redfish/tasks/config-vars.yml
+++ b/roles/kubevirt_redfish/tasks/config-vars.yml
@@ -1,0 +1,64 @@
+---
+- name: Create configuration Secret from variables
+  vars:
+    _kr_config_data: |
+      kubevirt:
+        api_version: "v1"
+        timeout: 30
+
+      server:
+        host: "{{ kr_server_host }}"
+        port: "{{ kr_server_port }}"
+        tls:
+          enabled: "{{ kr_server_tls_enabled }}"
+
+      system_id_convention: "{{ kr_system_id_convention }}"
+
+      chassis:
+      {% for vm in kr_vm_configs %}
+        - name: "{{ vm.name }}"
+          namespace: "{{ vm.namespace }}"
+          service_account: "{{ kr_sa_name }}"
+          vm_selector:
+            labels:
+              redfish-enabled: "true"
+      {% endfor %}
+
+      authentication:
+        users:
+      {% set _users = {} %}
+      {% for vm in kr_vm_configs %}
+      {%   set _uname = vm.username | default(kr_vm_username) %}
+      {%   if _uname not in _users %}
+      {%     set _ = _users.update({_uname: {"password": vm.bmc_password, "chassis": []}}) %}
+      {%   endif %}
+      {%   set _ = _users[_uname]["chassis"].append(vm.name) %}
+      {% endfor %}
+      {% for uname, udata in _users.items() %}
+          - username: "{{ uname }}"
+            password: "{{ udata.password }}"
+            chassis:
+      {% for c in udata.chassis %}
+              - "{{ c }}"
+      {% endfor %}
+      {% endfor %}
+
+      datavolume:
+        storage_size: "{{ kr_datavolume_storage_size }}"
+        allow_insecure_tls: "{{ kr_datavolume_allow_insecure_tls }}"
+        storage_class: "{{ kr_datavolume_storage_class }}"
+        vm_update_timeout: "{{ kr_datavolume_vm_update_timeout }}"
+        iso_download_timeout: "{{ kr_datavolume_iso_download_timeout }}"
+        helper_image: "{{ kr_helper_image }}"
+  kubernetes.core.k8s:
+    state: present
+    definition: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kubevirt-redfish-config
+        namespace: "{{ kr_namespace }}"
+      type: Opaque
+      data:
+        config.yaml: "{{ _kr_config_data | b64encode }}"
+  no_log: true

--- a/roles/kubevirt_redfish/tasks/deploy.yml
+++ b/roles/kubevirt_redfish/tasks/deploy.yml
@@ -1,0 +1,133 @@
+---
+- name: Create Deployment
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kubevirt-redfish
+        namespace: "{{ kr_namespace }}"
+        labels:
+          app.kubernetes.io/name: kubevirt-redfish
+          app.kubernetes.io/component: server
+      spec:
+        replicas: "{{ kr_replicas }}"
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kubevirt-redfish
+            app.kubernetes.io/component: server
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: kubevirt-redfish
+              app.kubernetes.io/component: server
+          spec:
+            serviceAccountName: "{{ kr_sa_name }}"
+            securityContext:
+              runAsNonRoot: true
+            containers:
+              - name: kubevirt-redfish
+                image: "{{ kr_image }}"
+                imagePullPolicy: "{{ kr_image_pull_policy }}"
+                ports:
+                  - name: http
+                    containerPort: "{{ kr_server_port }}"
+                    protocol: TCP
+                env:
+                  - name: CONFIG_PATH
+                    value: "/app/config/config.yaml"
+                  - name: LOG_LEVEL
+                    value: "{{ kr_log_level }}"
+                  - name: REDFISH_LOG_LEVEL
+                    value: "{{ kr_redfish_log_level }}"
+                  - name: REDFISH_LOGGING_ENABLED
+                    value: "{{ kr_redfish_logging_enabled }}"
+                resources:
+                  requests:
+                    memory: "{{ kr_resources_requests_memory }}"
+                    cpu: "{{ kr_resources_requests_cpu }}"
+                  limits:
+                    memory: "{{ kr_resources_limits_memory }}"
+                    cpu: "{{ kr_resources_limits_cpu }}"
+                livenessProbe:
+                  httpGet:
+                    path: /redfish/v1/
+                    port: "{{ kr_server_port }}"
+                    scheme: "{{ kr_server_tls_enabled | bool | ternary('HTTPS', 'HTTP') }}"
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+                readinessProbe:
+                  httpGet:
+                    path: /redfish/v1/
+                    port: "{{ kr_server_port }}"
+                    scheme: "{{ kr_server_tls_enabled | bool | ternary('HTTPS', 'HTTP') }}"
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+                securityContext:
+                  runAsNonRoot: true
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                      - "ALL"
+                volumeMounts:
+                  - name: config-volume
+                    mountPath: /app/config
+                    readOnly: true
+            volumes:
+              - name: config-volume
+                secret:
+                  secretName: kubevirt-redfish-config
+    wait: "{{ kr_deployment_wait }}"
+    wait_timeout: "{{ kr_deployment_wait_timeout }}"
+
+- name: Create Service
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: kubevirt-redfish
+        namespace: "{{ kr_namespace }}"
+        labels:
+          app.kubernetes.io/name: kubevirt-redfish
+          app.kubernetes.io/component: server
+      spec:
+        type: "{{ kr_service_type }}"
+        ports:
+          - name: http
+            port: "{{ kr_server_port }}"
+            targetPort: "{{ kr_server_port }}"
+            protocol: TCP
+        selector:
+          app.kubernetes.io/name: kubevirt-redfish
+          app.kubernetes.io/component: server
+
+- name: Create Route
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: kubevirt-redfish
+        namespace: "{{ kr_namespace }}"
+        labels:
+          app.kubernetes.io/name: kubevirt-redfish
+          app.kubernetes.io/component: server
+      spec:
+        port:
+          targetPort: http
+        tls:
+          termination: "{{ kr_route_tls_termination }}"
+          insecureEdgeTerminationPolicy: "{{ kr_route_insecure_policy }}"
+        to:
+          kind: Service
+          name: kubevirt-redfish
+          weight: 100
+  when: kr_create_route | bool

--- a/roles/kubevirt_redfish/tasks/main.yml
+++ b/roles/kubevirt_redfish/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Remove kubevirt-redfish resources
+  ansible.builtin.include_tasks: teardown.yml
+  when:
+    - kr_state == "absent"
+
+- name: Deploy kubevirt-redfish
+  when: kr_state == "present"
+  block:
+    - name: Prepare kubevirt-redfish namespace
+      ansible.builtin.include_tasks: prep.yml
+
+    - name: Apply configuration from file
+      when: kr_config_file | length > 0
+      ansible.builtin.include_tasks: config-file.yml
+
+    - name: Config from variables
+      when:
+        - kr_config_file | length == 0
+        - kr_vm_configs | length > 0
+      ansible.builtin.include_tasks: config-vars.yml
+
+    - name: Deploy kubevirt-redfish workload
+      ansible.builtin.include_tasks: deploy.yml
+      when: kr_config_file | length > 0 or kr_vm_configs | length > 0

--- a/roles/kubevirt_redfish/tasks/prep.yml
+++ b/roles/kubevirt_redfish/tasks/prep.yml
@@ -1,0 +1,51 @@
+---
+- name: Create namespace {{ kr_namespace }}
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ kr_namespace }}"
+
+- name: Create ServiceAccount {{ kr_sa_name }}
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "{{ kr_sa_name }}"
+        namespace: "{{ kr_namespace }}"
+        labels: "{{ _kr_rbac_labels }}"
+
+- name: Create RBAC role for kubevirt-redfish
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: "{{ (kr_scope == 'cluster') | ternary('ClusterRole', 'Role') }}"
+      metadata:
+        name: kubevirt-redfish-role
+        namespace: "{{ (kr_scope == 'namespaced') | ternary(kr_namespace, omit) }}"
+        labels: "{{ _kr_rbac_labels }}"
+      rules: "{{ _kr_rbac_rules }}"
+
+- name: Create RBAC role binding for kubevirt-redfish
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: "{{ (kr_scope == 'cluster') | ternary('ClusterRoleBinding', 'RoleBinding') }}"
+      metadata:
+        name: kubevirt-redfish-rolebinding
+        namespace: "{{ (kr_scope == 'namespaced') | ternary(kr_namespace, omit) }}"
+        labels: "{{ _kr_rbac_labels }}"
+      subjects:
+        - kind: ServiceAccount
+          name: "{{ kr_sa_name }}"
+          namespace: "{{ kr_namespace }}"
+      roleRef:
+        kind: "{{ (kr_scope == 'cluster') | ternary('ClusterRole', 'Role') }}"
+        name: kubevirt-redfish-role
+        apiGroup: rbac.authorization.k8s.io

--- a/roles/kubevirt_redfish/tasks/teardown.yml
+++ b/roles/kubevirt_redfish/tasks/teardown.yml
@@ -1,0 +1,47 @@
+---
+- name: Delete kubevirt-redfish resources
+  vars:
+    _kr_resources:
+      - api_version: route.openshift.io/v1
+        kind: Route
+        name: kubevirt-redfish
+        namespace: "{{ kr_namespace }}"
+      - api_version: v1
+        kind: Service
+        name: kubevirt-redfish
+        namespace: "{{ kr_namespace }}"
+      - api_version: apps/v1
+        kind: Deployment
+        name: kubevirt-redfish
+        namespace: "{{ kr_namespace }}"
+      - api_version: v1
+        kind: Secret
+        name: kubevirt-redfish-config
+        namespace: "{{ kr_namespace }}"
+      - api_version: rbac.authorization.k8s.io/v1
+        kind: "{{ (kr_scope == 'cluster') | ternary('ClusterRoleBinding', 'RoleBinding') }}"
+        name: kubevirt-redfish-rolebinding
+        namespace: "{{ (kr_scope == 'namespaced') | ternary(kr_namespace, omit) }}"
+      - api_version: rbac.authorization.k8s.io/v1
+        kind: "{{ (kr_scope == 'cluster') | ternary('ClusterRole', 'Role') }}"
+        name: kubevirt-redfish-role
+        namespace: "{{ (kr_scope == 'namespaced') | ternary(kr_namespace, omit) }}"
+      - api_version: v1
+        kind: ServiceAccount
+        name: "{{ kr_sa_name }}"
+        namespace: "{{ kr_namespace }}"
+      - api_version: v1
+        kind: Namespace
+        name: "{{ kr_namespace }}"
+  kubernetes.core.k8s:
+    state: absent
+    api_version: "{{ _kr_res.api_version }}"
+    kind: "{{ _kr_res.kind }}"
+    name: "{{ _kr_res.name }}"
+    namespace: "{{ _kr_res.namespace | default(omit) }}"
+    wait: true
+  when: _kr_res.kind != "Namespace" or (kr_delete_namespace | bool)
+  loop: "{{ _kr_resources }}"
+  loop_control:
+    loop_var: _kr_res
+    label: "{{ _kr_res.kind }}/{{ _kr_res.name }}"

--- a/roles/kubevirt_redfish/vars/main.yml
+++ b/roles/kubevirt_redfish/vars/main.yml
@@ -1,0 +1,45 @@
+---
+_kr_rbac_rules:
+  - apiGroups: ["kubevirt.io"]
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["kubevirt.io"]
+    resources:
+      - virtualmachines/status
+      - virtualmachineinstances/status
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["kubevirt.io"]
+    resources:
+      - virtualmachines/restart
+      - virtualmachines/start
+      - virtualmachines/stop
+    verbs: ["create"]
+  - apiGroups: ["subresources.kubevirt.io"]
+    resources:
+      - virtualmachineinstances/pause
+      - virtualmachineinstances/unpause
+    verbs: ["create", "update"]
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps", "secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: ["cdi.kubevirt.io"]
+    resources: ["datavolumes", "volumeimportsources"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list"]
+
+_kr_rbac_labels:
+  app.kubernetes.io/name: kubevirt-redfish
+  app.kubernetes.io/component: rbac


### PR DESCRIPTION
##### SUMMARY

Adds a new role to deploy kubevirt-redfish, which provides a Redfish BMC interface for managing KubeVirt VMs. The role creates all required Kubernetes resources.

Supports two configuration modes: a custom config file provided or a configuration through variables. Also, includes two modes, namespaced or cluster-scoped install, as well as its removal.

Bumps collection version to 3.2.

Assisted-by: Claude

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDUtMjFUMjM6MDI6NDU=
Gitleaks-Hash: 7eee74714b820141a3879c95b2a0095a63fd5891

##### ISSUE TYPE

- New

##### Tests

- [x] oc-4.22-spoke-ztp - https://www.distributed-ci.io/jobs/7f418bf0-9888-4c4f-b29c-d82cd4d5d979
- [x] kvr-green -  https://www.distributed-ci.io/jobs/0ad58ae9-895c-49c1-bf36-edffce3b3655

---

Test-hints: no-check