### PR TITLE
Add a module to find an available port

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Name | Description
 [redhatci.ocp.acm_spoke_mgmt](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/acm_spoke_mgmt/README.md) | This role allows to perform multiple management operations related to a spoke cluster,e.g. attach a spoke cluster to a given hub cluster, or detach a spoke cluster from a given hub cluster.
 [redhatci.ocp.acm.utils](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/acm/utils/README.md) | This is a helper role that is meant to be consumed by acm related roles.
 [redhatci.ocp.apply_nmstate](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/apply_nmstate/README.md) | Applies nmstate network configuration to a host.
-[redhatci.ocp.approve_csrs](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/approve_csrs/README.md) |Checks for Cert Signing Requests in the pending state and approves them until nodes in the day2_workers group are present in the oc nodes output.
+[redhatci.ocp.approve_csrs](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/approve_csrs/README.md) | Checks for Cert Signing Requests in the pending state and approves them until nodes in the day2_workers group are present in the oc nodes output.
 [redhatci.ocp.argocd_config](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/argocd_config/README.md) | A role to manage ArgoCD projects, repositories and applications.
 [redhatci.ocp.boot_disk](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/boot_disk/README.md) | Reboots nodes to the disk based on its vendor.
 [redhatci.ocp.boot_iso](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/boot_iso/README.md) | Boots nodes to the provided ISO on its vendor.
@@ -79,7 +79,7 @@ Name | Description
 [redhatci.ocp.include_components](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/include_components/README.md) | Create and attach DCI components to DCI jobs from git repositories, RPMs or commit URLs.
 [redhatci.ocp.insert_dns_records](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/insert_dns_records/README.md) | Setups `dnsmasq` (either directly or via `NetworkManager`) inserting the DNS A records required for OpenShift install.
 [redhatci.ocp.installer](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/installer/README.md) | [IPI installer](https://github.com/openshift-kni/baremetal-deploy)
-[redhatci.ocp.install_operator_gitops](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/install_operator_gitops/README.md) | Installs and configures the openshift-gitops-operator so it can be used for ZTP deployments. Installation is optional and may be skipped by setting the variable ```ioc_configure_only: true``
+[redhatci.ocp.install_operator_gitops](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/install_operator_gitops/README.md) | Installs and configures the openshift-gitops-operator so it can be used for ZTP deployments.
 [redhatci.ocp.jenkins_job_launcher](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/jenkins_job_launcher/README.md) | Launch Jenkins jobs
 [redhatci.ocp.junit2json](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/junit2json/README.md) | Convert JUnit XML files into JSON for reporting/observability role
 [redhatci.ocp.k8s_best_practices_certsuite](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/k8s_best_practices_certsuite/README.md) | Executes the [Red Hat Best Practices Test Suite for Kubernetes](https://github.com/redhat-best-practices-for-k8s/certsuite) tool.
@@ -102,7 +102,7 @@ Name | Description
 [redhatci.ocp.node_prep](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/node_prep/README.md) | [Preparation for IPI installer](https://github.com/openshift-kni/baremetal-deploy)
 [redhatci.ocp.oci_mirror](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/oci_mirror/README.md) | Mirror OpenShift operator catalogs and images using oc-mirror.
 [redhatci.ocp.ocp_add_users](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/ocp_add_users/README.md) | Add users to an OpenShift cluster through htpasswd Identity Provider.
-[redhatci.ocp.ocp_remove_nodes](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/ocp_remove_nodes/README.md) | Remove (worker) nodes from an OCP cluster. 
+[redhatci.ocp.ocp_remove_nodes](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/ocp_remove_nodes/README.md) | Remove (worker) nodes from an OCP cluster.
 [redhatci.ocp.ocp_logging](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/ocp_logging/README.md) | Enables the OCP logging subsystem.
 [redhatci.ocp.ocp_on_libvirt](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/ocp_on_libvirt/README.md) | Creation of a libvirt environment to install OCP
 [redhatci.ocp.odf_setup](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/odf_setup/README.md) | Setup of [OpenShift Data Foundation (ODF)](https://www.redhat.com/en/technologies/cloud-computing/openshift-data-foundation)
@@ -158,6 +158,7 @@ Name | Description
 
 Name | Type | Description
 --- | --- | ---
+[redhatci.ocp.find_available_port]() | Module | A module to find an available port in a given range
 [redhatci.ocp.get_compatible_rhocp_repo]() | Module | A module to find the latest available version of the RHOCP repository
 [redhatci.ocp.junit2dict]() | Filter | Transforms a JUnit into a dictionary
 [redhatci.ocp.junit2obj]() | Filter | Transforms a JUnit XML into a corresponding JSON text

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        3.2.EPOCH
+Version:        3.3.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -54,6 +54,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Tue Jun  2 2026 Tony Garcia <tonyg@redhat.com> - 3.3.EPOCH-VERS
+- Add find_available_port module
+
 * Tue May 21 2026 Tony Garcia <tonyg@redhat.com> - 3.2.EPOCH-VERS
 - Add kubevirt_redfish role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 3.2.0
+version: 3.3.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md
@@ -77,7 +77,6 @@ authors:
   - "ylamgarchal <yassine.lamgarchal@redhat.com>"
   - "Yurii Prokulevych <yprokule@users.noreply.github.com>"
   - "Yuval Kashtan <ykashtan@redhat.com>"
-
 
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection

--- a/plugins/modules/find_available_port.py
+++ b/plugins/modules/find_available_port.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: find_available_port
+short_description: Find an available port in a given range
+description:
+  - Finds an unused port by attempting to bind a socket on a random port
+    within the specified range.
+  - Supports TCP and UDP protocols. Port spaces are independent per protocol.
+  - Supports IPv4 and IPv6 address families.
+author:
+  - Jose Alberto Rodriguez (@betoredhat)
+  - Tony Garcia (@tonyskapunk)
+options:
+  range_start:
+    description:
+      - The start of the port range to search.
+    required: false
+    type: int
+    default: 32768
+  range_end:
+    description:
+      - The end of the port range to search (inclusive).
+    required: false
+    type: int
+    default: 60999
+  address_family:
+    description:
+      - The address family to use when checking port availability.
+      - Use C(ipv4) to bind on IPv4 or C(ipv6) to bind on IPv6.
+    required: false
+    type: str
+    default: ipv4
+    choices:
+      - ipv4
+      - ipv6
+  protocol:
+    description:
+      - The transport protocol to check port availability for.
+      - TCP and UDP have independent port spaces, so a port may be
+        available on one protocol but not the other.
+    required: false
+    type: str
+    default: tcp
+    choices:
+      - tcp
+      - udp
+  max_attempts:
+    description:
+      - Maximum number of random ports to try before giving up.
+    required: false
+    type: int
+    default: 100
+"""
+
+EXAMPLES = """
+- name: Find an available ephemeral port
+  redhatci.ocp.find_available_port:
+  register: available_port
+
+- name: Use the port
+  ansible.builtin.debug:
+    msg: "Using port {{ available_port.port }}"
+
+- name: Find a port in a custom range
+  redhatci.ocp.find_available_port:
+    range_start: 8000
+    range_end: 9000
+  register: custom_port
+
+- name: Find an available port on IPv6
+  redhatci.ocp.find_available_port:
+    address_family: ipv6
+  register: ipv6_port
+
+- name: Find an available UDP port
+  redhatci.ocp.find_available_port:
+    protocol: udp
+  register: udp_port
+"""
+
+RETURN = """
+port:
+  description: The available port found.
+  type: int
+  returned: always
+  sample: 45123
+"""
+
+import random
+import socket
+
+from ansible.module_utils.basic import AnsibleModule
+
+ADDRESS_FAMILIES = {
+    "ipv4": (socket.AF_INET, ""),
+    "ipv6": (socket.AF_INET6, "::"),
+}
+
+PROTOCOLS = {
+    "tcp": socket.SOCK_STREAM,
+    "udp": socket.SOCK_DGRAM,
+}
+
+
+def find_port(
+    range_start, range_end, address_family="ipv4", protocol="tcp", max_attempts=100
+):
+    af, bind_addr = ADDRESS_FAMILIES[address_family]
+    sock_type = PROTOCOLS[protocol]
+    attempts = 0
+    while attempts < max_attempts:
+        attempts += 1
+        port = random.randint(range_start, range_end)
+        try:
+            s = socket.socket(af, sock_type)
+            s.bind((bind_addr, port))
+            s.close()
+            return port
+        except OSError:
+            continue
+    return None
+
+
+def main():
+    module_args = dict(
+        range_start=dict(type="int", required=False, default=32768),
+        range_end=dict(type="int", required=False, default=60999),
+        address_family=dict(
+            type="str",
+            required=False,
+            default="ipv4",
+            choices=["ipv4", "ipv6"],
+        ),
+        protocol=dict(
+            type="str",
+            required=False,
+            default="tcp",
+            choices=["tcp", "udp"],
+        ),
+        max_attempts=dict(type="int", required=False, default=100),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    range_start = module.params["range_start"]
+    range_end = module.params["range_end"]
+
+    if range_start > range_end:
+        module.fail_json(
+            msg="range_start (%d) must be less than or equal to range_end (%d)"
+            % (range_start, range_end)
+        )
+
+    if range_start < 1 or range_end > 65535:
+        module.fail_json(msg="Port range must be between 1 and 65535")
+
+    address_family = module.params["address_family"]
+    protocol = module.params["protocol"]
+    max_attempts = module.params["max_attempts"]
+
+    if max_attempts < 1:
+        module.fail_json(msg="max_attempts must be at least 1")
+
+    port = find_port(range_start, range_end, address_family, protocol, max_attempts)
+    if port is None:
+        module.fail_json(
+            msg="Could not find an available port in range %d-%d after %d attempts"
+            % (range_start, range_end, max_attempts)
+        )
+
+    module.exit_json(changed=False, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/mirror_ocp_release/tasks/oc-mirror.yml
+++ b/roles/mirror_ocp_release/tasks/oc-mirror.yml
@@ -81,17 +81,8 @@
       until: _mor_get_oc_mirror is success
 
     - name: Find an available ephemeral port for oc-mirror
-      ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          sleep 0.$(shuf -i 0-999 -n 1)
-          while :; do
-            port=$(shuf -i 32768-60999 -n 1)
-            ss -lnt | awk '{print $4}' | grep -q ":${port}$" || { echo $port; break; }
-          done
-        executable: /bin/bash
+      redhatci.ocp.find_available_port:
       register: _mor_ephemeral_port
-      changed_when: false
 
     # Only GA and Candidate builds include signed images
     - name: Mirror the release to the local registry
@@ -102,7 +93,7 @@
           --authfile {{ mor_auths_file }}
           --workspace file://{{ _mor_tmp_dir.path }}
           docker://{{ mor_registry_url }}/{{ mor_registry_path }}
-          --port {{ _mor_ephemeral_port.stdout }}
+          --port {{ _mor_ephemeral_port.port }}
           {% if mor_allow_insecure_registry | bool %}
           --dest-tls-verify=false
           --src-tls-verify=false

--- a/roles/oci_mirror/tasks/mirroring.yml
+++ b/roles/oci_mirror/tasks/mirroring.yml
@@ -1,16 +1,7 @@
 ---
 - name: Find an available ephemeral port for oc-mirror
-  ansible.builtin.shell:
-    cmd: |
-      set -o pipefail
-      sleep 0.$(shuf -i 0-999 -n 1)
-      while :; do
-        port=$(shuf -i 32768-60999 -n 1)
-        ss -lnt | awk '{print $4}' | grep -q ":${port}$" || { echo $port; break; }
-      done
-    executable: /bin/bash
+  redhatci.ocp.find_available_port:
   register: _om_ephemeral_port
-  changed_when: false
 
 - name: Print ImageSetConfiguration content
   ansible.builtin.debug:
@@ -23,7 +14,7 @@
       {{ _om_tmp_dir.path }}/oc-mirror --v2 --config={{ om_imageset_config_path }}
       --workspace file://{{ _om_tmp_dir.path }}
       docker://{{ om_target }}
-      --port {{ _om_ephemeral_port.stdout }}
+      --port {{ _om_ephemeral_port.port }}
       {% if om_allow_insecure_registries | bool %}
       --dest-tls-verify=false
       --src-tls-verify=false


### PR DESCRIPTION
##### SUMMARY

This is based on the work made by Beto in oci_mirror and mirror_ocp_release roles to find for available ports in the controller.

Assisted-by: Claude

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDYtMDJUMTY6MjQ6NTF8Mzc3NjFiZGVmZWZmYjhmY2M5Y2QwMWQ0NzY0NDRhOWFhMjQ0ZDc2NA==
Gitleaks-Hash: 6614179f04243cfb7941fa3973e775a646ad0fd4a97ab1dffc1d5bcaf37c32c9

##### ISSUE TYPE

- Enhanced feature

##### Tests

- [x] TestBos2vMNOAirGap: virt-prega-4.22 - https://www.distributed-ci.io/jobs/b414917f-2d46-4e6c-9ea3-f666963b0f6b

---

Test-hints: no-check