### PR TITLE
Fix ansible-lint schema violations in meta and vars files

### DIFF
--- a/roles/boot_disk/meta/main.yml
+++ b/roles/boot_disk/meta/main.yml
@@ -3,5 +3,5 @@ galaxy_info:
   description: Boot from disk
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   galaxy_tags: []

--- a/roles/boot_iso/meta/main.yml
+++ b/roles/boot_iso/meta/main.yml
@@ -3,5 +3,5 @@ galaxy_info:
   description: Boot the Discovery ISO
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   galaxy_tags: []

--- a/roles/installer/meta/main.yml
+++ b/roles/installer/meta/main.yml
@@ -3,6 +3,6 @@ galaxy_info:
   description: The installer role assists in installing Red Hat OpenShift
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   galaxy_tags: []
 dependencies: []

--- a/roles/manage_firewalld_zone/meta/main.yml
+++ b/roles/manage_firewalld_zone/meta/main.yml
@@ -4,5 +4,5 @@ galaxy_info:
   description: Manages a firewalld zone
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   galaxy_tags: []

--- a/roles/node_prep/meta/main.yml
+++ b/roles/node_prep/meta/main.yml
@@ -3,6 +3,6 @@ galaxy_info:
   description: The node_prep role assists in setup of the provision host.
   company: Red Hat, Inc.
   license: Apache License, Version 2.0
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   galaxy_tags: []
 dependencies: []

--- a/roles/upi_installer/defaults/main.yml
+++ b/roles/upi_installer/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-serverport: 8000
-upi_installer_timeout: 600
 webserver_url: ""
 cache_dir: "/opt/cache"
 upi_pullsecret: "{{ cache_dir }}/pull-secret.txt"

--- a/roles/upi_installer/defaults/main.yml
+++ b/roles/upi_installer/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 serverport: 8000
-timeout: 600
+upi_installer_timeout: 600
 webserver_url: ""
 cache_dir: "/opt/cache"
 upi_pullsecret: "{{ cache_dir }}/pull-secret.txt"


### PR DESCRIPTION
## Summary

- Quoted `min_ansible_version: 2.9` as `"2.9"` in 5 `meta/main.yml` files to satisfy `schema[meta]` type requirement
- Removed unused variables `timeout` and `serverport` from `roles/upi_installer/defaults/main.yml` to satisfy `schema[vars]` reserved-name check and reduce dead code

## Changes

- `roles/boot_disk/meta/main.yml` — quoted `min_ansible_version` as string
- `roles/boot_iso/meta/main.yml` — quoted `min_ansible_version` as string
- `roles/installer/meta/main.yml` — quoted `min_ansible_version` as string
- `roles/manage_firewalld_zone/meta/main.yml` — quoted `min_ansible_version` as string
- `roles/node_prep/meta/main.yml` — quoted `min_ansible_version` as string
- `roles/upi_installer/defaults/main.yml` — removed unused variables `timeout` and `serverport`

## Notes

All 6 remaining `ansible-lint` schema violations (`schema[meta]` and `schema[vars]`) are addressed by this PR. The original ticket (CILAB-2024) listed 8 violations; the other 2 were fixed by PRs merged to `main` since the ticket was filed.

The `timeout` and `serverport` variables were dead defaults — never referenced in any task file within the role, and not used by any known downstream consumer. UPI installer has not been in active use for months. Removing them reduces maintenance surface per reviewer request.

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)

Test-Hints: no-check
