### PR TITLE
Update certsuite default version to v5.5.21

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.20
+kbpc_version: v5.5.21
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
SUMMARY
Update certsuite default version to v5.5.21

ISSUE TYPE
Nominal change

Tests

TestBos2Workload: certsuite-green certsuite-green:ansible_extravars=kbpc_version:v5.5.21
