### PR TITLE
Added retries to IPMI operations for PXE bootstrapping

### DIFF
--- a/roles/vendors/pxe/defaults/main.yml
+++ b/roles/vendors/pxe/defaults/main.yml
@@ -4,3 +4,5 @@ bmc_address: "{{ hostvars[target_host]['bmc_address'] }}"
 bmc_user: "{{ hostvars[target_host]['bmc_user'] }}"
 bmc_password: "{{ hostvars[target_host]['bmc_password'] }}"
 bmc_port: "{{ hostvars[target_host]['bmc_port'] | default(623) }}"
+pxe_ipmi_retries: 10
+pxe_ipmi_delay: 5

--- a/roles/vendors/pxe/tasks/iso.yml
+++ b/roles/vendors/pxe/tasks/iso.yml
@@ -6,6 +6,10 @@
     password: "{{ bmc_password }}"
     port: "{{ bmc_port }}"
     state: "off"
+  register: pxe_power_off
+  retries: "{{ pxe_ipmi_retries }}"
+  delay: "{{ pxe_ipmi_delay }}"
+  until: pxe_power_off is succeeded and pxe_power_off.powerstate == 'off'
 
 - name: Set server to boot from network
   community.general.ipmi_boot:
@@ -16,6 +20,10 @@
     bootdev: network
     persistent: false
     uefiboot: true
+  register: pxe_ipmi_boot
+  retries: "{{ pxe_ipmi_retries }}"
+  delay: "{{ pxe_ipmi_delay }}"
+  until: pxe_ipmi_boot is succeeded
 
 - name: PXE server Power on
   community.general.ipmi_power:
@@ -24,3 +32,7 @@
     password: "{{ bmc_password }}"
     port: "{{ bmc_port }}"
     state: boot
+  register: pxe_power_on
+  retries: "{{ pxe_ipmi_retries }}"
+  delay: "{{ pxe_ipmi_delay }}"
+  until: pxe_power_on is succeeded and pxe_power_on.powerstate == 'on'


### PR DESCRIPTION
##### SUMMARY

The PXE type vendors rely on IPMI set up the network bootstrapping of the servers.

For some HW, the boot up operation may tend to fail, thus the need to enable retries for these operations.

##### ISSUE TYPE

- Enhanced Feature

##### Tests
---
Test-Hint: no-check
