### PR TITLE
Enable CPU Partitioning Mode for all nodes

### DIFF
--- a/roles/generate_manifests/README.md
+++ b/roles/generate_manifests/README.md
@@ -21,6 +21,7 @@ All of the variables have sane defaults which you can override to force things, 
 | ocp_registry_image            | openshift4                        | No        | Name for image in the image mirror |
 | gm_image_sources              | (default block)                   | No        | Override the default ICSP block [^2] |
 | single_node_openshift_enabled | false                             | No        | Install OCP in single-node mode |
+| partitioning_enabled          | false                             | No        | Enable CPU partitioning mode for all Nodes |
 
 ## Usage Examples
 
@@ -45,6 +46,7 @@ All of the variables have sane defaults which you can override to force things, 
         - source: registry.example.com/ocp/release
           mirrors:
             - my-custom-registry.example.com:5000/my-repo
+    partitioning_enabled: false
   ansible.builtin.include_role:
     name: redhatci.ocp.generate_manifests
 ```

--- a/roles/generate_manifests/templates/install-config.yaml.j2
+++ b/roles/generate_manifests/templates/install-config.yaml.j2
@@ -1,6 +1,9 @@
 #jinja2:trim_blocks: True, lstrip_blocks: True
 apiVersion: v1
 baseDomain: {{ base_dns_domain}}
+{% if partitioning_enabled | default(false) | bool %}
+cpuPartitioningMode: AllNodes
+{% endif %}
 controlPlane:
   name: master
   replicas: {{ groups['masters'] | length }}


### PR DESCRIPTION


##### SUMMARY

- This flag must be enabled during installation
 ref: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/enabling-workload-partitioning#enabling-workload-partitioning_enabling-workload-partitioning

This feature is supported from 4.14 and used for Telco industries 

Test-Hints: no-check

- [x] TestBos2: abi - https://www.distributed-ci.io/jobs/055821f8-ace3-4112-9757-d2c950a9f2b9/jobStates