### PR TITLE
Bump certsuite to v5.5.23

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.22
+kbpc_version: v5.5.23
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"
@@ -59,7 +59,7 @@ kbpc_feedback:
   access-control-security-context: ""
   access-control-security-context-non-root-user-check: ""
   access-control-security-context-privilege-escalation: ""
-  access-control-security-context-read-only-file-system: ""
+  access-control-security-context-read-only-root-file-system: ""
   access-control-service-type: ""
   access-control-ssh-daemons: ""
   access-control-sys-admin-capability-check: ""


### PR DESCRIPTION
##### SUMMARY

- Bump certsuite to v5.5.23
- Update name for read-only-root-file-system test

##### ISSUE TYPE

- Bump version

##### Tests

- [x] Passed job: https://www.distributed-ci.io/jobs/df1aaf66-5ada-4a26-ae03-1c9d06e8d7a1/jobStates

Test-Hints: no-check