### PR TITLE
feat: add networking-unsecured-container-ports to kbpc_feedback list

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.3.5
+kbpc_version: v5.5.20
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"
@@ -14,9 +14,16 @@ kbpc_test_config:
 kbpc_accepted_kernel_taints: []
 kbpc_services_ignore_list: []
 kbpc_allow_preflight_insecure: false
+# CWE Hydra apikey for automated results submission
+# It must be created manually in Connect UI
+# Do not forget to define kbpc_cwe_project_id as well
+kbpc_cwe_apikey_path: "/opt/cache/cwe-apikey.txt"
+# Variables to feed the collector DB when submitting a result with a unique user and pass
+kbpc_partner_name: ""
+kbpc_collector_app_password: ""
 # If this is not set to true, JUnit file will not be created
 kbpc_enable_xml_creation: true
-kbpc_non_intrusive_only: false
+kbpc_intrusive: true
 kbpc_log_level: info
 kbpc_postrun_delete_resources: true
 kbpc_pullsecret: ""
@@ -48,10 +55,11 @@ kbpc_feedback:
   access-control-pod-host-pid: ""
   access-control-pod-role-bindings: ""
   access-control-pod-service-account: ""
-  access-control-requests-and-limits: ""
+  access-control-requests: ""
   access-control-security-context: ""
   access-control-security-context-non-root-user-check: ""
   access-control-security-context-privilege-escalation: ""
+  access-control-security-context-read-only-file-system: ""
   access-control-service-type: ""
   access-control-ssh-daemons: ""
   access-control-sys-admin-capability-check: ""
@@ -79,34 +87,39 @@ kbpc_feedback:
   lifecycle-startup-probe: ""
   lifecycle-statefulset-scaling: ""
   lifecycle-storage-provisioner: ""
+  lifecycle-topology-spread-constraint: ""
   manageability-container-port-name-format: ""
   manageability-containers-image-tag: ""
-  networking-dpdk-cpu-pinning-exec-probe: ""
   networking-dual-stack-service: ""
   networking-icmpv4-connectivity: ""
   networking-icmpv4-connectivity-multus: ""
   networking-icmpv6-connectivity: ""
   networking-icmpv6-connectivity-multus: ""
+  networking-network-attachment-definition-sriov-mtu: ""
   networking-network-policy-deny-all: ""
   networking-ocp-reserved-ports-usage: ""
   networking-reserved-partner-ports: ""
   networking-restart-on-reboot-sriov-pod: ""
   networking-undeclared-container-ports-usage: ""
+  networking-unsecured-container-ports: ""
+  observability-compatibility-with-next-ocp-release: ""
   observability-container-logging: ""
   observability-crd-status: ""
   observability-pod-disruption-budget: ""
   observability-termination-policy: ""
-  operator-automount-tokens: ""
+  operator-catalogsource-bundle-count: ""
   operator-crd-openapi-schema: ""
   operator-crd-versioning: ""
   operator-install-source: ""
   operator-install-status-no-privileges: ""
   operator-install-status-succeeded: ""
-  operator-read-only-file-system: ""
-  operator-run-as-non-root: ""
-  operator-run-as-user-id: ""
+  operator-multiple-same-operators: ""
+  operator-olm-skip-range: ""
+  operator-pods-no-hugepages: ""
   operator-semantic-versioning: ""
   operator-single-crd-owner: ""
+  operator-single-or-multi-namespaced-allowed-in-tenant-namespaces: ""
+  performance-cpu-pinning-no-exec-probes: ""
   performance-exclusive-cpu-pool: ""
   performance-exclusive-cpu-pool-rt-scheduling-policy: ""
   performance-isolated-cpu-pool-rt-scheduling-policy: ""
@@ -115,6 +128,7 @@ kbpc_feedback:
   performance-shared-cpu-pool-non-rt-scheduling-policy: ""
   platform-alteration-base-image: ""
   platform-alteration-boot-params: ""
+  platform-alteration-cluster-operator-health: ""
   platform-alteration-hugepages-1g-only: ""
   platform-alteration-hugepages-2m-only: ""
   platform-alteration-hugepages-config: ""


### PR DESCRIPTION
## Summary
- Add `networking-unsecured-container-ports` to the `kbpc_feedback` dict in the certsuite role defaults

This new test case is being added to certsuite in [redhat-best-practices-for-k8s/certsuite#3614](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3614). It detects unsecured (non-TLS) container ports. The feedback entry is needed so the DCI pipeline can provide feedback for this test.