### PR TITLE
mirror_ocp_release: added new var mor_oc_mirror_binary_url and fixed …

### DIFF
--- a/roles/mirror_ocp_release/README.md
+++ b/roles/mirror_ocp_release/README.md
@@ -27,6 +27,7 @@ If enabled, the role requires a container registry to mirror the OCP container i
 | mor_write_custom_config      | true                                                               | No       | Writes the OCP configuration files and sets the custom URL facts. Requires `mor_webserver_url` to be set.
 | mor_allow_insecure_registry  | true                                                               | No       | Allow interacting with registries that are using an unknown CA certificate.
 | mor_extra_flags              | ""                                                                 | No       | Extra flags to pass to the `oc adm release mirror` command when mirroring release images.
+| mor_oc_mirror_binary_url     | https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/oc-mirror.tar.gz | No | Download URL for the `oc-mirror` tarball used when mirroring container images on OCP 4.20+.
 | mor_build                    | ga                                                                 | No       | The build type of the OCP release. Supported values: ga, candidate, dev, nightly.
 
 ## Requirements

--- a/roles/mirror_ocp_release/tasks/oc-mirror.yml
+++ b/roles/mirror_ocp_release/tasks/oc-mirror.yml
@@ -76,7 +76,7 @@
 
     - name: Extract latest oc-mirror
       ansible.builtin.unarchive:
-        src: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/oc-mirror.tar.gz"
+        src: "{{ mor_oc_mirror_binary_url }}"
         dest: "{{ _mor_tmp_dir.path }}"
         remote_src: true
         mode: "0755"
@@ -88,6 +88,14 @@
     - name: Find an available ephemeral port for oc-mirror
       redhatci.ocp.find_available_port:
       register: _mor_ephemeral_port
+
+    - name: Workaround oc-mirror v2 authfile issue
+      no_log: true
+      ansible.builtin.copy:
+        src: "{{ mor_auths_file }}"
+        remote_src: true
+        dest: "$XDG_RUNTIME_DIR/containers/auth.json"
+        mode: "0644"
 
     # Only GA and Candidate builds include signed images
     - name: Mirror the release to the local registry
@@ -109,6 +117,12 @@
       delay: 10
       until: _mor_cmd_output.rc == 0
       changed_when: _mor_cmd_output.rc == 0
+
+    - name: Remove authfile workaround oc-mirror
+      no_log: true
+      ansible.builtin.file:
+        path: "$XDG_RUNTIME_DIR/containers/auth.json"
+        state: absent
 
     - name: Write Image Source manifest
       ansible.builtin.copy:


### PR DESCRIPTION
…auth issue

##### SUMMARY

<!-- Describe the change, including rationale and design decisions -->

This update improves OCP 4.20+ release mirroring in mirror_ocp_release in two ways.

Configurable oc-mirror download URL

The oc-mirror tarball URL was hardcoded in oc-mirror.yml. It is now exposed as mor_oc_mirror_binary_url (defaulting to the existing OpenShift mirror URL). That lets users point at an  mirror or pin a specific client version(bug free), without changing role tasks. 

Auth workaround for oc-mirror v2

oc-mirror v2 does not always honor --authfile the way the role expects. Before the mirror run, the role copies mor_auths_file to $XDG_RUNTIME_DIR/containers/auth.json, which is where the containers stack looks for credentials. The copy is removed after mirroring. The mirror command still passes --authfile and unsets REGISTRY_AUTH_FILE so env-based auth does not override the intended file. Auth-related tasks use no_log: true to avoid leaking credentials.

Documentation

mor_oc_mirror_binary_url is documented in the role README. No change to the mirroring flow beyond configurability and more reliable registry authentication.
<!-- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!-- Pick one below and delete the other: -->
- Bug, Docs Fix or other nominal change
- New or Enhanced Feature

##### Tests

<!-- Document the tests for this change, if any -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->

<!-- Examples:
- [ ] Testvcp: ocp-4.17-vanilla - <JobURL>
- [ ] TestvcpHybrid: ocp-4.17-vanilla-hybrid - <JobURL>
- [ ] TestvcpWorkload: preflight-green - <JobURL>
- [ ] TestBos2: virt - <JobURL>
- [ ] TestBos2Sno: sno - <JobURL>
- [ ] TestBos2SnoBaremetal: sno - <JobURL>
-->

---

<!-- Include the test and dependencies for this change -->
<!-- See: https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/CONTRIBUTING.md#ci-pipelines -->


<!-- Examples:

Test-Hint: no-check
Depends-on: https://path/to/depending/change

-->
