### PR TITLE
mirror_ocp_release: fixed lookup plugin, removed REGISTRY_AUTH_FILE e…

### DIFF
--- a/roles/mirror_ocp_release/tasks/oc-mirror.yml
+++ b/roles/mirror_ocp_release/tasks/oc-mirror.yml
@@ -65,9 +65,14 @@
         dest: "{{ _mor_tmp_dir.path }}/ocp-release.yaml"
         mode: "0644"
 
+    - name: Read ImageSetConfiguration content
+      ansible.builtin.slurp:
+        src: "{{ _mor_tmp_dir.path }}/ocp-release.yaml"
+      register: _mor_imageset_config
+
     - name: Print ImageSetConfiguration content
       ansible.builtin.debug:
-        msg: "{{ lookup('file', _mor_tmp_dir.path + '/ocp-release.yaml') }}"
+        msg: "{{ _mor_imageset_config.content | b64decode }}"
 
     - name: Extract latest oc-mirror
       ansible.builtin.unarchive:
@@ -88,7 +93,7 @@
     - name: Mirror the release to the local registry
       ansible.builtin.shell:
         cmd: >
-          umask 0022 &&
+          umask 0022 && env -u REGISTRY_AUTH_FILE
           {{ _mor_tmp_dir.path }}/oc-mirror --v2 --config={{ _mor_tmp_dir.path }}/ocp-release.yaml
           --authfile {{ mor_auths_file }}
           --workspace file://{{ _mor_tmp_dir.path }}


### PR DESCRIPTION
##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->
Fix mirror_ocp_release oc-mirror tasks for remote hosts and auth handling

The debug task that prints the rendered ImageSetConfiguration used lookup('file', ...), which always reads from the Ansible controller. When mirroring runs on a remote host, the rendered file lives under a remote temp directory (_mor_tmp_dir), so the lookup fails or shows the wrong content.

Replace it with ansible.builtin.slurp, which reads the file on the target host, and decode the result with b64decode before passing it to debug. 

When running oc-mirror, unset REGISTRY_AUTH_FILE in the shell command via env -u REGISTRY_AUTH_FILE so the tool does not pick up a host-level auth file that may conflict with the explicit --authfile {{ mor_auths_file }} argument. Credentials should come only from the path the role configures.

Test-Hint: no-check