### PR TITLE
Replace hardcoded worker node names with variables in multibench_run

### DIFF
--- a/roles/multibench_run/README.md
+++ b/roles/multibench_run/README.md
@@ -15,11 +15,56 @@ It uses a pre-existing VM/host where all the crucible binaries are ready.
 | multibench_script         | run.sh	                                                 | string    | false    | Name of the script to be executed for launching the crucible cmd. Located in the `multibench_script_dir` |
 | multibench_script_dir     | /root/crucible-examples/multibench/openshift/example-A	 | string    | false    | Path of the multibench script on the multi-bench host                                                    |
 | multibench_tags           | automation:ansible                                      | key:value | false    | Tag to be added to the multi-bench Run in the Opensearch DB                                              |
+| multibench_target_nodes | client: [worker-0, worker-1, worker-2], server: [worker-0, worker-1, worker-2 | dict with lists | false | Dictionary defining target worker nodes for client and server roles. Must contain at least 3 nodes for each role when running default workload, or at least 1 node when multibench_uperf_num is defined |
 | multibench_crucible_metric_collect   | true                        | bool    | false    | When true, extract primary period-id from result-summary, run `crucible get metric`, and optionally upload to DCI                         |
 | multibench_crucible_metric_source   | mpstat                     | string  | false    | Crucible metric source (e.g. mpstat)                                                                     |
 | multibench_crucible_metric_type    | Busy-CPU                   | string  | false    | Crucible metric type                                                                                     |
 | multibench_crucible_metric_breakout| hostname=worker-3,num      | string  | false    | Crucible metric breakout filter                                                                          |
 | multibench_crucible_metric_filename| crucible-metric-mpstat-busy-cpu.txt | string | false | Name of the file where metric output is saved and uploaded to DCI                                       |
+
+## Configuring Target Worker Nodes
+The role uses the `multibench_target_nodes` variable to specify which worker nodes should run the client and server workloads. This is particularly important when working with OpenShift clusters that use FQDN node names.
+
+### Default Configuration
+By default, the role targets workers using short hostnames:
+```yaml
+multibench_target_nodes:
+  client:
+    - worker-0
+    - worker-1
+    - worker-2
+  server:
+    - worker-0
+    - worker-1
+    - worker-2
+```
+
+### Using FQDN Node Names
+For clusters where worker nodes have FQDN names (e.g., `worker-0.ocp.example.com`), override the variable in your playbook:
+
+```yaml
+- name: "Include role multi-bench"
+  include_role:
+    name: redhatci.ocp.multibench_run
+  vars:
+    ocp_host: "{{ groups['provisioner'] | first }}"
+    multibench_host: "{{ groups['multibench'] | first }}"
+    multibench_target_nodes:
+      client:
+        - worker-0.ocp.example.com
+        - worker-1.ocp.example.com
+        - worker-2.ocp.example.com
+      server:
+        - worker-0.ocp.example.com
+        - worker-1.ocp.example.com
+        - worker-2.ocp.example.com
+```
+
+### Node Requirements
+- **Default workload** (`kube-all-in-one.json.j2`): Requires at least 3 nodes in both client and server lists
+- **Uperf workload** (`kube-all-in-one-uperf.json.j2`): Requires at least 1 node in both client and server lists (when `multibench_uperf_num` is defined and > 0)
+
+The role will validate these requirements and fail early if insufficient nodes are provided.
 
 ## Presentation of the workload
 By default, the workload launched by default is the example-A of Multi-bench, composed of 2 uperf scenarios and 1 iperf.

--- a/roles/multibench_run/defaults/main.yml
+++ b/roles/multibench_run/defaults/main.yml
@@ -6,6 +6,16 @@ multibench_script_dir: "/root/crucible-examples/multibench/openshift/example-A/d
 multibench_uperf_config_base: "/root/crucible-examples/multibench/openshift/example-A/daily/uperf_config"
 multibench_script: "run.sh"
 multibench_uperf_controller_ip: "{{ multibench_controller_ip | default('192.168.5.30') }}"
+# Target worker nodes for client and server roles
+multibench_target_nodes:
+  client:
+    - worker-0
+    - worker-1
+    - worker-2
+  server:
+    - worker-0
+    - worker-1
+    - worker-2
 # Crucible metric collection (used after run when result-summary is available)
 multibench_crucible_metric_source: "mpstat"
 multibench_crucible_metric_type: "Busy-CPU"

--- a/roles/multibench_run/tasks/main.yml
+++ b/roles/multibench_run/tasks/main.yml
@@ -12,6 +12,37 @@
     msg: "Host does not have crucible installed. Please run playbooks/multibench_setup_host.yml before using this role."
   when: _multibench_run_binaries.rc != 0
 
+- name: Validate multibench_uperf_num is a sane value if defined
+  ansible.builtin.assert:
+    that:
+      - multibench_uperf_num | int > 0
+    fail_msg: "multibench_uperf_num must be a positive integer when defined"
+  when: multibench_uperf_num is defined
+
+- name: Validate multibench_target_nodes for uperf workload
+  ansible.builtin.assert:
+    that:
+      - multibench_target_nodes is defined
+      - multibench_target_nodes.client is defined
+      - multibench_target_nodes.client | length >= 1
+      - multibench_target_nodes.server is defined
+      - multibench_target_nodes.server | length >= 1
+    fail_msg: "multibench_target_nodes.client and multibench_target_nodes.server must be defined with at least 1 node each when multibench_uperf_num is defined and > 0"
+    success_msg: "multibench_target_nodes validated for uperf workload"
+  when: multibench_uperf_num is defined and multibench_uperf_num | int > 0
+
+- name: Validate multibench_target_nodes for default workload
+  ansible.builtin.assert:
+    that:
+      - multibench_target_nodes is defined
+      - multibench_target_nodes.client is defined
+      - multibench_target_nodes.client | length >= 3
+      - multibench_target_nodes.server is defined
+      - multibench_target_nodes.server | length >= 3
+    fail_msg: "multibench_target_nodes.client and multibench_target_nodes.server must be defined with at least 3 nodes each when running default workload"
+    success_msg: "multibench_target_nodes validated for default workload"
+  when: multibench_uperf_num is not defined
+
 - name: Generate config file for multibench
   ansible.builtin.template:
     src: templates/config.ini.j2

--- a/roles/multibench_run/templates/kube-all-in-one-uperf.json.j2
+++ b/roles/multibench_run/templates/kube-all-in-one-uperf.json.j2
@@ -49,7 +49,7 @@
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",
             "nodeSelector": {
-              "kubernetes.io/hostname": "worker-1"
+              "kubernetes.io/hostname": "{{ multibench_target_nodes.client[0] }}"
             },
             "resources": {
               "requests": { "cpu": "6", "memory": "1024Mi" },
@@ -70,7 +70,7 @@
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",
             "nodeSelector": {
-              "kubernetes.io/hostname": "worker-3"
+              "kubernetes.io/hostname": "{{ multibench_target_nodes.server[0] }}"
             },
             "resources": {
               "requests": { "cpu": "2", "memory": "1024Mi" },

--- a/roles/multibench_run/templates/kube-all-in-one.json.j2
+++ b/roles/multibench_run/templates/kube-all-in-one.json.j2
@@ -194,7 +194,7 @@
           }
         },
         {
-          "targets": [{ "role": "server", "ids": "23-24+29" }],
+          "targets": [{ "role": "server", "ids": "23-24+29+30" }],
           "settings": {
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",

--- a/roles/multibench_run/templates/kube-all-in-one.json.j2
+++ b/roles/multibench_run/templates/kube-all-in-one.json.j2
@@ -159,7 +159,7 @@
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",
             "nodeSelector": {
-              "kubernetes.io/hostname": "worker-0"
+              "kubernetes.io/hostname": "{{ multibench_target_nodes.client[0] }}"
             }
           }
         },
@@ -169,7 +169,7 @@
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",
             "nodeSelector": {
-              "kubernetes.io/hostname": "worker-1"
+              "kubernetes.io/hostname": "{{ multibench_target_nodes.client[1] }}"
             }
           }
         },
@@ -179,7 +179,7 @@
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",
             "nodeSelector": {
-              "kubernetes.io/hostname": "worker-2"
+              "kubernetes.io/hostname": "{{ multibench_target_nodes.client[2] }}"
             }
           }
         },
@@ -189,8 +189,8 @@
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",
             "nodeSelector": {
-              "kubernetes.io/hostname": "worker-0"
-            }    
+              "kubernetes.io/hostname": "{{ multibench_target_nodes.server[0] }}"
+            }
           }
         },
         {
@@ -199,7 +199,7 @@
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",
             "nodeSelector": {
-              "kubernetes.io/hostname": "worker-1"
+              "kubernetes.io/hostname": "{{ multibench_target_nodes.server[1] }}"
             }
           }
         },
@@ -209,7 +209,7 @@
             "userenv": "stream9",
             "runtimeClassName": "performance-blueprint-profile",
             "nodeSelector": {
-              "kubernetes.io/hostname": "worker-2"
+              "kubernetes.io/hostname": "{{ multibench_target_nodes.server[2] }}"
             }
           }
         },


### PR DESCRIPTION
##### SUMMARY

Added multibench_target_nodes variable to support FQDN node names. Templates now use configurable node lists instead of hardcoded worker-0/1/2/3. Includes validation tasks and updated documentation with usage examples.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMDNUMTg6NDc6MDF8M2E5NDAyMWFlNjcyMTNlYTc3MGRjMTQyNGYyODE1NTYzODJkNjg0OQ==
Gitleaks-Hash: 0438faff2defdd25bdbcd5f08cb8712557ad1a37a2804d643b0fe54e94a1014b

##### ISSUE TYPE

Fix

##### Tests

- [x] multibench - https://www.distributed-ci.io/jobs/40bc2e29-ba22-4375-b57f-9505334155dd/jobStates?sort=date
- [x] multibench-uperf - https://www.distributed-ci.io/jobs/9b457b8c-e435-40b1-88e2-5a4603499acb/jobStates?sort=date
---

build-depends: https://github.com/dci-labs/vcp-config/pull/1663

Test-hints: no-check