### PR TITLE
Do not attempt to poweroff redfish nodes with ipmi

### DIFF
--- a/roles/installer/tasks/59_power_off_cluster_servers.yml
+++ b/roles/installer/tasks/59_power_off_cluster_servers.yml
@@ -15,6 +15,8 @@
         ( item not in groups['dell_hosts_redfish'] | default([]) )
           and
         ( item not in groups['hp_hosts_redfish'] | default([]) )
+          and
+        ( item not in groups['kvm_hosts_redfish'] | default([]) )
       loop: "{{ groups.masters + groups.workers | default([]) }}"
 
     - name: Check node power status via ipmi to filter off nodes
@@ -71,6 +73,7 @@
     baseuri: "{{ hostvars[item]['ipmi_address'] }}"
     username: "{{ hostvars[item]['ipmi_user'] }}"
     password: "{{ hostvars[item]['ipmi_password'] }}"
+    resource_id: "{{ hostvars[item]['kvm_uuid'] | default(omit) }}"
   when: |
     (
       (hostvars[item]['poweroff'] is not defined) or
@@ -82,7 +85,10 @@
       ) or (
         groups['hp_hosts_redfish'] is defined and
         groups['hp_hosts_redfish'] | length > 0
+      ) or (
+        groups['kvm_hosts_redfish'] is defined and
+        groups['kvm_hosts_redfish'] | length > 0
       )
     )
-  loop: "{{ groups['dell_hosts_redfish'] | default([]) + groups['hp_hosts_redfish'] | default([]) }}"
+  loop: "{{ groups['dell_hosts_redfish'] | default([]) + groups['hp_hosts_redfish'] | default([]) + groups['kvm_hosts_redfish'] | default([]) }}"
 ...


### PR DESCRIPTION
##### SUMMARY

Exclude the attempt to interact with redfish group nodes using IPMI similarly as for hp or dell nodes.
Use the expected place to turn off redfish grouped nodes as well.

##### ISSUE TYPE

- Bug

##### Tests

- [x] https://www.distributed-ci.io/jobs/c08bf15a-1c24-42d6-be26-b6c9ddfca193/jobStates?sort=date&task=a324a4cd-562f-45ba-9b96-c62fff6b325f

---

Test-Hint: no-check
