### PR TITLE
fix: configure HTTP port for PXE download URLs in mount_discovery_iso_for_pxe role

### DIFF
--- a/roles/mount_discovery_iso_for_pxe/defaults/main.yml
+++ b/roles/mount_discovery_iso_for_pxe/defaults/main.yml
@@ -39,4 +39,12 @@ URL_ASSISTED_INSTALLER_CLUSTERS_DOWNLOAD_IMAGE: "{{ ASSISTED_INSTALLER_BASE_URL 
 DOWNLOAD_DEST_FILE: "{{ discovery_iso_name }}"
 DOWNLOAD_DEST_PATH: "{{ iso_download_dest_path | default('/opt/http_store/data') }}"
 HTTPD_PXE_HOST: "{{ hostvars['http_store']['ansible_host'] }}"
+# NOTE: The hostvars key 'http_store' below is intentional and correct — it matches
+# the same inventory host used for HTTPD_PXE_HOST above. Any other key (e.g.
+# 'httpd_pxe_host') would silently resolve to an empty string and produce broken URLs.
+#
+# WARNING: This role (mount_discovery_iso_for_pxe) is not covered by public CI.
+# It requires physical PXE/bare-metal hardware available only in private partner labs.
+# Changes to this role or its templates must be validated in a PXE lab environment
+# before merging.
 HTTPD_PORT_FOR_PXE: "{{ hostvars['http_store']['httpd_port_for_pxe'] | default(80) }}"

--- a/roles/mount_discovery_iso_for_pxe/defaults/main.yml
+++ b/roles/mount_discovery_iso_for_pxe/defaults/main.yml
@@ -13,7 +13,7 @@ mounted_iso_files:
   - "{{ mount_efiboot_directory }}/EFI/BOOT/grubx64.efi"
   - "{{ mount_efiboot_directory }}/EFI/BOOT/BOOTX64.EFI"
 
-mounted_tftp_files: "http://{{ HTTPD_PXE_HOST }}/{{ pxe_directory }}"
+mounted_tftp_files: "http://{{ HTTPD_PXE_HOST }}:{{ HTTPD_PORT_FOR_PXE }}/{{ pxe_directory }}"
 tftp_files_to_download:
   - "{{ mounted_tftp_files }}/ignition.img"
   - "{{ mounted_tftp_files }}/efiboot.img"
@@ -39,4 +39,4 @@ URL_ASSISTED_INSTALLER_CLUSTERS_DOWNLOAD_IMAGE: "{{ ASSISTED_INSTALLER_BASE_URL 
 DOWNLOAD_DEST_FILE: "{{ discovery_iso_name }}"
 DOWNLOAD_DEST_PATH: "{{ iso_download_dest_path | default('/opt/http_store/data') }}"
 HTTPD_PXE_HOST: "{{ hostvars['http_store']['ansible_host'] }}"
-HTTPD_PORT_FOR_PXE: "{{ hostvars['httpd_pxe_host']['httpd_port_for_pxe'] }}"
+HTTPD_PORT_FOR_PXE: "{{ hostvars['http_store']['httpd_port_for_pxe'] | default(80) }}"

--- a/roles/mount_discovery_iso_for_pxe/templates/grub.cfg.j2
+++ b/roles/mount_discovery_iso_for_pxe/templates/grub.cfg.j2
@@ -1,5 +1,6 @@
 set timeout=1
 menuentry 'Install Red Hat Enterprise Linux CoreOS' --class fedora --class gnu-linux --class gnu --class os {
+	# HTTPD_PORT_FOR_PXE is required here for non-default HTTP port environments (default: 80).
 	linuxefi vmlinuz random.trust_cpu=on ignition.firstboot ignition.platform.id=metal 'coreos.live.rootfs_url=http://{{ HTTPD_PXE_HOST }}:{{ HTTPD_PORT_FOR_PXE }}/{{ pxe_directory }}/rootfs.img' 
 	initrdefi initrd.img ignition.img
 }

--- a/roles/mount_discovery_iso_for_pxe/templates/grub.cfg.j2
+++ b/roles/mount_discovery_iso_for_pxe/templates/grub.cfg.j2
@@ -1,5 +1,5 @@
 set timeout=1
 menuentry 'Install Red Hat Enterprise Linux CoreOS' --class fedora --class gnu-linux --class gnu --class os {
-	linuxefi vmlinuz random.trust_cpu=on ignition.firstboot ignition.platform.id=metal 'coreos.live.rootfs_url=http://{{ HTTPD_PXE_HOST }}/{{ pxe_directory }}/rootfs.img' 
+	linuxefi vmlinuz random.trust_cpu=on ignition.firstboot ignition.platform.id=metal 'coreos.live.rootfs_url=http://{{ HTTPD_PXE_HOST }}:{{ HTTPD_PORT_FOR_PXE }}/{{ pxe_directory }}/rootfs.img' 
 	initrdefi initrd.img ignition.img
 }


### PR DESCRIPTION
## Summary
Fixed HTTP port configuration for PXE download URLs in the `mount_discovery_iso_for_pxe` role:
- Fixed `HTTPD_PORT_FOR_PXE` hostvars lookup key from `'httpd_pxe_host'` to `'http_store'` (matching `HTTPD_PXE_HOST`) with `| default(80)` fallback
- Added `:{{"{{ HTTPD_PORT_FOR_PXE }}"}}` to `mounted_tftp_files` base URL, cascading to all TFTP/system download URLs
- Added port to `coreos.live.rootfs_url` in `grub.cfg.j2` template for consistent PXE asset resolution
- Added comment block in `defaults/main.yml` above `HTTPD_PORT_FOR_PXE` documenting that the `http_store` hostvars key is intentional and that this role has no public CI coverage (requires physical PXE/bare-metal hardware in private partner labs)
- Added inline comment in `grub.cfg.j2` near `rootfs_url` noting that `HTTPD_PORT_FOR_PXE` is required for non-default HTTP port environments

This role is not covered by public CI — it requires physical PXE/bare-metal hardware available only in private partner labs. The bug was discovered from real production failures tracked in [CILAB-2650](https://issues.redhat.com/browse/CILAB-2650) and referenced in [#961](https://github.com/redhatci/ansible-collection-redhatci-ocp/issues/961) and [#959](https://github.com/redhatci/ansible-collection-redhatci-ocp/issues/959).

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PXE boot URLs to include the configured HTTP port, supporting environments where PXE content is served on a non-default port.
  * Added a fallback to port 80 when no custom PXE HTTP port is configured.
  * Corrected host configuration lookup for more reliable PXE file and root filesystem retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->