### PR TITLE
Set console serial to file for debugging purposes

### DIFF
--- a/roles/create_vms/templates/create_vm.sh.j2
+++ b/roles/create_vms/templates/create_vm.sh.j2
@@ -40,6 +40,7 @@ virt-install \
     {% if item.additional_vm_install_options is defined %}
     {{ item.additional_vm_install_options }} \
     {% endif %}
+    --serial file,path=/tmp/{{item.name}}-console.log
     --events on_reboot=restart \
     --autostart \
     --print-xml > /tmp/{{item.name}}.xml


### PR DESCRIPTION
##### SUMMARY

THIS IS A TESTING PR

Sending create_vm console to log file for debugging purposes.

##### ISSUE TYPE

- Bug

##### Tests

TestBos2: abi 'abi:ansible_extravars={"extra_manifests":[{"file":"/home/dci/nsilla/rhel10/manifests/rhel10_machine_config.yaml"},{"file":"/home/dci/dci/bos2-ci-config/files/hooks/nfs-client/hooks/files/nfsclient-config-worker.yaml"}]}'
