### PR TITLE
Set minimal versions to galaxy dependencies

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -97,12 +97,12 @@ license_file: ''
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification).
 # Multiple version range specifiers can be set and are separated by ','
 dependencies:
-  "ansible.posix": "*"
-  "ansible.utils": "*"
+  "ansible.posix": ">=1.5.4"
+  "ansible.utils": ">=2.12.0"
   "community.crypto": "2.18.0"
   "community.general": "7.0.1"
-  "community.libvirt": "*"
-  "containers.podman": "*"
+  "community.libvirt": ">=1.3.0"
+  "containers.podman": ">=1.16.3"
   "kubernetes.core": "2.4.2"
 
 # The URL of the originating SCM repository


### PR DESCRIPTION
##### SUMMARY

Setting minimal versions helps to avoid keep querying galaxy for all the versions available in a collection
It has been observed that when there are no local requirements installed the ansible galaxy queries all the versions of a requirement, taking a really long time to process the dependencies, e.g.

```Log
Processing requirement collection 'ansible.posix' - as dependency of redhatci.ocp
Collection requirement 'ansible.posix' is the name of a collection
Found API version 'v3, pulp-v3, v1' with Galaxy server default (https://galaxy.ansible.com/api/)
Calling Galaxy at https://galaxy.ansible.com/api/v3/collections/ansible/posix/versions/
Calling Galaxy at https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/ansible/posix/versions/?limit=10&offset=10
...
Calling Galaxy at https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/ansible/posix/versions/?limit=10&offset=70
Calling Galaxy at https://galaxy.ansible.com/api/v3/collections/ansible/utils/versions/
Collection 'ansible.posix' obtained from server default https://galaxy.ansible.com/api/
Processing requirement collection 'ansible.utils' - as dependency of redhatci.ocp
```

This change should reduce the queries and also set a known minimal version that has been tested.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDYtMTVUMjE6MjE6NTJ8OWVlMjQ4ZDUyYmU4OWVmZDMyM2Y3M2NmOGRjMGQ5ZTgzNDQwZDY3NQ==
Gitleaks-Hash: 2f70f4179c98b0b4a6c485a509c7e2c9b39f37de544373deb5fe49ce2d076edc


##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/804f6160-a38c-49ed-bdc4-cf72c380eb3f

---

Test-hints: no-check