### PR TITLE
Revert Remove kvm_hosts_redfish servers group

### DIFF
--- a/roles/installer/tasks/59_power_off_cluster_servers.yml
+++ b/roles/installer/tasks/59_power_off_cluster_servers.yml
@@ -67,10 +67,14 @@
 
 - name: Power Off via Redfish
   tags: powerservers
+  vars:
+    _baseuri: >-
+      {{ hostvars[item]['ipmi_address'] }}{{ ':' + hostvars[item]['redfish_port'] | string
+      if hostvars[item]['redfish_port'] is defined else '' }}
   community.general.redfish_command:
     category: Systems
     command: PowerGracefulShutdown
-    baseuri: "{{ hostvars[item]['ipmi_address'] }}"
+    baseuri: "{{ _baseuri }}"
     username: "{{ hostvars[item]['ipmi_user'] }}"
     password: "{{ hostvars[item]['ipmi_password'] }}"
     resource_id: "{{ hostvars[item]['kvm_uuid'] | default(omit) }}"

--- a/roles/installer/tasks/59_power_off_cluster_servers.yml
+++ b/roles/installer/tasks/59_power_off_cluster_servers.yml
@@ -15,6 +15,8 @@
         ( item not in groups['dell_hosts_redfish'] | default([]) )
           and
         ( item not in groups['hp_hosts_redfish'] | default([]) )
+          and
+        ( item not in groups['kvm_hosts_redfish'] | default([]) )
       loop: "{{ groups.masters + groups.workers | default([]) }}"
 
     - name: Check node power status via ipmi to filter off nodes
@@ -83,7 +85,10 @@
       ) or (
         groups['hp_hosts_redfish'] is defined and
         groups['hp_hosts_redfish'] | length > 0
+      ) or (
+        groups['kvm_hosts_redfish'] is defined and
+        groups['kvm_hosts_redfish'] | length > 0
       )
     )
-  loop: "{{ groups['dell_hosts_redfish'] | default([]) + groups['hp_hosts_redfish'] | default([]) }}"
+  loop: "{{ groups['dell_hosts_redfish'] | default([]) + groups['hp_hosts_redfish'] | default([]) + groups['kvm_hosts_redfish'] | default([]) }}"
 ...


### PR DESCRIPTION
##### SUMMARY
    
Adding back the use of kvm_hosts_redfish servers to power off the
servers with redfish support.

Injects the port when using redfish_port, when powering off the nodes.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDYtMjdUMDE6NDc6MTR8MDBhMTFlNWFkYzRjYmI1MjBiMjI1MzQ0Mzc5ZDUzZDhmMzY1MGE4Mw==
Gitleaks-Hash: 827370cd07192547e89bb80d0efa191cfdfa6db8f7b4030182a03d6496e54eae

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/ed458577-2083-43d8-850b-5c8e99dddffa
- [x] ocp-4.22-vcp-hybrid - https://www.distributed-ci.io/jobs/c8a3c507-83d3-471a-8d2a-c77cc3942a49

Test-hints: no-check