### PR TITLE
[installer] allow to use clusterOSimages var in OCP < 4.10

### DIFF
--- a/roles/installer/templates/install-config-virtualmedia.j2
+++ b/roles/installer/templates/install-config-virtualmedia.j2
@@ -95,6 +95,9 @@ platform:
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}
 {% endif %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 10)) and (clusterosimage is defined and clusterosimage|length)) %}
+    clusterOSImage: {{ clusterosimage }}
+{% endif %}
     hosts:
 {% for host in groups['masters'] %}
       - name: {{ hostvars[host]['inventory_hostname'] }}

--- a/roles/installer/templates/install-config.j2
+++ b/roles/installer/templates/install-config.j2
@@ -88,6 +88,9 @@ platform:
 {% if bootstraposimage is defined and bootstraposimage|length %}
     bootstrapOSImage: {{ bootstraposimage }}
 {% endif %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 10)) and (clusterosimage is defined and clusterosimage|length)) %}
+    clusterOSImage: {{ clusterosimage }}
+{% endif %}
     hosts:
 {% for host in groups['masters'] %}
       - name: {{ hostvars[host]['inventory_hostname'] }}


### PR DESCRIPTION
##### SUMMARY

clusterOSimages is obsolete and breaks >= 4.21 deployments
and clusterOSimages is not doing anything starting with 4.10
this will allow to use the role with older versions of ocp

##### ISSUE TYPE

Fix

##### Tests

- [x] Testvcp: ocp-4.7-vcp - https://www.distributed-ci.io/jobs/53cf8320-5125-48d6-9a4d-7ccb6e9f5049/jobStates - Job failed because of AspenMesh, but installation passed so the patch in this PR works.
- [x] Testvcp: ocp-4.21-vanilla - https://www.distributed-ci.io/jobs/fa9c56a0-3ff7-4879-95ba-4f7730b90b0f/jobStates - confirmed newer OCP releases are not impacted by this PR

Test-Hints: no-check