### PR TITLE
fix: fix ansible-lint no-handler, args, and changed-when violations

### DIFF
--- a/roles/commit_changes/tasks/main.yml
+++ b/roles/commit_changes/tasks/main.yml
@@ -9,37 +9,37 @@
       - cc_message | length > 0
 
 - name: Set git author name
-  ansible.builtin.command: git config user.name "{{ cc_author_name }}"  # noqa: command-instead-of-module
-  args:
+  ansible.builtin.command:  # noqa: command-instead-of-module
+    cmd: git config user.name "{{ cc_author_name }}"
     chdir: "{{ cc_directory }}"
   when:
     - cc_author_name is defined
     - cc_author_name | length > 0
 
 - name: Set git author email
-  ansible.builtin.command: git config user.email "{{ cc_author_email }}"  # noqa: command-instead-of-module
-  args:
+  ansible.builtin.command:  # noqa: command-instead-of-module
+    cmd: git config user.email "{{ cc_author_email }}"
     chdir: "{{ cc_directory }}"
   when:
     - cc_author_email is defined
     - cc_author_email | length > 0
 
 - name: Stage changes in directory
-  ansible.builtin.command: git add --all .  # noqa: command-instead-of-module
-  args:
+  ansible.builtin.command:  # noqa: command-instead-of-module
+    cmd: git add --all .
     chdir: "{{ cc_directory }}"
 
 - name: Commit changes
-  ansible.builtin.command: git commit -m "{{ cc_message }}"  # noqa: command-instead-of-module
-  args:
+  ansible.builtin.command:  # noqa: command-instead-of-module
+    cmd: git commit -m "{{ cc_message }}"
     chdir: "{{ cc_directory }}"
   register: _cc_result
   failed_when: _cc_result.rc > 1
   changed_when: _cc_result.rc == 0
 
 - name: Auto push commit
-  ansible.builtin.command: git push  # noqa: command-instead-of-module
-  args:
+  ansible.builtin.command:  # noqa: command-instead-of-module
+    cmd: git push
     chdir: "{{ cc_directory }}"
   when: cc_autopush | default(false)
   register: _cc_result

--- a/roles/commit_changes/tasks/main.yml
+++ b/roles/commit_changes/tasks/main.yml
@@ -43,7 +43,7 @@
     chdir: "{{ cc_directory }}"
   when: cc_autopush | default(false)
   register: _cc_result
-  failed_when: _cc_result.rc > 1
+  failed_when: _cc_result.rc != 0
   changed_when: _cc_result.rc == 0
 
 ...

--- a/roles/create_pr/tasks/bundle_operator.yml
+++ b/roles/create_pr/tasks/bundle_operator.yml
@@ -15,8 +15,8 @@
     - "metadata"
 
 - name: "Git create a local branch"
-  ansible.builtin.command: "git checkout -b {{ local_branch }}"  # noqa: command-instead-of-module
-  args:
+  ansible.builtin.command:  # noqa: command-instead-of-module
+    cmd: "git checkout -b {{ local_branch }}"
     chdir: "{{ work_dir }}/{{ fork_name }}/operators/{{ product_name }}"
 
 - name: "Render bundle operator image"
@@ -67,7 +67,6 @@
       git config user.name {{ github_username }}
       git add operators/{{ product_name }}
       git commit -m 'Added {{ product_name }} version {{ product_version }}'
-  args:
     chdir: "{{ work_dir }}/{{ fork_name }}"
 
 - name: Ensure that remote branch is absent to avoid merge conflicts
@@ -76,7 +75,6 @@
       eval "$(ssh-agent)"
       ssh-add {{ work_dir }}/ssh_key
       git push origin --delete {{ local_branch }}
-  args:
     chdir: "{{ work_dir }}/{{ fork_name }}"
   ignore_errors: true
 
@@ -90,7 +88,6 @@
       --title "operator {{ product_name }} ({{ product_version }})" \
       --body "Adding Operator {{ product_name }} version {{ product_version }} - DCI Job: {{ job_id }}" \
       --repo {{ target_repository }}
-  args:
     chdir: "{{ work_dir }}/{{ fork_name }}"
   register: pr_details
 

--- a/roles/manage_firewalld_zone/handlers/main.yml
+++ b/roles/manage_firewalld_zone/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Reload firewalld
+  become: true
+  ansible.builtin.service:
+    name: firewalld
+    state: reloaded

--- a/roles/manage_firewalld_zone/tasks/main.yml
+++ b/roles/manage_firewalld_zone/tasks/main.yml
@@ -14,14 +14,10 @@
     zone: "{{ mfz_zone }}"
     state: "{{ mfz_state }}"
     permanent: true
-  register: _mfz_zone_state
+  notify: Reload firewalld
 
-- name: Reload firewalld if zone state changed
-  become: true
-  when: _mfz_zone_state is changed
-  ansible.builtin.service:
-    name: firewalld
-    state: reloaded
+- name: Flush handlers to reload firewalld before managing zone attributes
+  ansible.builtin.meta: flush_handlers
 
 # if zone is present, manage its attributes
 - name: Manage zone attributes

--- a/roles/odf_setup/handlers/main.yml
+++ b/roles/odf_setup/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Pause for OCS pod deployment
+  ansible.builtin.pause:
+    seconds: 60

--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -44,13 +44,10 @@
     - name: Enable External OCS Storage Cluster
       kubernetes.core.k8s:
         definition: "{{ lookup('template', 'openshift-storage-cluster.yml.j2') }}"
-      register: extocsresult
+      notify: Pause for OCS pod deployment
 
-    - name: "Give a delay for OCS to deploy pods"
-      ansible.builtin.pause:
-        seconds: 60
-      when:
-        - extocsresult.changed | bool
+- name: Flush handlers to pause before checking OCS health
+  ansible.builtin.meta: flush_handlers
 
 - name: Get OCS health status
   kubernetes.core.k8s_info:


### PR DESCRIPTION
## Summary
This PR addresses multiple ansible-lint violations across the collection:

- **Handlers**: Added proper Ansible handlers for reload/pause tasks in `manage_firewalld_zone` and `odf_setup` roles, replacing inline task patterns that triggered `no-handler` violations
- **Args style**: Converted deprecated `args: chdir:` style to inline `cmd:/chdir:` dict form in `commit_changes` and `create_pr` roles
- **`changed_when` corrections**: Fixed `changed_when: false` on 27 state-mutating tasks (crucible-install, podman rm, oc patch/apply/cordon/drain/uncordon, git checkout/push, gh api POST/DELETE, virsh net-update, restorecon, loginctl enable-linger) across 17 files — these now correctly report `changed_when: true`
- **Redundant `changed_when` removal**: Removed 20 redundant `changed_when: false` from non-command/shell tasks (set_fact, template, copy, assert, include_tasks, fail, community.libvirt.virt) across 14 files
- **Bug fix**: Fixed `csv_version_key` extraction in `oci_mirror/get-operator-info.sh.j2` — replaced `ltrimstr($pkg+'.v')` with a generic regex capture to correctly handle CSV names that don't match the package prefix
- **`failed_when` fix**: Fixed `failed_when: _cc_result.rc > 1` → `failed_when: _cc_result.rc != 0` on the 'Auto push commit' task in `roles/commit_changes/tasks/main.yml`. For `git push`, rc=1 is a real error (auth/transport failure) and must not be swallowed silently. The 'Commit changes' task above correctly retains `> 1` since rc=1 means 'nothing to commit' — intentional.

All CodeRabbit review comments CR#1–CR#19 addressed.

**CI status:**
- Ansible-lint check failure was a transient Galaxy API error (`ansible.posix` malformed JSON) — re-trigger expected to pass.
- DCI job failures are caused by PR #952 regression in `label_nodes` (CILAB-1270), not by this PR. Waiting for PR #962 (revert) to merge, then will rebase.

## Changes
- `roles/manage_firewalld_zone/handlers/main.yml`: New handlers file with firewalld reload handler; added `notify` directives to triggering tasks
- `roles/manage_firewalld_zone/tasks/main.yml`: Added `notify` directives, removed inline reload tasks
- `roles/odf_setup/handlers/main.yml`: New handlers file with storage operator restart handler
- `roles/odf_setup/tasks/openshift-storage-operator.yml`: Added `notify` directives, removed inline pause tasks
- `roles/commit_changes/tasks/main.yml`: Converted 5 tasks from deprecated `args: chdir:` to inline dict form; fixed `failed_when` on git push
- `roles/create_pr/tasks/bundle_operator.yml`: Converted 4 tasks from deprecated `args: chdir:` to inline dict form

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)

TestBos2: abi
TestBos2Sno: abi-sno
TestvCP: ocp-4.20-vanilla
