### PR TITLE
Include tolerations of master, control-plane & storage when odf_setup_ocs_on_control_plane is enabled

### DIFF
--- a/roles/odf_setup/README.md
+++ b/roles/odf_setup/README.md
@@ -34,6 +34,7 @@ Role Variables
 | ocs_total_deviceset              | length of local_storage_devices | Int | No          | (Optional) number of device sets for OCS |
 | odf_setup_enable_encryption      | false | Boolean | No          | Whether enable disk cluster-wide encryption for ODF |
 | odf_setup_key_rotation_period    | weekly | String | No          | Period of key rotation: daily, weekly, monthly, etc. |
+| odf_setup_ocs_on_control_plane   | false | Boolean | No          | Set true when ODF storage runs on dedicated control-plane nodes (e.g. MNO masters). Adds master/control-plane tolerations to LSO and StorageCluster storageDeviceSets. |
 
 
 Inventory Groups and Variables

--- a/roles/odf_setup/defaults/main.yml
+++ b/roles/odf_setup/defaults/main.yml
@@ -40,3 +40,18 @@ odf_setup_key_rotation_period: weekly
 
 # ODF enable Ceph Tools
 odf_setup_enable_ceph_tools: true
+
+# CSI_PLUGIN_TOLERATIONS for rook-ceph-operator-config
+odf_setup_csi_plugin_tolerations: |
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+  - key: node.ocs.openshift.io/storage
+    operator: Exists
+    effect: NoSchedule
+
+# ODF setup on control plane nodes. When true, add control-plane tolerations for LSO workloads.
+odf_setup_ocs_on_control_plane: false

--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -6,6 +6,24 @@
   when:
     - ocs_install_type == 'internal'
 
+- name: Configure CSI plugin tolerations in rook-ceph-operator-config
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: ConfigMap
+    name: rook-ceph-operator-config
+    namespace: "{{ ocs_storage_namespace }}"
+    merge_type: merge
+    definition:
+      data:
+        CSI_PLUGIN_TOLERATIONS: "{{ odf_setup_csi_plugin_tolerations }}"
+  register: _odf_setup_csi_tolerations_patch
+  retries: 60
+  delay: 10
+  until: _odf_setup_csi_tolerations_patch is not failed
+  when:
+    - ocs_install_type == 'internal'
+    - odf_setup_ocs_on_control_plane | default(false) | bool
+
 - name: Tasks for External OCS/ODF Integration
   when:
     - ocs_install_type == 'external'

--- a/roles/odf_setup/templates/local-storage-block.yml.j2
+++ b/roles/odf_setup/templates/local-storage-block.yml.j2
@@ -5,6 +5,14 @@ metadata:
   name: local-block
 spec:
   tolerations:
+{% if (odf_setup_ocs_on_control_plane | default(false) | bool) and (ocp_version is version("4.16", ">=")) %}
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+{% endif %}
   - key: "node.ocs.openshift.io/storage"
     value: "true"
     effect: NoSchedule

--- a/roles/odf_setup/templates/ocs-disk-gatherer.yml.j2
+++ b/roles/odf_setup/templates/ocs-disk-gatherer.yml.j2
@@ -66,6 +66,14 @@ spec:
       nodeSelector:
         cluster.ocs.openshift.io/openshift-storage: ''
       tolerations:
+{% if (odf_setup_ocs_on_control_plane | default(false) | bool) and (ocp_version is version("4.16", ">="))  %}
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+{% endif %}
       - key: "node.ocs.openshift.io/storage"
         operator: Equal
         value: "true"

--- a/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
+++ b/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
@@ -24,6 +24,97 @@ spec:
 {% elif ocs_install_type == 'internal' %}
   manageNodes: false
   monDataDirHostPath: /var/lib/rook
+{% if (odf_setup_ocs_on_control_plane | default(false) | bool) and (ocp_version is version("4.16", ">=")) %}
+  placement:
+    all:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+    mds:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+    rgw:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+    toolbox:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+    csi-rbdplugin:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+    csi-cephfsplugin:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+    metrics-exporter:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+    noobaa-core:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+{% endif %}
   storageDeviceSets:
   - count: {{ ocs_total_deviceset | default(local_storage_devices | length) }}
     dataPVCTemplate:
@@ -36,7 +127,21 @@ spec:
         storageClassName: localblock
         volumeMode: Block
     name: ocs-deviceset
+{% if (odf_setup_ocs_on_control_plane | default(false) | bool) and (ocp_version is version("4.16", ">=")) %}
+    placement:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node.ocs.openshift.io/storage
+        operator: Exists
+        effect: NoSchedule
+{% else %}
     placement: {}
+{% endif %}
     portable: false
     replica: {{ replica_size | int }}
     resources: {}


### PR DESCRIPTION
##### SUMMARY

Updating templates to include toleration of master/control-plane taints
This is requires to make use of odf_setup role on samsungRAN where ODF is deployed on control-plane nodes. Master nodes also carry the control-plane taint (node-role.kubernetes.io/control-plane:NoSchedule), which the gatherer does not tolerate. Kubernetes therefore treats zero nodes as eligible.

##### ISSUE TYPE

Enhanced Feature

SUCCESS https://www.distributed-ci.io/jobs/921d9afb-9fe1-4505-b0cf-69fb61fc7462/jobStates

Test-Hint: no-check
