### PR TITLE
Validate free port

### DIFF
--- a/roles/mirror_ocp_release/tasks/oc-mirror.yml
+++ b/roles/mirror_ocp_release/tasks/oc-mirror.yml
@@ -84,10 +84,20 @@
       ansible.builtin.shell:
         cmd: |
           set -o pipefail
+          SS=$(command -v ss 2>/dev/null || true)
+          if [[ -z $SS ]]; then
+            for _p in /usr/sbin/ss /sbin/ss; do
+              if [[ -x $_p ]]; then
+                SS=$_p
+                break
+              fi
+            done
+          fi
+          [[ -n $SS ]] || { echo "ss not found" >&2; exit 1; }
           sleep 0.$(shuf -i 0-999 -n 1)
           while :; do
             port=$(shuf -i 32768-60999 -n 1)
-            ss -lnt | awk '{print $4}' | grep -q ":${port}$" || { echo $port; break; }
+            "$SS" -lnt | awk '{print $4}' | grep -q ":${port}$" || { echo "$port"; break; }
           done
         executable: /bin/bash
       register: _mor_ephemeral_port

--- a/roles/oci_mirror/tasks/mirroring.yml
+++ b/roles/oci_mirror/tasks/mirroring.yml
@@ -3,10 +3,20 @@
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
+      SS=$(command -v ss 2>/dev/null || true)
+      if [[ -z $SS ]]; then
+        for _p in /usr/sbin/ss /sbin/ss; do
+          if [[ -x $_p ]]; then
+            SS=$_p
+            break
+          fi
+        done
+      fi
+      [[ -n $SS ]] || { echo "ss not found" >&2; exit 1; }
       sleep 0.$(shuf -i 0-999 -n 1)
       while :; do
         port=$(shuf -i 32768-60999 -n 1)
-        ss -lnt | awk '{print $4}' | grep -q ":${port}$" || { echo $port; break; }
+        "$SS" -lnt | awk '{print $4}' | grep -q ":${port}$" || { echo "$port"; break; }
       done
     executable: /bin/bash
   register: _om_ephemeral_port


### PR DESCRIPTION
##### SUMMARY

When ss is not  found in the $PATH, the script returns an unverified port. Checking for common SS paths 

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### Tests

TestBos2: virt-prega-4.22