### PR TITLE
include wait-sno play for MCP updates on SNO nodes

### DIFF
--- a/roles/check_resource/tasks/wait-mcp.yml
+++ b/roles/check_resource/tasks/wait-mcp.yml
@@ -4,6 +4,11 @@
     api_version: machineconfiguration.openshift.io/v1
     kind: MachineConfigPool
   register: _cr_mcp_check
+  until:
+    - _cr_mcp_check.resources is defined
+    - _cr_mcp_check.resources | length > 0
+  retries: "{{ check_wait_retries }}"
+  delay: "{{ check_wait_delay }}"
   no_log: true
 
 - name: "Wait for MCP updates"

--- a/roles/deploy_cr/README.md
+++ b/roles/deploy_cr/README.md
@@ -92,3 +92,5 @@ This Ansible role is used to deploy a Kubernetes Custom Resource (CR) to a speci
         dc_name: "{{ kubelet_config_cr.name }}"
         dc_spec: "{{ kubelet_config_cr.spec }}"
         dc_wait_condition: "{{ kubelet_config_cr.wait_condition }}"
+
+NOTE: The role detects whether the cluster is an SNO and defines the timeout values for the check_mcp tasks and consider a possible node restart.

--- a/roles/deploy_cr/tasks/main.yml
+++ b/roles/deploy_cr/tasks/main.yml
@@ -28,9 +28,22 @@
   until: _deploy_cr_result is not failed
   when: dc_wait_for_cr | bool
 
-- name: Pause to wait for MCP to be updated if any
-  ansible.builtin.pause:
-    seconds: 60
+- name: Get list of all cluster nodes
+  kubernetes.core.k8s_info:
+    kind: Node
+  register: _deploy_cr_nodes
+  until:
+    - _deploy_cr_nodes.resources is defined
+    - _deploy_cr_nodes.resources | length > 0
+  retries: 6
+  delay: 10
+
+- name: Set wait times for SNO reboot
+  ansible.builtin.set_fact:
+    dc_wait_mc_retries: 4
+    dc_wait_mc_delay: 300
+  when:
+    - _deploy_cr_nodes.resources | length == 1
 
 - name: Wait for MCPs changes applied if any
   ansible.builtin.include_role:


### PR DESCRIPTION
Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMTBUMTk6NTQ6MjR8NzQ3OWNkNTU0MTU2NjBhMDYwM2JiMTU5NDgyZTlkOTU0ZDQyMjk2Yg==
Gitleaks-Hash: 648de544d7bc0a4b20a89b0e3b988065dd91dca7d28af45cc9935a40acb25254

##### SUMMARY
Roles such as `deploy_cr` invoke the  `check_resource` role to wait for MCPs to be available after applying a change, but in the case of SNO nodes, the nodes are immediately restated and the MCP checks fail. This PR introduces a play to validate if the cluster is an SNO and wait for API to be available and the node ready before checking the MCP resource.

##### ISSUE TYPE

Enhanced Feature

#### Tests

- [x] TestBos2Sno: sno - https://www.distributed-ci.io/jobs/98c36a07-5e37-457c-b7f4-87ae00d72ed2/jobStates
- [x]  hub: - https://www.distributed-ci.io/jobs/e13748ea-f94d-4498-8865-0bb121f96bf5/jobStates

Test-hints: no-check