### PR TITLE
Allow templates rendering for OCP 5x

### DIFF
--- a/roles/installer/templates/etc-chrony.conf.j2
+++ b/roles/installer/templates/etc-chrony.conf.j2
@@ -30,7 +30,7 @@ spec:
         group:
           name: root
         mode: 420
-{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int > 5)) %}
+{% if (release_version.split('.')[0]|int >= 5) or ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int > 5)) %}
         overwrite: true
 {% endif %}
         path: /etc/chrony.conf

--- a/roles/installer/templates/install-config-virtualmedia.j2
+++ b/roles/installer/templates/install-config-virtualmedia.j2
@@ -138,7 +138,7 @@ platform:
           {{ hostvars[host]['root_device_hint'] }}: '{{ hostvars[host]['root_device_hint_value'] }}'
 {% endif %}
 {% endif %}
-{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) or (release_version.split('.')[0]|int >= 5)) %}
 {% if master_network_config_template is defined %}
         networkConfig:
 {{ lookup('template', master_network_config_template, template_vars=hostvars[host]) | indent(10, true) }}
@@ -185,7 +185,7 @@ platform:
           {{ hostvars[host]['root_device_hint'] }}: '{{ hostvars[host]['root_device_hint_value'] }}'
 {% endif %}
 {% endif %}
-{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) or (release_version.split('.')[0]|int >= 5)) %}
 {% if worker_network_config_template is defined %}
         networkConfig:
 {{ lookup('template', worker_network_config_template, template_vars=hostvars[host]) | indent(10, true) }}

--- a/roles/installer/templates/install-config.j2
+++ b/roles/installer/templates/install-config.j2
@@ -130,7 +130,7 @@ platform:
           {{ hostvars[host]['root_device_hint'] }}: '{{ hostvars[host]['root_device_hint_value'] }}'
 {% endif %}
 {% endif %}
-{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) or (release_version.split('.')[0]|int >= 5)) %}
 {% if master_network_config_template is defined %}
         networkConfig:
 {{ lookup('template', master_network_config_template, template_vars=hostvars[host]) | indent(10, true) }}
@@ -176,7 +176,7 @@ platform:
           {{ hostvars[host]['root_device_hint'] }}: '{{ hostvars[host]['root_device_hint_value'] }}'
 {% endif %}
 {% endif %}
-{% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 10)) or (release_version.split('.')[0]|int >= 5)) %}
 {% if worker_network_config_template is defined %}
         networkConfig:
 {{ lookup('template', worker_network_config_template, template_vars=hostvars[host]) | indent(10, true) }}


### PR DESCRIPTION
##### SUMMARY

Allow the templates rendering on ocp-5x

- [x] TestVcp: ocp-5.0-vanilla - https://www.distributed-ci.io/jobs/5f9561b9-b946-4b80-88e9-ef10084e674a/jobStates

Test-hints: no-check