### PR TITLE
delete each stuck resource after removing finalizers

### DIFF
--- a/roles/cleanup_namespace/README.md
+++ b/roles/cleanup_namespace/README.md
@@ -22,6 +22,7 @@ This role dynamically discovers all namespaced API resource types and scans for 
 | cn_dry_run | No | `false` | When `true`, only report stuck resources without removing finalizers |
 | cn_skip_api_resources | No | `[]` | List of API resources to skip (format: `resource.group`, e.g. `events.events.k8s.io`) |
 | cn_remove_all_finalizers | No | `true` | When `true`, remove finalizers from any resource in the namespace that still has them. When `false`, only resources already terminating or in a terminating namespace are cleaned |
+| cn_delete_resources | No | `true` | When `true`, delete each stuck resource after removing its finalizers |
 
 ## Output
 

--- a/roles/cleanup_namespace/defaults/main.yml
+++ b/roles/cleanup_namespace/defaults/main.yml
@@ -4,4 +4,5 @@ cn_skip_api_resources:
   - templates.template.openshift.io
   - processedtemplates.template.openshift.io
 cn_remove_all_finalizers: true
+cn_delete_resources: true
 ...

--- a/roles/cleanup_namespace/tasks/main.yml
+++ b/roles/cleanup_namespace/tasks/main.yml
@@ -28,7 +28,8 @@
   ansible.builtin.debug:
     msg: >-
       Would remove finalizers from {{ item.resource_type }}/{{ item.name }}
-      ({{ item.api_version }})
+      ({{ item.api_version }}){% if cn_delete_resources | bool %}
+      and delete the resource{% endif %}
   loop: "{{ _cn_stuck.resources }}"
   when:
     - cn_dry_run | bool
@@ -55,6 +56,28 @@
     - _cn_patch_result is failed
     - "'NotFound' not in (_cn_patch_result.msg | default(''))"
 
+- name: Delete stuck resources
+  kubernetes.core.k8s:
+    api_version: "{{ item.api_version }}"
+    kind: "{{ item.kind }}"
+    name: "{{ item.name }}"
+    namespace: "{{ item.namespace }}"
+    state: absent
+    delete_options:
+      gracePeriodSeconds: 0
+      propagationPolicy: Background
+  loop: "{{ _cn_stuck.resources }}"
+  loop_control:
+    label: "{{ item.kind }}/{{ item.name }}"
+  when:
+    - not (cn_dry_run | bool)
+    - cn_delete_resources | bool
+    - _cn_stuck.resources | length > 0
+  register: _cn_delete_result
+  failed_when:
+    - _cn_delete_result is failed
+    - "'NotFound' not in (_cn_delete_result.msg | default(''))"
+
 - name: Summary
   ansible.builtin.debug:
     msg: >-
@@ -65,4 +88,3 @@
       {{ _cn_stuck.resources | length }} stuck resource(s) cleaned up
       in namespace {{ cn_namespace }}.
       {% endif %}
-...


### PR DESCRIPTION
##### SUMMARY

This PR is to delete stuck resources after deleting finalizers.
In some cases, eg [here](https://www.distributed-ci.io/jobs/36aef878-0031-46a6-b0ac-ec51bcedcfeb/jobStates?sort=date&task=cc1150a8-4123-4252-8cc3-c6bd19ef0831),  The k8s_json_patch result shows KafkaTopic/kafka-logs-topic still Ready with full spec/status. Stripping finalizers does not delete the object.During termination the topic operator commonly puts finalizers back on KafkaTopic while it tries to delete the topic in Kafka. If the cluster is already gone or unreachable, that blocks namespace removal for the full 300s wait

##### ISSUE TYPE

Enhanced Feature

Test-Hint: no-check