### PR TITLE
feat(eco_gotests): add generic test runner with configurable label filtering

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Fri Jun 19 2026 Frederic Lepied <flepied@redhat.com> - 3.5.EPOCH-VERS
+- Add generic test runner for eco_gotests role
+
 * Thu Jun 12 2026 Frederic Lepied <flepied@redhat.com> - 3.5.EPOCH-VERS
 - Add cleanup_namespace role and cleanup_stuck_resources module
 

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        3.5.EPOCH
+Version:        3.6.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,7 +55,7 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
-* Fri Jun 19 2026 Frederic Lepied <flepied@redhat.com> - 3.5.EPOCH-VERS
+* Fri Jun 19 2026 Frederic Lepied <flepied@redhat.com> - 3.6.EPOCH-VERS
 - Add generic test runner for eco_gotests role
 
 * Thu Jun 12 2026 Frederic Lepied <flepied@redhat.com> - 3.5.EPOCH-VERS

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 3.5.0
+version: 3.6.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/hack/run_ansible_test.sh
+++ b/hack/run_ansible_test.sh
@@ -16,18 +16,6 @@
 
 set -ex
 
-# If docker is actually podman, ensure DOCKER_HOST points to the podman socket
-# so that ansible-test --docker can communicate with the container runtime.
-if [ -z "$DOCKER_HOST" ] && command -v docker &>/dev/null; then
-    real_docker=$(readlink -f "$(command -v docker)")
-    if [[ "$real_docker" == */podman ]]; then
-        podman_sock="/run/user/$(id -u)/podman/podman.sock"
-        if [ -S "$podman_sock" ]; then
-            export DOCKER_HOST="unix://$podman_sock"
-        fi
-    fi
-fi
-
 # when run outside of a GitHub action
 if [ -z "$GITHUB_STEP_SUMMARY" ]; then
     GITHUB_STEP_SUMMARY=/dev/null

--- a/hack/run_ansible_test.sh
+++ b/hack/run_ansible_test.sh
@@ -16,6 +16,18 @@
 
 set -ex
 
+# If docker is actually podman, ensure DOCKER_HOST points to the podman socket
+# so that ansible-test --docker can communicate with the container runtime.
+if [ -z "$DOCKER_HOST" ] && command -v docker &>/dev/null; then
+    real_docker=$(readlink -f "$(command -v docker)")
+    if [[ "$real_docker" == */podman ]]; then
+        podman_sock="/run/user/$(id -u)/podman/podman.sock"
+        if [ -S "$podman_sock" ]; then
+            export DOCKER_HOST="unix://$podman_sock"
+        fi
+    fi
+fi
+
 # when run outside of a GitHub action
 if [ -z "$GITHUB_STEP_SUMMARY" ]; then
     GITHUB_STEP_SUMMARY=/dev/null

--- a/roles/eco_gotests/README.md
+++ b/roles/eco_gotests/README.md
@@ -54,6 +54,9 @@ SRIOV uses the same `eco_gotests_dump_failed_tests` toggle; reports are written 
 - `eco_gotests_generic_skip_labels` (default: `[]`): List of Ginkgo labels to skip (prefixed with `!` and joined with `&&`).
 - `eco_gotests_generic_env` (default: `{}`): Additional environment variables to pass to the container. Merged on top of the base environment using `combine()`.
 - `eco_gotests_generic_timeout` (default: `'12h'`): Timeout for the test run.
+- `eco_gotests_generic_run_label_operator` (default: `'||'`): Operator used to join run labels. Use `'||'` for OR semantics (default) or `'&&'` for AND semantics (used internally by PTP).
+
+> **Note:** PTP and SRIOV test suites now delegate to the generic runner internally. All PTP/SRIOV user-facing variables remain unchanged — they are mapped to generic runner variables automatically.
 
 ## Example Playbook
 

--- a/roles/eco_gotests/README.md
+++ b/roles/eco_gotests/README.md
@@ -1,6 +1,6 @@
 # eco_gotests
 
-This role runs [eco-gotests](https://github.com/rh-ecosystem-edge/eco-gotests) for OpenShift CNF (Cloud Native Functions) testing, specifically for PTP (Precision Time Protocol) and SRIOV (Single Root I/O Virtualization) test suites.
+This role runs [eco-gotests](https://github.com/rh-ecosystem-edge/eco-gotests) for OpenShift CNF (Cloud Native Functions) testing. It supports PTP (Precision Time Protocol), SRIOV (Single Root I/O Virtualization), and a generic test runner for any eco-gotests feature with configurable label filtering.
 
 ## Requirements
 
@@ -17,9 +17,9 @@ This role runs [eco-gotests](https://github.com/rh-ecosystem-edge/eco-gotests) f
 
 ### Required Variables
 
-- `eco_gotests_test_suites`: List of test suites to run (e.g., `['ptp', 'sriov']`)
+- `eco_gotests_test_suites`: List of test suites to run (e.g., `['ptp', 'sriov', 'generic']`)
 - `eco_gotests_log_dir`: Path where test logs and reports will be stored
-- `eco_gotests_kubconfig_dir`: Directory containing kubeconfig files
+- `eco_gotests_kubeconfig_dir`: Directory containing kubeconfig files
 - `eco_gotests_registry_auth_file`: Path to the registry authentication file
 
 ### Optional Variables
@@ -48,6 +48,13 @@ This role runs [eco-gotests](https://github.com/rh-ecosystem-edge/eco-gotests) f
 
 SRIOV uses the same `eco_gotests_dump_failed_tests` toggle; reports are written at `/tmp/reports` in the container, mapped to `{{ eco_gotests_log_dir }}/eco_gotests/sriov` on the host.
 
+#### Generic Test Runner Configuration
+- `eco_gotests_generic_features` (default: `''`): The ECO_TEST_FEATURES value (e.g., `'network'`, `'ran'`). **Required** when using `'generic'` in `eco_gotests_test_suites`.
+- `eco_gotests_generic_run_labels` (default: `[]`): List of Ginkgo labels to run (joined with `||`). Example: `['lacp-bond-stability']`.
+- `eco_gotests_generic_skip_labels` (default: `[]`): List of Ginkgo labels to skip (prefixed with `!` and joined with `&&`).
+- `eco_gotests_generic_env` (default: `{}`): Additional environment variables to pass to the container. Merged on top of the base environment using `combine()`.
+- `eco_gotests_generic_timeout` (default: `'12h'`): Timeout for the test run.
+
 ## Example Playbook
 
 ```yaml
@@ -57,7 +64,7 @@ SRIOV uses the same `eco_gotests_dump_failed_tests` toggle; reports are written 
   gather_facts: false
   vars:
     eco_gotests_test_suites: ['ptp', 'sriov']
-    eco_gotests_kubconfig_dir: /home/user/clusterconfigs
+    eco_gotests_kubeconfig_dir: /home/user/clusterconfigs
     eco_gotests_registry_auth_file: /home/user/pull-secret.json
   roles:
     - redhatci.ocp.eco_gotests
@@ -88,10 +95,31 @@ SRIOV uses the same `eco_gotests_dump_failed_tests` toggle; reports are written 
   vars:
     eco_gotests_test_suites: ['ptp']
     eco_gotests_skip_labels_ptp: ['node-reboot', 'process-restart']
-    eco_gotests_kubconfig_dir: /home/user/clusterconfigs
+    eco_gotests_kubeconfig_dir: /home/user/clusterconfigs
     eco_gotests_registry_auth_file: /home/user/pull-secret.json
   roles:
     - redhatci.ocp.eco_gotests
 ```
 
 This example will run all PTP tests except those labeled with `node-reboot` and `process-restart`.
+
+## Example with Generic Runner (LACP Bond Stability)
+
+```yaml
+---
+- name: Run LACP bond stability tests via generic eco-gotests runner
+  hosts: localhost
+  gather_facts: false
+  vars:
+    eco_gotests_test_suites: ['generic']
+    eco_gotests_generic_features: 'network'
+    eco_gotests_generic_run_labels: ['lacp-bond-stability']
+    eco_gotests_generic_env:
+      ECO_LACP_BONDED_NODES: "worker-0,worker-1"
+    eco_gotests_kubeconfig_dir: /home/user/clusterconfigs
+    eco_gotests_registry_auth_file: /home/user/pull-secret.json
+  roles:
+    - redhatci.ocp.eco_gotests
+```
+
+This example uses the generic runner to launch only the `lacp-bond-stability` labeled tests from the `network` feature, passing the `ECO_LACP_BONDED_NODES` environment variable to the container.

--- a/roles/eco_gotests/defaults/main.yml
+++ b/roles/eco_gotests/defaults/main.yml
@@ -19,6 +19,8 @@ eco_gotests_sriov_timeout: "12h"
 eco_gotests_verbose_level: 100
 eco_gotests_test_verbose: true
 
+eco_gotests_kubeconfig_dir: "{{ eco_gotests_kubconfig_dir | default('') }}"
+
 # PTP test configuration
 eco_gotests_eco_test_features_ptp: "ptp"
 eco_gotests_run_labels_ptp: []
@@ -26,3 +28,10 @@ eco_gotests_skip_labels_ptp: []
 eco_gotests_ptp_check_prerequisites: true
 # Max wall-clock time (seconds) for the PTP eco-gotests podman run; Ansible stops the task after this (default 1h).
 eco_gotests_ptp_run_timeout_sec: 3600
+
+# Generic test runner configuration
+eco_gotests_generic_features: ''
+eco_gotests_generic_run_labels: []
+eco_gotests_generic_skip_labels: []
+eco_gotests_generic_env: {}
+eco_gotests_generic_timeout: '12h'

--- a/roles/eco_gotests/defaults/main.yml
+++ b/roles/eco_gotests/defaults/main.yml
@@ -35,3 +35,4 @@ eco_gotests_generic_run_labels: []
 eco_gotests_generic_skip_labels: []
 eco_gotests_generic_env: {}
 eco_gotests_generic_timeout: '12h'
+eco_gotests_generic_run_label_operator: '||'

--- a/roles/eco_gotests/tasks/generic.yml
+++ b/roles/eco_gotests/tasks/generic.yml
@@ -57,7 +57,7 @@
   register: _eco_gotests_generic_failed_dump_stat
 
 - name: "Compress failed suite dumps: {{ eco_gotests_generic_features }}"
-  ansible.builtin.archive:
+  community.general.archive:
     path: "{{ eco_gotests_log_dir }}/eco_gotests/{{ eco_gotests_generic_features }}/failed_{{ eco_gotests_generic_features }}_suite_test"
     dest: "{{ eco_gotests_log_dir }}/failed_{{ eco_gotests_generic_features }}_suite_test.tar.gz"
     format: gz

--- a/roles/eco_gotests/tasks/generic.yml
+++ b/roles/eco_gotests/tasks/generic.yml
@@ -17,11 +17,11 @@
     _eco_gotests_generic_test_labels: >-
       {%- if eco_gotests_generic_run_labels | length > 0
       and eco_gotests_generic_skip_labels | length > 0 -%}
-      {{ '(' ~ (eco_gotests_generic_run_labels | join(' || '))
+      {{ '(' ~ (eco_gotests_generic_run_labels | join(' ' ~ eco_gotests_generic_run_label_operator ~ ' '))
       ~ ') && '
       ~ (eco_gotests_generic_skip_labels | map('regex_replace', '^', '!') | join(' && ')) }}
       {%- elif eco_gotests_generic_run_labels | length > 0 -%}
-      {{ eco_gotests_generic_run_labels | join(' || ') }}
+      {{ eco_gotests_generic_run_labels | join(' ' ~ eco_gotests_generic_run_label_operator ~ ' ') }}
       {%- elif eco_gotests_generic_skip_labels | length > 0 -%}
       {{ eco_gotests_generic_skip_labels | map('regex_replace', '^', '!') | join(' && ') }}
       {%- endif -%}

--- a/roles/eco_gotests/tasks/generic.yml
+++ b/roles/eco_gotests/tasks/generic.yml
@@ -1,0 +1,82 @@
+---
+- name: "Validate generic runner configuration"
+  ansible.builtin.assert:
+    that:
+      - eco_gotests_generic_features | length > 0
+    fail_msg: "eco_gotests_generic_features must be set when using the 'generic' test suite"
+    success_msg: "Generic runner configured for feature: {{ eco_gotests_generic_features }}"
+
+- name: "Create reports directory for generic tests: {{ eco_gotests_generic_features }}"
+  ansible.builtin.file:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/{{ eco_gotests_generic_features }}"
+    state: directory
+    mode: '0755'
+
+- name: "Run eco-gotests generic tests: {{ eco_gotests_generic_features }}"
+  vars:
+    _eco_gotests_generic_test_labels: >-
+      {%- if eco_gotests_generic_run_labels | length > 0
+      and eco_gotests_generic_skip_labels | length > 0 -%}
+      {{ '(' ~ (eco_gotests_generic_run_labels | join(' || '))
+      ~ ') && '
+      ~ (eco_gotests_generic_skip_labels | map('regex_replace', '^', '!') | join(' && ')) }}
+      {%- elif eco_gotests_generic_run_labels | length > 0 -%}
+      {{ eco_gotests_generic_run_labels | join(' || ') }}
+      {%- elif eco_gotests_generic_skip_labels | length > 0 -%}
+      {{ eco_gotests_generic_skip_labels | map('regex_replace', '^', '!') | join(' && ') }}
+      {%- endif -%}
+    _eco_gotests_generic_base_env:
+      KUBECONFIG: "/kubeconfig/kubeconfig"
+      ECO_TEST_FEATURES: "{{ eco_gotests_generic_features }}"
+      REGISTRY_AUTH_FILE: "{{ eco_gotests_registry_auth_file }}"
+      ECO_TEST_LABELS: "{{ _eco_gotests_generic_test_labels }}"
+      ECO_REPORTS_DUMP_DIR: "/tmp/reports"
+      ECO_DUMP_FAILED_TESTS: "{{ eco_gotests_dump_failed_tests | bool }}"
+  containers.podman.podman_container:
+    name: "eco-gotests-{{ eco_gotests_generic_features }}-{{ eco_gotests_date }}"
+    image: "{{ eco_gotests_image }}"
+    pull: newer
+    state: started
+    interactive: true
+    network_mode: host
+    uidmap:
+      - "0:1:1000"
+      - "1000:0:1"
+    env: "{{ _eco_gotests_generic_base_env | combine(eco_gotests_generic_env) }}"
+    volumes:
+      - "{{ eco_gotests_kubeconfig_dir }}/:/kubeconfig:Z"
+      - "{{ eco_gotests_log_dir }}/eco_gotests/{{ eco_gotests_generic_features }}:/tmp/reports:Z"
+    detach: false
+    remove: true
+    command: ["--timeout={{ eco_gotests_generic_timeout }}", "--keep-going"]
+  failed_when: false
+
+- name: "Stat failed suite dump directory: {{ eco_gotests_generic_features }}"
+  ansible.builtin.stat:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/{{ eco_gotests_generic_features }}/failed_{{ eco_gotests_generic_features }}_suite_test"
+  register: _eco_gotests_generic_failed_dump_stat
+
+- name: "Compress failed suite dumps: {{ eco_gotests_generic_features }}"
+  ansible.builtin.archive:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/{{ eco_gotests_generic_features }}/failed_{{ eco_gotests_generic_features }}_suite_test"
+    dest: "{{ eco_gotests_log_dir }}/failed_{{ eco_gotests_generic_features }}_suite_test.tar.gz"
+    format: gz
+    mode: "0644"
+  when:
+    - eco_gotests_dump_failed_tests | bool
+    - _eco_gotests_generic_failed_dump_stat.stat.exists | default(false)
+    - _eco_gotests_generic_failed_dump_stat.stat.isdir | default(false)
+
+- name: "Remove failed suite dump directory after compression: {{ eco_gotests_generic_features }}"
+  ansible.builtin.file:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/{{ eco_gotests_generic_features }}/failed_{{ eco_gotests_generic_features }}_suite_test"
+    state: absent
+  when:
+    - eco_gotests_dump_failed_tests | bool
+    - _eco_gotests_generic_failed_dump_stat.stat.exists | default(false)
+    - _eco_gotests_generic_failed_dump_stat.stat.isdir | default(false)
+
+- name: "Remove temporary testrun report file: {{ eco_gotests_generic_features }}"
+  ansible.builtin.file:
+    path: "{{ eco_gotests_log_dir }}/eco_gotests/{{ eco_gotests_generic_features }}/report_testrun.xml"
+    state: absent

--- a/roles/eco_gotests/tasks/main.yml
+++ b/roles/eco_gotests/tasks/main.yml
@@ -18,12 +18,17 @@
 - name: "Eco_gotests : Run PTP tests"
   ansible.builtin.include_tasks: ptp.yml
   when:
-    - '"ptp" in ( eco_gotests_test_suites | lower )'
+    - '"ptp" in (eco_gotests_test_suites | map("lower") | list)'
 
 - name: "Eco_gotests : Run SRIOV tests"
   ansible.builtin.include_tasks: sriov.yml
   when:
-    - '"sriov" in ( eco_gotests_test_suites | lower )'
+    - '"sriov" in (eco_gotests_test_suites | map("lower") | list)'
+
+- name: "Eco_gotests : Run generic tests"
+  ansible.builtin.include_tasks: generic.yml
+  when:
+    - '"generic" in (eco_gotests_test_suites | map("lower") | list)'
 
 - name: "Rename junit XML files with the feature name"
   ansible.builtin.shell: |
@@ -32,7 +37,7 @@
         -type f \
         -exec sh -c 'mv "$1" "{{ eco_gotests_log_dir }}/{{ item }}_$(basename "$1")"' _ {} \;
     fi
-  loop:
-    - ptp
-    - sriov
+  loop: >-
+    {{ ['ptp', 'sriov'] +
+       ([eco_gotests_generic_features] if eco_gotests_generic_features else []) }}
   changed_when: false

--- a/roles/eco_gotests/tasks/ptp.yml
+++ b/roles/eco_gotests/tasks/ptp.yml
@@ -43,66 +43,14 @@
       eco_gotests_skip_labels_ptp: "{{ eco_gotests_skip_labels_ptp | default([]) }}"
       eco_gotests_ptp_run_timeout_sec: "{{ eco_gotests_ptp_run_timeout_sec }}"
 
-- name: "Run PTP tests with eco-gotests"
-  vars:
-    _eco_gotests_ptp_test_labels: >-
-      {{
-        [
-          eco_gotests_run_labels_ptp | default([]) | join(' && '),
-          eco_gotests_skip_labels_ptp | default([]) | map('regex_replace', '^', '!') | join(' && ')
-        ] | map('trim') | reject('equalto', '') | join(' && ')
-      }}
-  containers.podman.podman_container:
-    name: "eco-gotests-ptp-{{ eco_gotests_date }}"
-    image: "{{ eco_gotests_image }}"
-    pull: newer
-    state: started
-    interactive: true
-    network_mode: host
-    uidmap:
-      - "0:1:1000"
-      - "1000:0:1"
-    env:
-      KUBECONFIG: "/kubeconfig/kubeconfig"
-      ECO_TEST_FEATURES: "{{ eco_gotests_eco_test_features_ptp }}"
-      REGISTRY_AUTH_FILE: "{{ eco_gotests_registry_auth_file }}"
-      ECO_TEST_LABELS: "{{ _eco_gotests_ptp_test_labels }}"
-      ECO_REPORTS_DUMP_DIR: "/tmp/reports"
-      ECO_DUMP_FAILED_TESTS: "{{ eco_gotests_dump_failed_tests | bool }}"
-    volumes:
-      - "{{ eco_gotests_kubeconfig_dir }}/:/kubeconfig:Z"
-      - "{{ eco_gotests_log_dir }}/eco_gotests/ptp:/tmp/reports:Z"
-    detach: false
-    remove: true
-    timeout: "{{ eco_gotests_ptp_run_timeout_sec }}"
-  failed_when: false
+- name: "Map PTP variables to generic runner"
+  ansible.builtin.set_fact:
+    eco_gotests_generic_features: "{{ eco_gotests_eco_test_features_ptp }}"
+    eco_gotests_generic_run_labels: "{{ eco_gotests_run_labels_ptp }}"
+    eco_gotests_generic_skip_labels: "{{ eco_gotests_skip_labels_ptp }}"
+    eco_gotests_generic_env: {}
+    eco_gotests_generic_timeout: "{{ eco_gotests_ptp_run_timeout_sec }}s"
+    eco_gotests_generic_run_label_operator: '&&'
 
-- name: "Stat failed PTP suite dump directory"
-  ansible.builtin.stat:
-    path: "{{ eco_gotests_log_dir }}/eco_gotests/ptp/failed_ptp_suite_test"
-  register: _eco_gotests_ptp_failed_dump_stat
-
-- name: "Compress failed PTP suite dumps to failed_ptp_suite_test.tar.gz"
-  ansible.builtin.archive:  # noqa: fqcn[canonical]
-    path: "{{ eco_gotests_log_dir }}/eco_gotests/ptp/failed_ptp_suite_test"
-    dest: "{{ eco_gotests_log_dir }}/failed_ptp_suite_test.tar.gz"
-    format: gz
-    mode: "0644"
-  when:
-    - eco_gotests_dump_failed_tests | bool
-    - _eco_gotests_ptp_failed_dump_stat.stat.exists | default(false)
-    - _eco_gotests_ptp_failed_dump_stat.stat.isdir | default(false)
-
-- name: "Remove failed PTP suite dump directory after compression"
-  ansible.builtin.file:
-    path: "{{ eco_gotests_log_dir }}/eco_gotests/ptp/failed_ptp_suite_test"
-    state: absent
-  when:
-    - eco_gotests_dump_failed_tests | bool
-    - _eco_gotests_ptp_failed_dump_stat.stat.exists | default(false)
-    - _eco_gotests_ptp_failed_dump_stat.stat.isdir | default(false)
-
-- name: "Remove temporary PTP testrun report file"
-  ansible.builtin.file:
-    path: "{{ eco_gotests_log_dir }}/eco_gotests/ptp/report_testrun.xml"
-    state: absent
+- name: "Run PTP tests via generic runner"
+  ansible.builtin.include_tasks: generic.yml

--- a/roles/eco_gotests/tasks/ptp.yml
+++ b/roles/eco_gotests/tasks/ptp.yml
@@ -70,7 +70,7 @@
       ECO_REPORTS_DUMP_DIR: "/tmp/reports"
       ECO_DUMP_FAILED_TESTS: "{{ eco_gotests_dump_failed_tests | bool }}"
     volumes:
-      - "{{ eco_gotests_kubconfig_dir }}/:/kubeconfig:Z"
+      - "{{ eco_gotests_kubeconfig_dir }}/:/kubeconfig:Z"
       - "{{ eco_gotests_log_dir }}/eco_gotests/ptp:/tmp/reports:Z"
     detach: false
     remove: true

--- a/roles/eco_gotests/tasks/sriov.yml
+++ b/roles/eco_gotests/tasks/sriov.yml
@@ -1,22 +1,12 @@
 ---
-- name: "Run SRIOV tests with eco-gotests"
-  containers.podman.podman_container:
-    name: "eco-gotests-sriov-{{ eco_gotests_date }}"
-    image: "{{ eco_gotests_image }}"
-    pull: newer
-    state: started
-    interactive: true
-    network_mode: host
-    uidmap:
-      - "0:1:1000"
-      - "1000:0:1"
-    env:
-      KUBECONFIG: "/kubeconfig/kubeconfig"
-      ECO_REPORTS_DUMP_DIR: "/tmp/reports"
+- name: "Map SRIOV variables to generic runner"
+  ansible.builtin.set_fact:
+    eco_gotests_generic_features: "{{ eco_gotests_eco_test_features_sriov }}"
+    eco_gotests_generic_run_labels: []
+    eco_gotests_generic_skip_labels: []
+    eco_gotests_generic_env:
       ECO_VERBOSE_LEVEL: "{{ eco_gotests_verbose_level }}"
       ECO_TEST_VERBOSE: "{{ eco_gotests_test_verbose | lower }}"
-      ECO_DUMP_FAILED_TESTS: "{{ eco_gotests_dump_failed_tests | bool }}"
-      ECO_TEST_FEATURES: "{{ eco_gotests_eco_test_features_sriov }}"
       ECO_TEST_LABELS: "{{ eco_gotests_sriov_labels }}"
       ECO_WORKER_LABEL: "{{ eco_gotests_worker_label }}"
       ECO_CNF_CORE_NET_CNF_MCP_LABEL: "{{ eco_gotests_worker_label }}"
@@ -24,41 +14,7 @@
       ECO_CNF_CORE_NET_TEST_CONTAINER: "{{ eco_gotests_network_test_container }}"
       ECO_CNF_CORE_NET_DPDK_TEST_CONTAINER: "{{ eco_gotests_dpdk_test_container }}"
       ECO_CNF_CORE_NET_FRR_IMAGE: "{{ eco_gotests_frr_image }}"
-      REGISTRY_AUTH_FILE: "{{ eco_gotests_registry_auth_file }}"
-    volumes:
-      - "{{ eco_gotests_kubeconfig_dir }}/:/kubeconfig:Z"
-      - "{{ eco_gotests_log_dir }}/eco_gotests/sriov:/tmp/reports:Z"
-    detach: false
-    remove: true
-    command: ["--timeout={{ eco_gotests_sriov_timeout }}", "--keep-going"]
-  failed_when: false
+    eco_gotests_generic_timeout: "{{ eco_gotests_sriov_timeout }}"
 
-- name: "Stat failed SRIOV suite dump directory"
-  ansible.builtin.stat:
-    path: "{{ eco_gotests_log_dir }}/eco_gotests/sriov/failed_sriov_suite_test"
-  register: _eco_gotests_sriov_failed_dump_stat
-
-- name: "Compress failed SRIOV suite dumps to failed_sriov_suite_test.tar.gz"
-  ansible.builtin.archive:  # noqa: fqcn[canonical]
-    path: "{{ eco_gotests_log_dir }}/eco_gotests/sriov/failed_sriov_suite_test"
-    dest: "{{ eco_gotests_log_dir }}/failed_sriov_suite_test.tar.gz"
-    format: gz
-    mode: "0644"
-  when:
-    - eco_gotests_dump_failed_tests | bool
-    - _eco_gotests_sriov_failed_dump_stat.stat.exists | default(false)
-    - _eco_gotests_sriov_failed_dump_stat.stat.isdir | default(false)
-
-- name: "Remove failed SRIOV suite dump directory after compression"
-  ansible.builtin.file:
-    path: "{{ eco_gotests_log_dir }}/eco_gotests/sriov/failed_sriov_suite_test"
-    state: absent
-  when:
-    - eco_gotests_dump_failed_tests | bool
-    - _eco_gotests_sriov_failed_dump_stat.stat.exists | default(false)
-    - _eco_gotests_sriov_failed_dump_stat.stat.isdir | default(false)
-
-- name: "Remove temporary SRIOV testrun report file"
-  ansible.builtin.file:
-    path: "{{ eco_gotests_log_dir }}/eco_gotests/sriov/report_testrun.xml"
-    state: absent
+- name: "Run SRIOV tests via generic runner"
+  ansible.builtin.include_tasks: generic.yml

--- a/roles/eco_gotests/tasks/sriov.yml
+++ b/roles/eco_gotests/tasks/sriov.yml
@@ -26,7 +26,7 @@
       ECO_CNF_CORE_NET_FRR_IMAGE: "{{ eco_gotests_frr_image }}"
       REGISTRY_AUTH_FILE: "{{ eco_gotests_registry_auth_file }}"
     volumes:
-      - "{{ eco_gotests_kubconfig_dir }}/:/kubeconfig:Z"
+      - "{{ eco_gotests_kubeconfig_dir }}/:/kubeconfig:Z"
       - "{{ eco_gotests_log_dir }}/eco_gotests/sriov:/tmp/reports:Z"
     detach: false
     remove: true


### PR DESCRIPTION
## Summary

Add a generic test runner to the eco_gotests role that supports any eco-gotests feature with configurable Ginkgo label filtering (run/skip), custom environment variables, and per-feature report directories.

Refactor `ptp.yml` and `sriov.yml` to delegate to `generic.yml` internally, eliminating ~92 lines of duplicated podman container run boilerplate. PTP keeps its prerequisite checks and debug task, then maps PTP-specific variables to generic runner variables (with `eco_gotests_generic_run_label_operator='&&'` for AND semantics). SRIOV maps all its env vars into `eco_gotests_generic_env`. All user-facing PTP/SRIOV variables remain unchanged — fully backward compatible.

New variables:
- `eco_gotests_generic_features`
- `eco_gotests_generic_run_labels`
- `eco_gotests_generic_skip_labels`
- `eco_gotests_generic_env`
- `eco_gotests_generic_timeout`
- `eco_gotests_generic_run_label_operator` (default: `||`)

Also includes:
- Fix `eco_gotests_kubeconfig_dir` typo (was `kubconfig`) with backward-compatible fallback
- Fix `map('lower')` list membership check in `main.yml`
- Use `community.general.archive` (canonical FQCN) in `generic.yml`
- Bump collection version to 3.6.0 (RPM spec + galaxy.yml)

TestBos2Workload: control-plane