### PR TITLE
Do not include provisioner in group

### DIFF
--- a/roles/ocp_on_libvirt/templates/hosts.j2
+++ b/roles/ocp_on_libvirt/templates/hosts.j2
@@ -96,6 +96,8 @@ ansible_ssh_extra_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/n
 {% if enable_redfish | bool -%}
 [kvm_hosts_redfish]
 {% for key, value in ironic_nodes.items() -%}
+{% if 'provision' not in key -%}
 {{ key }}
+{% endif -%}
 {% endfor %}
 {%- endif %}


### PR DESCRIPTION
##### SUMMARY

The provisioner is not part of the cluster itself, we don't want to control it through kvm_host_group, only cluster nodes.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDYtMjNUMjM6MDE6NTV8NWQ4OTNiODNhMGFlODFmNGY3ZTE1M2FlN2FmZGM1ZDZhZDllZWFiZQ==
Gitleaks-Hash: 1851782acaf102e266279e1da5236244490fbae70da5a5d38ed5f7f16eacc524

##### ISSUE TYPE

- Bug

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/e3cfd52a-1669-4e98-acc2-55253f9f95e8, https://www.distributed-ci.io/jobs/fc704df5-dc03-4512-bfff-c84ab5442eee

---

Test-hints: no-check
