### PR TITLE
Bump certsuite to v5.5.22

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.21
+kbpc_version: v5.5.22
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"


### PR DESCRIPTION
##### SUMMARY

Bump certsuite to v5.5.22

##### ISSUE TYPE

- Bump version

##### Tests

- [x] TestBos2Workload: certsuite-green certsuite-green:ansible_extravars=kbpc_version:v5.5.22 - https://www.distributed-ci.io/jobs/d2163174-481b-4a5e-accd-be0e8f46b2a2/jobStates

Test-Hints: no-check