### PR TITLE
Assert can't be use in loop in ansible 2.15

### DIFF
--- a/roles/acm_sno/tasks/create-cluster.yml
+++ b/roles/acm_sno/tasks/create-cluster.yml
@@ -1,13 +1,11 @@
 ---
 - name: "Validate parameters"
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required"
-  with_items:
-    - acm_bmc_user
-    - acm_bmc_address
-    - acm_boot_mac_address
-    - acm_machine_cidr
+    that:
+      - acm_bmc_user is defined
+      - acm_bmc_address is defined
+      - acm_boot_mac_address is defined
+      - acm_machine_cidr is defined
 
 - name: "Create a managed cluster namespace"
   kubernetes.core.k8s:

--- a/roles/acm_sno/tasks/delete-cluster.yml
+++ b/roles/acm_sno/tasks/delete-cluster.yml
@@ -1,10 +1,8 @@
 ---
 - name: "Validate parameters"
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required"
-  with_items:
-    - acm_cluster_name
+    that:
+      - acm_cluster_name is defined
 
 - name: "Delete managed cluster"
   kubernetes.core.k8s:

--- a/roles/chart_verifier/tasks/main.yml
+++ b/roles/chart_verifier/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
 - name: "Validate_ parameters"
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required"
-  with_items:
-    - kubeconfig_path
-    - ocp_version_full
-    - dci_charts
+    that:
+      - kubeconfig_path is defined
+      - ocp_version_full is defined
+      - dci_charts is defined
 
 - name: "Get partner name"
   ansible.builtin.include_tasks: get-partner-name.yml

--- a/roles/chart_verifier/tasks/tests.yml
+++ b/roles/chart_verifier/tasks/tests.yml
@@ -7,7 +7,7 @@
     success_msg: "All chart required parameters are defined"
 
 - name: "Check if chart.values_file is iterable"
-  assert:
+  ansible.builtin.assert:
     that:
       - chart.values_file | type_debug == "list"
       - chart.values_file is iterable

--- a/roles/create_certification_project/tasks/check_if_cnf_project_exists.yml
+++ b/roles/create_certification_project/tasks/check_if_cnf_project_exists.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check that organization_id is defined
   ansible.builtin.assert:
-    that: "{{ organization_id }} is defined"
+    that: organization_id is defined
 
 - name: Get certification cnf projects for the organization
   vars:

--- a/roles/create_certification_project/tasks/check_if_container_project_exists.yml
+++ b/roles/create_certification_project/tasks/check_if_container_project_exists.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check that organization_id is defined
   ansible.builtin.assert:
-    that: "{{ organization_id }} is defined"
+    that: organization_id is defined
 
 - name: Set container image facts
   ansible.builtin.set_fact:

--- a/roles/create_certification_project/tasks/check_if_helmchart_project_exists.yml
+++ b/roles/create_certification_project/tasks/check_if_helmchart_project_exists.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check that organization_id is defined
   ansible.builtin.assert:
-    that: "{{ organization_id }} is defined"
+    that: organization_id is defined
 
 - name: Set Helm Chart project facts
   ansible.builtin.set_fact:

--- a/roles/create_certification_project/tasks/main.yml
+++ b/roles/create_certification_project/tasks/main.yml
@@ -3,9 +3,8 @@
 # it could be container, operator, cnf, or helmchart
 - name: Validate_ cert_item to be defined
   ansible.builtin.assert:
-    that: "{{ cert_item }} is defined"
-    fail_msg: "The parameter cert_item is required to create cert project"
-    success_msg: "The parameter {{ cert_item }} is present"
+    that: cert_item is defined
+    success_msg: "The parameter cert_item is present"
 
 - name: Reset the project id to handle multiple CNF
   ansible.builtin.set_fact:

--- a/roles/create_certification_project/tasks/validate_cert_settings.yml
+++ b/roles/create_certification_project/tasks/validate_cert_settings.yml
@@ -1,50 +1,44 @@
 ---
 - name: Validate_ cert_settings for container project
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required to update cert project"
-    success_msg: "The parameter {{ item }} is present"
-  with_items:
-    - cert_item.short_description
-    - cert_settings.auto_publish
-    - cert_settings.email_address
-    - cert_settings.build_categories
-    - cert_settings.registry_override_instruct
-    - cert_settings.application_categories
-    - cert_settings.os_content_type
-    - cert_settings.privileged
-    - cert_settings.release_category
-    - cert_settings.repository_description
+    that:
+      - cert_item.short_description is defined
+      - cert_settings.auto_publish is defined
+      - cert_settings.email_address is defined
+      - cert_settings.build_categories is defined
+      - cert_settings.registry_override_instruct is defined
+      - cert_settings.application_categories is defined
+      - cert_settings.os_content_type is defined
+      - cert_settings.privileged is defined
+      - cert_settings.release_category is defined
+      - cert_settings.repository_description is defined
+    success_msg: "All required cert_settings parameters are present"
   when: product_type == 'container'
 
 - name: Validate_ cert_settings for operator project
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required to update cert project"
-    success_msg: "The parameter {{ item }} is present"
-  with_items:
-    - cert_item.short_description
-    - cert_settings.auto_publish
-    - cert_settings.email_address
-    - cert_settings.registry_override_instruct
-    - cert_settings.application_categories
-    - cert_settings.privileged
-    - cert_settings.repository_description
+    that:
+      - cert_item.short_description is defined
+      - cert_settings.auto_publish is defined
+      - cert_settings.email_address is defined
+      - cert_settings.registry_override_instruct is defined
+      - cert_settings.application_categories is defined
+      - cert_settings.privileged is defined
+      - cert_settings.repository_description is defined
+    success_msg: "All required cert_settings parameters are present"
   when: product_type == 'operator'
 
 - name: Validate_ cert_settings for Helm Chart project
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required to update cert project"
-    success_msg: "The parameter {{ item }} is present"
-  with_items:
-    - cert_item.short_description
-    - cert_settings.long_description
-    - cert_settings.email_address
-    - cert_settings.distribution_method
-    - cert_settings.application_categories
-    - cert_settings.distribution_instructions
-    - cert_settings.github_usernames
+    that:
+      - cert_item.short_description is defined
+      - cert_settings.long_description is defined
+      - cert_settings.email_address is defined
+      - cert_settings.distribution_method is defined
+      - cert_settings.application_categories is defined
+      - cert_settings.distribution_instructions is defined
+      - cert_settings.github_usernames is defined
+    success_msg: "All required cert_settings parameters are present"
   when: product_type == 'helmchart'
 
 - name: Validate_ Short Description Length

--- a/roles/create_pr/tasks/main.yml
+++ b/roles/create_pr/tasks/main.yml
@@ -1,16 +1,14 @@
 ---
 - name: Validate_ the presence of parameters
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required"
-  with_items:
-    - product_type
-    - product_name
-    - product_version
-    - fork_name
-    - github_token_path
-    - target_repository
-    - work_dir
+    that:
+      - product_type is defined
+      - product_name is defined
+      - product_version is defined
+      - fork_name is defined
+      - github_token_path is defined
+      - target_repository is defined
+      - work_dir is defined
 
 - name: Validate_ that cert_project_id is provided
   ansible.builtin.fail:

--- a/roles/hostedbm/tasks/validations.yml
+++ b/roles/hostedbm/tasks/validations.yml
@@ -2,13 +2,10 @@
 - name: Ensure required variables are defined
   ansible.builtin.assert:
     that:
-      - "{{ item }} is defined"
-    fail_msg: "The variable {{ item }} is not defined. Please define it to proceed."
-  loop:
-    - hostedbm_cluster_name
-    - hostedbm_cluster_base_domain
-    - hostedbm_guest_ingress_ip
-    - hostedbm_kubeconfig_file
+      - hostedbm_cluster_name is defined
+      - hostedbm_cluster_base_domain is defined
+      - hostedbm_guest_ingress_ip is defined
+      - hostedbm_kubeconfig_file is defined
 
 - name: Manage directories for deployment
   ansible.builtin.file:

--- a/roles/include_components/tasks/track_repo_commit_component.yml
+++ b/roles/include_components/tasks/track_repo_commit_component.yml
@@ -1,6 +1,6 @@
 ---
 - name: Assert ic_commit_url
-  assert:
+  ansible.builtin.assert:
     that:
       # Assert that ic_commit_url is a valid URL
       # of the sort https://github.com/organisation/reponame/commit/commit_hash

--- a/roles/merge_registry_creds/tasks/main.yml
+++ b/roles/merge_registry_creds/tasks/main.yml
@@ -1,10 +1,9 @@
 ---
 - name: "Check if the list has items"
-  assert:
+  ansible.builtin.assert:
     that:
-      - "{{ mrc_auths is defined }}"
-      - "{{ mrc_auths | length > 0 }}"
-    fail_msg: "A list of JSON auth files is required"
+      - mrc_auths is defined
+      - mrc_auths | length > 0
 
 - name: "Combine auths"
   set_fact:

--- a/roles/metallb_setup/tasks/pre-requisites.yml
+++ b/roles/metallb_setup/tasks/pre-requisites.yml
@@ -43,10 +43,8 @@
 
 - name: "Validate_ parameters are defined"
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required. See README.md for more details"
-  loop:
-    - mlb_ipaddr_pool
+    that:
+      - mlb_ipaddr_pool is defined
 
 - name: "Validate_ values of mlb_wait_* are positive integers"
   ansible.builtin.assert:
@@ -70,8 +68,7 @@
 
 - name: "Validate_ parameter mlb_ipaddr_pool is a list"
   ansible.builtin.assert:
-    that: "{{ mlb_ipaddr_pool }} is iterable"
-    fail_msg: "The parameter {{ mlb_ipaddr_pool }} is required to be a list"
+    that: mlb_ipaddr_pool is iterable
 
 - name: "Validate_ values of mlb_bgp_peers are defined"
   ansible.builtin.assert:

--- a/roles/ocp_logging/tasks/pre-run.yml
+++ b/roles/ocp_logging/tasks/pre-run.yml
@@ -19,16 +19,14 @@
 
 - name: "Validate_ parameters"
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required"
-  with_items:
-    - ol_access_key_id
-    - ol_access_key_secret
-    - ol_bucket
-    - ol_endpoint
-    - ol_region
-    - ol_loki_size
-    - ol_storage_class
+    that:
+      - ol_access_key_id is defined
+      - ol_access_key_secret is defined
+      - ol_bucket is defined
+      - ol_endpoint is defined
+      - ol_region is defined
+      - ol_loki_size is defined
+      - ol_storage_class is defined
 
 - name: "Get cluster version"
   kubernetes.core.k8s_info:

--- a/roles/opcap_tool/tasks/main.yml
+++ b/roles/opcap_tool/tasks/main.yml
@@ -1,12 +1,10 @@
 ---
 - name: Validate_ parameters
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required"
-  with_items:
-    - opcap_target_catalog_source
-    - opcap_catalog_source_namespace
-    - opcap_output_dir
+    that:
+      - opcap_target_catalog_source is defined
+      - opcap_catalog_source_namespace is defined
+      - opcap_output_dir is defined
 
 - name: Create tmp dir for opcap tool
   ansible.builtin.tempfile:

--- a/roles/populate_mirror_registry/tasks/prerequisites.yml
+++ b/roles/populate_mirror_registry/tasks/prerequisites.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check that release_url variable is not defined
-  assert:
+  ansible.builtin.assert:
     that:
       - release_url is not defined
     fail_msg: >

--- a/roles/prereq_facts_check/tasks/main.yml
+++ b/roles/prereq_facts_check/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check for pull_secret
-  assert:
+  ansible.builtin.assert:
     that:
       - pull_secret is defined
       - pull_secret.auths is defined
@@ -10,7 +10,7 @@
   when: pull_secret_check | bool
 
 - name: Check for ssh_public_key
-  assert:
+  ansible.builtin.assert:
     that:
       - ssh_public_key is defined
       - ssh_public_key is string
@@ -20,7 +20,7 @@
   when: ssh_public_check | bool
 
 - name: Check for mirror_certificate
-  assert:
+  ansible.builtin.assert:
     that:
       - mirror_certificate is defined
       - mirror_certificate is string

--- a/roles/setup_radvd/tasks/pre-requisites.yaml
+++ b/roles/setup_radvd/tasks/pre-requisites.yaml
@@ -1,27 +1,21 @@
 ---
 - name: "Validate_ required parameters are defined"
   ansible.builtin.assert:
-    that: "{{ item }} is defined"
-    fail_msg: "The parameter {{ item }} is required. See README.md for more details."
-  loop:
-    - setup_radvd_baremetal_bridge
-    - setup_radvd_ipv6_network_cidr
+    that:
+      - setup_radvd_baremetal_bridge is defined
+      - setup_radvd_ipv6_network_cidr is defined
 
 - name: "Validate_ values of interval and lifetime parameters are positive integers"
   ansible.builtin.assert:
-    that: "{{ item }} | int > 0"
-    fail_msg: "The interval parameters must be positive integers."
-  loop:
-    - setup_radvd_min_interval
-    - setup_radvd_max_interval
-    - setup_radvd_default_lifetime
+    that:
+      - setup_radvd_min_interval | int > 0
+      - setup_radvd_max_interval | int > 0
+      - setup_radvd_default_lifetime | int > 0
 
 - name: "Validate_ for intervals, min < max"
   ansible.builtin.assert:
     that: setup_radvd_min_interval | int < setup_radvd_max_interval | int
-    fail_msg: "Min must be less than Max."
 
 - name: "Validate_ that setup_radvd_ipv6_network_cidr is a proper ipv6 network address"
   ansible.builtin.assert:
     that: setup_radvd_ipv6_network_cidr | ansible.utils.ipv6('network')
-    fail_msg: "setup_radvd_ipv6_network_cidr must be a valid IPv6 network address."


### PR DESCRIPTION
##### SUMMARY

Ansible 2.15 rejects embedded {{ }} in that conditionals (GHSA-7j69-qfc3-2fq9). Replacing patterns like "{{ item }} is defined" with direct variable references such as item is defined

https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_core_2.15.html#playbook


##### ISSUE TYPE
- Bug

##### Tests
- SUCCESS https://www.distributed-ci.io/jobs/54b09bf6-f5ee-4359-85c0-a8953087cdd6/jobStates
- SUCCESS https://www.distributed-ci.io/jobs/1e571126-a8a0-4012-96e4-42cb7a272a9e/jobStates
- SUCCESS https://www.distributed-ci.io/jobs/d698faeb-ce6a-4ebb-9dc0-004620ef6e83/jobStates

