### PR TITLE
feat: add D2M workflow and digest verification to mirror_ocp_release role

### DIFF
--- a/roles/mirror_ocp_release/README.md
+++ b/roles/mirror_ocp_release/README.md
@@ -28,18 +28,16 @@ If enabled, the role requires a container registry to mirror the OCP container i
 | mor_allow_insecure_registry  | true                                                               | No       | Allow interacting with registries that are using an unknown CA certificate.
 | mor_extra_flags              | ""                                                                 | No       | Extra flags to pass to the `oc adm release mirror` command when mirroring release images.
 | mor_build                    | ga                                                                 | No       | The build type of the OCP release. Supported values: ga, candidate, dev, nightly.
-| mor_d2m_workflow             | false                                                              | No       | Enable two-step Disk-to-Mirror (D2M) workflow. Avoids TOCTOU race conditions during mirroring.
-| mor_verify_digests           | true                                                               | No       | Verify that the mirrored release image digest matches the pre-mirror digest. Detects TOCTOU drift.
+| mor_d2m_workflow             | false                                                              | No       | Enable two-step Disk-to-Mirror (D2M) workflow, matching the workflow used by customers in disconnected environments.
+| mor_verify_digests           | true                                                               | No       | Post-mirror integrity check: verify that the mirrored release image digest matches the expected pre-mirror digest.
 
 ## D2M Workflow Validation
 
 The default mirroring path streams images directly from the upstream registry to
-the local registry in a single `oc-mirror` invocation. This can be subject to
-TOCTOU (Time-of-Check-Time-of-Use) race conditions where the upstream release
-image digest changes between mirror resolution and push (see [ECOENGCL-475] and
-[PR #1390]).
+the local registry in a single `oc-mirror` invocation.
 
-When `mor_d2m_workflow` is enabled, the role uses a two-step path:
+When `mor_d2m_workflow` is enabled, the role uses an alternative two-step path
+that matches the workflow used by customers in disconnected environments:
 
 1. **M2D (Mirror-to-Disk):** `oc-mirror` archives the upstream images to a local
    disk directory.
@@ -49,8 +47,8 @@ When `mor_d2m_workflow` is enabled, the role uses a two-step path:
 After mirroring (regardless of which workflow is used), if `mor_verify_digests`
 is `true` (default), the role inspects the mirrored release image in the local
 registry and asserts that its digest matches the pre-mirror digest captured from
-the upstream source. A mismatch causes a clear failure referencing the TOCTOU
-issue.
+the upstream source. A mismatch causes a clear failure indicating a post-mirror
+integrity problem.
 
 ### Usage example
 
@@ -67,9 +65,6 @@ issue.
     mor_d2m_workflow: true
     mor_verify_digests: true
 ```
-
-[ECOENGCL-475]: https://issues.redhat.com/browse/ECOENGCL-475
-[PR #1390]: https://github.com/redhatci/ocp/pull/1390
 
 ## Requirements
 

--- a/roles/mirror_ocp_release/README.md
+++ b/roles/mirror_ocp_release/README.md
@@ -28,6 +28,48 @@ If enabled, the role requires a container registry to mirror the OCP container i
 | mor_allow_insecure_registry  | true                                                               | No       | Allow interacting with registries that are using an unknown CA certificate.
 | mor_extra_flags              | ""                                                                 | No       | Extra flags to pass to the `oc adm release mirror` command when mirroring release images.
 | mor_build                    | ga                                                                 | No       | The build type of the OCP release. Supported values: ga, candidate, dev, nightly.
+| mor_d2m_workflow             | false                                                              | No       | Enable two-step Disk-to-Mirror (D2M) workflow. Avoids TOCTOU race conditions during mirroring.
+| mor_verify_digests           | true                                                               | No       | Verify that the mirrored release image digest matches the pre-mirror digest. Detects TOCTOU drift.
+
+## D2M Workflow Validation
+
+The default mirroring path streams images directly from the upstream registry to
+the local registry in a single `oc-mirror` invocation. This can be subject to
+TOCTOU (Time-of-Check-Time-of-Use) race conditions where the upstream release
+image digest changes between mirror resolution and push (see [ECOENGCL-475] and
+[PR #1390]).
+
+When `mor_d2m_workflow` is enabled, the role uses a two-step path:
+
+1. **M2D (Mirror-to-Disk):** `oc-mirror` archives the upstream images to a local
+   disk directory.
+2. **D2M (Disk-to-Mirror):** `oc-mirror` pushes the on-disk archive to the
+   target registry.
+
+After mirroring (regardless of which workflow is used), if `mor_verify_digests`
+is `true` (default), the role inspects the mirrored release image in the local
+registry and asserts that its digest matches the pre-mirror digest captured from
+the upstream source. A mismatch causes a clear failure referencing the TOCTOU
+issue.
+
+### Usage example
+
+```yaml
+- name: Mirror release with D2M workflow
+  ansible.builtin.include_role:
+    name: redhatci.ocp.mirror_ocp_release
+  vars:
+    mor_version: "4.17.5"
+    mor_pull_url: "quay.io/openshift-release-dev/ocp-release@sha256:abc123..."
+    mor_auths_file: "/var/pull_secret"
+    mor_webserver_url: "https://mywebserver"
+    mor_registry_url: "my-registry:5000"
+    mor_d2m_workflow: true
+    mor_verify_digests: true
+```
+
+[ECOENGCL-475]: https://issues.redhat.com/browse/ECOENGCL-475
+[PR #1390]: https://github.com/redhatci/ocp/pull/1390
 
 ## Requirements
 

--- a/roles/mirror_ocp_release/defaults/main.yml
+++ b/roles/mirror_ocp_release/defaults/main.yml
@@ -20,6 +20,8 @@ mor_registry_path: "ocp-{{ mor_base_version }}/{{ mor_version }}"
 mor_build: "ga"
 mor_allow_insecure_registry: true
 mor_extra_flags: ""
+mor_d2m_workflow: false
+mor_verify_digests: true
 # Required images according install type
 mor_upi: []
 mor_ipi:

--- a/roles/mirror_ocp_release/meta/argument_specs.yml
+++ b/roles/mirror_ocp_release/meta/argument_specs.yml
@@ -229,9 +229,8 @@ argument_specs:
         description: >
           Enable the two-step Disk-to-Mirror (D2M) workflow. When true,
           oc-mirror first archives images to a local disk (M2D) then
-          pushes the archive to the target registry (D2M). This avoids
-          TOCTOU race conditions where upstream digests change between
-          mirror resolution and push.
+          pushes the archive to the target registry (D2M), matching
+          the workflow used by customers in disconnected environments.
       mor_verify_digests:
         type: bool
         required: false
@@ -239,5 +238,5 @@ argument_specs:
         description: >
           After mirroring, verify that the release image digest in the
           local registry matches the pre-mirror digest captured from
-          the upstream source. Detects TOCTOU digest drift.
-          See ECOENGCL-475 and PR #1390 for background.
+          the upstream source. Ensures the mirrored release image
+          digest matches the expected pre-mirror digest.

--- a/roles/mirror_ocp_release/meta/argument_specs.yml
+++ b/roles/mirror_ocp_release/meta/argument_specs.yml
@@ -222,3 +222,22 @@ argument_specs:
         default:
           - azurestack
         description: List of images required for Azure installation type.
+      mor_d2m_workflow:
+        type: bool
+        required: false
+        default: false
+        description: >
+          Enable the two-step Disk-to-Mirror (D2M) workflow. When true,
+          oc-mirror first archives images to a local disk (M2D) then
+          pushes the archive to the target registry (D2M). This avoids
+          TOCTOU race conditions where upstream digests change between
+          mirror resolution and push.
+      mor_verify_digests:
+        type: bool
+        required: false
+        default: true
+        description: >
+          After mirroring, verify that the release image digest in the
+          local registry matches the pre-mirror digest captured from
+          the upstream source. Detects TOCTOU digest drift.
+          See ECOENGCL-475 and PR #1390 for background.

--- a/roles/mirror_ocp_release/tasks/oc-mirror.yml
+++ b/roles/mirror_ocp_release/tasks/oc-mirror.yml
@@ -112,8 +112,8 @@
       when: not mor_d2m_workflow | bool
 
     # D2M two-step workflow: Mirror-to-Disk then Disk-to-Mirror
-    # This path avoids TOCTOU race conditions where upstream image
-    # digests can change between mirror resolution and push.
+    # This path mirrors to disk first, then pushes to the local registry,
+    # matching the workflow used by customers in disconnected environments.
     - name: "D2M step 1 - Mirror to disk archive (M2D)"
       ansible.builtin.shell:
         cmd: >

--- a/roles/mirror_ocp_release/tasks/oc-mirror.yml
+++ b/roles/mirror_ocp_release/tasks/oc-mirror.yml
@@ -90,7 +90,7 @@
       register: _mor_ephemeral_port
 
     # Only GA and Candidate builds include signed images
-    - name: Mirror the release to the local registry
+    - name: Mirror the release directly to the local registry
       ansible.builtin.shell:
         cmd: >
           umask 0022 && env -u REGISTRY_AUTH_FILE
@@ -109,6 +109,50 @@
       delay: 10
       until: _mor_cmd_output.rc == 0
       changed_when: _mor_cmd_output.rc == 0
+      when: not mor_d2m_workflow | bool
+
+    # D2M two-step workflow: Mirror-to-Disk then Disk-to-Mirror
+    # This path avoids TOCTOU race conditions where upstream image
+    # digests can change between mirror resolution and push.
+    - name: "D2M step 1 - Mirror to disk archive (M2D)"
+      ansible.builtin.shell:
+        cmd: >
+          umask 0022 && env -u REGISTRY_AUTH_FILE
+          {{ _mor_tmp_dir.path }}/oc-mirror --v2 --config={{ _mor_tmp_dir.path }}/ocp-release.yaml
+          --authfile {{ mor_auths_file }}
+          --workspace file://{{ _mor_tmp_dir.path }}
+          file://{{ _mor_tmp_dir.path }}/archive
+          --port {{ _mor_ephemeral_port.port }}
+          {% if mor_allow_insecure_registry | bool %}
+          --src-tls-verify=false
+          {% endif %}
+          --ignore-release-signature
+      register: _mor_m2d_output
+      retries: 3
+      delay: 10
+      until: _mor_m2d_output.rc == 0
+      changed_when: _mor_m2d_output.rc == 0
+      when: mor_d2m_workflow | bool
+
+    - name: "D2M step 2 - Push disk archive to local registry (D2M)"
+      ansible.builtin.shell:
+        cmd: >
+          umask 0022 && env -u REGISTRY_AUTH_FILE
+          {{ _mor_tmp_dir.path }}/oc-mirror --v2
+          --authfile {{ mor_auths_file }}
+          --workspace file://{{ _mor_tmp_dir.path }}
+          --from file://{{ _mor_tmp_dir.path }}/archive
+          docker://{{ mor_registry_url }}/{{ mor_registry_path }}
+          --port {{ _mor_ephemeral_port.port }}
+          {% if mor_allow_insecure_registry | bool %}
+          --dest-tls-verify=false
+          {% endif %}
+      register: _mor_d2m_output
+      retries: 3
+      delay: 10
+      until: _mor_d2m_output.rc == 0
+      changed_when: _mor_d2m_output.rc == 0
+      when: mor_d2m_workflow | bool
 
     - name: Write Image Source manifest
       ansible.builtin.copy:
@@ -120,6 +164,10 @@
         mode: "0644"
         setype: httpd_sys_content_t
       become: true
+
+    - name: Verify mirrored image digests
+      ansible.builtin.include_tasks: verify-digests.yml
+      when: mor_verify_digests | bool
 
   always:
     - name: Clean up temporary directory

--- a/roles/mirror_ocp_release/tasks/verify-digests.yml
+++ b/roles/mirror_ocp_release/tasks/verify-digests.yml
@@ -1,0 +1,34 @@
+---
+# Post-mirror digest verification
+# Detects TOCTOU digest drift where the upstream image changes between
+# mirror resolution and push, causing a digest mismatch in the local
+# registry.  See ECOENGCL-475 and PR #1390 for background.
+
+- name: Inspect mirrored release image digest from local registry
+  ansible.builtin.command: >
+    skopeo inspect
+    --no-tags
+    --authfile {{ mor_auths_file }}
+    {%- if mor_allow_insecure_registry | bool %}
+    --tls-verify=false
+    {%- endif %}
+    --format '{{ "{{" }} .Digest {{ "}}" }}'
+    docker://{{ mor_registry_url }}/{{ mor_registry_path }}/openshift/release-images@{{ mor_release_image_digest }}
+  register: _mor_post_mirror_digest
+  changed_when: false
+
+- name: Verify mirrored digest matches pre-mirror digest
+  ansible.builtin.assert:
+    that:
+      - _mor_post_mirror_digest.stdout | trim == mor_release_image_digest
+    fail_msg: >-
+      TOCTOU digest drift detected!
+      The pre-mirror digest ({{ mor_release_image_digest }}) does not match
+      the post-mirror digest ({{ _mor_post_mirror_digest.stdout | trim }})
+      in the local registry.  This indicates the upstream release image
+      changed between mirror resolution and push.
+      See ECOENGCL-475 and PR #1390 for details.
+    success_msg: >-
+      Post-mirror digest verification passed:
+      {{ mor_release_image_digest }}
+...

--- a/roles/mirror_ocp_release/tasks/verify-digests.yml
+++ b/roles/mirror_ocp_release/tasks/verify-digests.yml
@@ -1,8 +1,7 @@
 ---
-# Post-mirror digest verification
-# Detects TOCTOU digest drift where the upstream image changes between
-# mirror resolution and push, causing a digest mismatch in the local
-# registry.  See ECOENGCL-475 and PR #1390 for background.
+# Post-mirror integrity check
+# Verifies that the mirrored release image digest in the local registry
+# matches the expected pre-mirror digest.
 
 - name: Inspect mirrored release image digest from local registry
   ansible.builtin.command: >
@@ -13,7 +12,7 @@
     --tls-verify=false
     {%- endif %}
     --format '{{ "{{" }} .Digest {{ "}}" }}'
-    docker://{{ mor_registry_url }}/{{ mor_registry_path }}/openshift/release-images@{{ mor_release_image_digest }}
+    docker://{{ mor_registry_url }}/{{ mor_registry_path }}/openshift/release-images:{{ mor_version }}
   register: _mor_post_mirror_digest
   changed_when: false
 
@@ -22,12 +21,10 @@
     that:
       - _mor_post_mirror_digest.stdout | trim == mor_release_image_digest
     fail_msg: >-
-      TOCTOU digest drift detected!
+      Post-mirror digest mismatch detected!
       The pre-mirror digest ({{ mor_release_image_digest }}) does not match
       the post-mirror digest ({{ _mor_post_mirror_digest.stdout | trim }})
-      in the local registry.  This indicates the upstream release image
-      changed between mirror resolution and push.
-      See ECOENGCL-475 and PR #1390 for details.
+      in the local registry.
     success_msg: >-
       Post-mirror digest verification passed:
       {{ mor_release_image_digest }}


### PR DESCRIPTION
## Summary

- Added `mor_d2m_workflow` variable (default: `false`) to enable the two-step M2D→D2M oc-mirror v2 workflow, matching the disconnected environment workflow used by customers
- Added `mor_verify_digests` variable (default: `true`) for post-mirror integrity check: verifies the mirrored release image digest matches the expected pre-mirror digest
- Documented new variables in argument specs and README with usage examples
- Fixed skopeo inspect to use tag-based reference for meaningful digest comparison (was using digest-pinned reference which was tautological)
- Removed incorrect TOCTOU race condition framing (OCP release image digests are immutable); reframed D2M as disconnected customer workflow and digest check as post-mirror integrity verification
- Removed misapplied ECOENGCL-475 and PR #1390 references (those cover operator/connectivity issues, not release digest drift)

## Changes

- `roles/mirror_ocp_release/defaults/main.yml`: Added `mor_d2m_workflow` and `mor_verify_digests` variables with safe defaults
- `roles/mirror_ocp_release/tasks/oc-mirror.yml`: Refactored to conditionally use the M2D→D2M two-step workflow when `mor_d2m_workflow=true`; replaced TOCTOU comment with disconnected workflow framing
- `roles/mirror_ocp_release/tasks/verify-digests.yml`: Post-mirror integrity check using skopeo inspect with tag-based reference (`:version`) to correctly detect digest mismatches
- `roles/mirror_ocp_release/meta/argument_specs.yml`: Added argument specs for the two new variables; removed TOCTOU/ECOENGCL-475 references from descriptions
- `roles/mirror_ocp_release/README.md`: Added full documentation and usage example for the D2M workflow; removed TOCTOU claims and ECOENGCL-475/PR#1390 references

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)