### PR TITLE
Add oc-mirror v2 manifest validation tests

### DIFF
--- a/docs/manifest-audit-process.md
+++ b/docs/manifest-audit-process.md
@@ -1,0 +1,167 @@
+# Generated Manifest Audit Process
+
+This document describes the checklist and procedure for auditing oc-mirror v2
+output manifests when a serialization defect or data quality issue is discovered.
+
+---
+
+## Background
+
+The oc-mirror v2 tool produces several Kubernetes manifest types when mirroring
+operator catalogs to a disconnected registry. Each manifest type has required
+fields that must be populated for the manifest to be usable by OpenShift. A
+serialization defect in the tool can produce manifests where normally-populated
+fields are absent, empty, or set to empty collection values (e.g. `status: {}`).
+
+Affected manifest types:
+
+| Kind | File pattern | Critical fields |
+|------|-------------|-----------------|
+| `ImageDigestMirrorSet` (IDMS) | `idms-*.yaml` | `spec.imageDigestMirrors` (non-empty list) |
+| `ImageTagMirrorSet` (ITMS) | `itms-*.yaml` | `spec.imageTagMirrors` (non-empty list) |
+| `CatalogSource` | `cs-*.yaml` | `spec.sourceType`, `spec.image` |
+| `ClusterCatalog` | `cc-*.yaml` | `spec.source` |
+| `UpdateService` | `update-service-*.yaml` | `spec.graphDataImage`, `spec.releases` |
+
+---
+
+## Verification Steps
+
+### Step 1 — Run the validation script
+
+```bash
+./hack/validate_manifests.sh <manifest-output-directory>
+```
+
+The script exits 0 if all manifests pass and prints `OK: all N manifest(s)
+passed validation.` Review any `ERROR:` lines printed to stderr before
+proceeding.
+
+### Step 2 — Verify each manifest type
+
+#### ImageDigestMirrorSet (IDMS)
+
+```bash
+# Check spec.imageDigestMirrors is a non-empty list
+python3 -c "
+import yaml, sys
+doc = yaml.safe_load(open(sys.argv[1]))
+mirrors = doc.get('spec', {}).get('imageDigestMirrors', [])
+print(f'imageDigestMirrors entries: {len(mirrors)}')
+assert len(mirrors) > 0, 'EMPTY — defect detected'
+" idms-oc-mirror.yaml
+```
+
+Checklist:
+- [ ] `apiVersion: config.openshift.io/v1`
+- [ ] `kind: ImageDigestMirrorSet`
+- [ ] `metadata.name` non-empty
+- [ ] `status` field absent or non-empty (not `{}`)
+- [ ] `spec.imageDigestMirrors` is a list with at least one entry
+- [ ] Each entry has both `source` and `mirrors` fields
+
+#### ImageTagMirrorSet (ITMS)
+
+Checklist:
+- [ ] `apiVersion: config.openshift.io/v1`
+- [ ] `kind: ImageTagMirrorSet`
+- [ ] `metadata.name` non-empty
+- [ ] `status` field absent or non-empty (not `{}`)
+- [ ] `spec.imageTagMirrors` is a list with at least one entry
+- [ ] Each entry has both `source` and `mirrors` fields
+
+#### CatalogSource
+
+Checklist:
+- [ ] `apiVersion: operators.coreos.com/v1alpha1`
+- [ ] `kind: CatalogSource`
+- [ ] `metadata.name` and `metadata.namespace` non-empty
+- [ ] `spec.sourceType` non-empty (typically `grpc`)
+- [ ] `spec.image` is a fully qualified image reference
+
+#### ClusterCatalog
+
+Checklist:
+- [ ] `apiVersion: catalogd.operatorframework.io/v1`
+- [ ] `kind: ClusterCatalog`
+- [ ] `metadata.name` non-empty
+- [ ] `spec.source` is defined and contains `type` and `image` sub-fields
+- [ ] `spec.source.image.ref` is a fully qualified image reference
+
+#### UpdateService
+
+Checklist:
+- [ ] `apiVersion: updateservice.operator.openshift.io/v1`
+- [ ] `kind: UpdateService`
+- [ ] `metadata.name` non-empty
+- [ ] `spec.graphDataImage` non-empty
+- [ ] `spec.releases` non-empty
+
+---
+
+## GitOps and ACM Policy Compliance Verification
+
+When manifests are consumed by a GitOps pipeline or ACM policy framework,
+incomplete manifests cause silent reconciliation failures. Before committing
+manifests to the policy repository:
+
+1. Run `./hack/validate_manifests.sh <output-dir>` — exit code must be 0.
+2. Verify that each manifest that would be applied by ACM/ArgoCD matches the
+   expected structure for its target cluster version (e.g. classic OLM clusters
+   use `CatalogSource`; OLM v1 clusters use `ClusterCatalog`).
+3. Apply the manifests to a staging cluster and confirm that the relevant
+   operator controller reports no errors:
+   ```bash
+   oc get idms,itms,catalogsource,clustercatalog -A
+   oc describe idms idms-oc-mirror
+   ```
+4. If any field is empty or missing, do **not** commit the manifests. Proceed to
+   the resolution steps below.
+
+---
+
+## Resolution Steps
+
+When a manifest fails validation:
+
+1. **Identify the scope**: run `./hack/validate_manifests.sh` over all output
+   directories produced by the mirroring run to determine which manifest types
+   are affected.
+
+2. **Re-run mirroring**: if the defect is transient (e.g. caused by a partial
+   push or network interruption), rerun the mirroring role with a clean
+   workspace directory.
+
+3. **Check tool version**: confirm the version of oc-mirror in use and compare
+   against the known good version documented in the release notes.
+
+4. **Quarantine the output**: move the defective manifest directory to a
+   quarantine location and record the tool version, workspace path, and error
+   output for further analysis.
+
+5. **Do not propagate**: ensure the defective manifests are not committed to any
+   GitOps repository or ACM policy source until the issue is resolved and all
+   validation checks pass.
+
+6. **Verify after fix**: after applying a fix or upgrading the tool, re-run the
+   full mirroring pipeline and confirm that `./hack/validate_manifests.sh`
+   exits 0 before proceeding.
+
+---
+
+## Automated Validation in the Role
+
+The `oci_mirror` Ansible role runs `tasks/validate-manifests.yml` automatically
+after every mirroring run when `om_validate_manifests: true` (the default).
+This provides early detection of defective manifests before they are used
+downstream.
+
+To disable automatic validation (not recommended for production):
+
+```yaml
+om_validate_manifests: false
+```
+
+---
+
+*See also: `hack/validate_manifests.sh`, `roles/oci_mirror/tasks/validate-manifests.yml`.*

--- a/hack/validate_manifests.sh
+++ b/hack/validate_manifests.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# validate_manifests.sh — validate oc-mirror v2 output manifests
+#
+# Usage: validate_manifests.sh <directory>
+#
+# Validates all *.yaml files in <directory>:
+#   - apiVersion, kind, and metadata.name must be non-empty strings
+#   - status must not be an empty dict ({})
+#   - Kind-specific spec field checks:
+#       ImageDigestMirrorSet  : spec.imageDigestMirrors non-empty list
+#       ImageTagMirrorSet     : spec.imageTagMirrors non-empty list
+#       CatalogSource         : spec.sourceType and spec.image non-empty strings
+#       ClusterCatalog        : spec.source must be defined
+#
+# Exit 0 on success, exit 1 with ERROR lines on stderr on any failure.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <manifest-directory>" >&2
+    exit 1
+fi
+
+MANIFEST_DIR="$1"
+
+if [[ ! -d "${MANIFEST_DIR}" ]]; then
+    echo "ERROR: directory not found: ${MANIFEST_DIR}" >&2
+    exit 1
+fi
+
+python3 - "${MANIFEST_DIR}" <<'PYEOF'
+import sys
+import os
+import glob
+import yaml
+
+def validate_manifest(path):
+    errors = []
+    basename = os.path.basename(path)
+
+    with open(path, "r", encoding="utf-8") as fh:
+        try:
+            doc = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            return [f"{basename}: YAML parse error: {exc}"]
+
+    if not isinstance(doc, dict):
+        return [f"{basename}: top-level document is not a mapping"]
+
+    # --- Common required fields ---
+    for field in ("apiVersion", "kind"):
+        val = doc.get(field)
+        if not val or not str(val).strip():
+            errors.append(f"{basename}: '{field}' is missing or empty")
+
+    metadata = doc.get("metadata")
+    if not isinstance(metadata, dict) or not metadata.get("name", "").strip():
+        errors.append(f"{basename}: 'metadata.name' is missing or empty")
+
+    # --- status must not be an empty dict ---
+    if "status" in doc and doc["status"] == {}:
+        errors.append(
+            f"{basename}: 'status' is an empty dict — this indicates a "
+            "serialization defect in the manifest output"
+        )
+
+    kind = doc.get("kind", "")
+    spec = doc.get("spec", {}) or {}
+
+    # --- Kind-specific checks ---
+    if kind == "ImageDigestMirrorSet":
+        mirrors = spec.get("imageDigestMirrors")
+        if not mirrors or not isinstance(mirrors, list) or len(mirrors) == 0:
+            errors.append(
+                f"{basename}: 'spec.imageDigestMirrors' is missing or empty "
+                "(ImageDigestMirrorSet)"
+            )
+
+    elif kind == "ImageTagMirrorSet":
+        mirrors = spec.get("imageTagMirrors")
+        if not mirrors or not isinstance(mirrors, list) or len(mirrors) == 0:
+            errors.append(
+                f"{basename}: 'spec.imageTagMirrors' is missing or empty "
+                "(ImageTagMirrorSet)"
+            )
+
+    elif kind == "CatalogSource":
+        if not spec.get("sourceType", "").strip():
+            errors.append(
+                f"{basename}: 'spec.sourceType' is missing or empty (CatalogSource)"
+            )
+        if not spec.get("image", "").strip():
+            errors.append(
+                f"{basename}: 'spec.image' is missing or empty (CatalogSource)"
+            )
+
+    elif kind == "ClusterCatalog":
+        if "source" not in spec:
+            errors.append(
+                f"{basename}: 'spec.source' is missing (ClusterCatalog)"
+            )
+
+    return errors
+
+
+manifest_dir = sys.argv[1]
+yaml_files = sorted(glob.glob(os.path.join(manifest_dir, "*.yaml")))
+
+if not yaml_files:
+    print(f"WARNING: no *.yaml files found in {manifest_dir}", file=sys.stderr)
+    sys.exit(0)
+
+all_errors = []
+for manifest_path in yaml_files:
+    file_errors = validate_manifest(manifest_path)
+    for err in file_errors:
+        print(f"ERROR: {err}", file=sys.stderr)
+    all_errors.extend(file_errors)
+
+if all_errors:
+    sys.exit(1)
+
+print(f"OK: all {len(yaml_files)} manifest(s) passed validation.")
+PYEOF

--- a/hack/validate_manifests.sh
+++ b/hack/validate_manifests.sh
@@ -11,6 +11,7 @@
 #       ImageTagMirrorSet     : spec.imageTagMirrors non-empty list
 #       CatalogSource         : spec.sourceType and spec.image non-empty strings
 #       ClusterCatalog        : spec.source must be defined
+#       UpdateService         : spec.graphDataImage and spec.releases non-empty strings
 #
 # Exit 0 on success, exit 1 with ERROR lines on stderr on any failure.
 
@@ -98,6 +99,18 @@ def validate_manifest(path):
         if "source" not in spec:
             errors.append(
                 f"{basename}: 'spec.source' is missing (ClusterCatalog)"
+            )
+
+    elif kind == "UpdateService":
+        if not spec.get("graphDataImage", "").strip():
+            errors.append(
+                f"{basename}: 'spec.graphDataImage' is missing or empty "
+                "(UpdateService)"
+            )
+        if not spec.get("releases", "").strip():
+            errors.append(
+                f"{basename}: 'spec.releases' is missing or empty "
+                "(UpdateService)"
             )
 
     return errors

--- a/roles/oci_mirror/README.md
+++ b/roles/oci_mirror/README.md
@@ -146,6 +146,8 @@ Each YAML file in that directory is parsed and checked for:
 - **CatalogSource** (`cs-*.yaml`): `spec.sourceType` and `spec.image` must be
   non-empty strings.
 - **ClusterCatalog** (`cc-*.yaml`): `spec.source` must be defined.
+- **UpdateService** (`update-service-*.yaml`): `spec.graphDataImage` and
+  `spec.releases` must be non-empty strings.
 
 Set `om_validate_manifests: false` to skip validation (e.g. when you know the
 mirroring tool produces partial output intentionally).

--- a/roles/oci_mirror/README.md
+++ b/roles/oci_mirror/README.md
@@ -22,6 +22,7 @@ Either you point the role at an existing **ImageSetConfiguration**, or you let i
 | `om_keep_working_dir` | bool | `false` | Keep the temp workspace after the role finishes (useful for debugging). |
 | `om_remove_signatures` | bool | `false` | Pass `--remove-signatures` to `oc-mirror` (needed for some unsigned images). |
 | `om_ignore_errors` | bool | `false` | Sets Ansible `ignore_errors` on the mirror task. |
+| `om_validate_manifests` | bool | `true` | Validate all generated manifests after mirroring. See [Manifest Validation](#manifest-validation). |
 
 ### Standard path only (`om_custom_config` not set)
 
@@ -130,6 +131,31 @@ Some operators stay on `om_source_index`; others use another index via `catalog`
       local-storage-operator:
     om_keep_working_dir: true
 ```
+
+## Manifest Validation
+
+When `om_validate_manifests` is `true` (the default), the role runs
+`tasks/validate-manifests.yml` after copying manifests to `_om_output_dir`.
+Each YAML file in that directory is parsed and checked for:
+
+- `apiVersion`, `kind`, and `metadata.name` must be non-empty strings.
+- `status` must not be an empty dict (`{}`). An empty status field can
+  indicate a serialization defect in the mirroring tool output.
+- **IDMS** (`idms-*.yaml`): `spec.imageDigestMirrors` must be a non-empty list.
+- **ITMS** (`itms-*.yaml`): `spec.imageTagMirrors` must be a non-empty list.
+- **CatalogSource** (`cs-*.yaml`): `spec.sourceType` and `spec.image` must be
+  non-empty strings.
+- **ClusterCatalog** (`cc-*.yaml`): `spec.source` must be defined.
+
+Set `om_validate_manifests: false` to skip validation (e.g. when you know the
+mirroring tool produces partial output intentionally).
+
+### GitOps and ACM Policy Compliance
+
+When using the generated manifests in a GitOps workflow or as ACM policy
+sources, validation failures indicate that one or more manifests are incomplete
+and must not be committed to the policy repository. Resolve the root cause
+before propagating the manifests downstream.
 
 ## Output / facts
 

--- a/roles/oci_mirror/defaults/main.yml
+++ b/roles/oci_mirror/defaults/main.yml
@@ -3,3 +3,4 @@ om_allow_insecure_registries: false
 om_keep_working_dir: false
 om_remove_signatures: false
 om_ignore_errors: false
+om_validate_manifests: true

--- a/roles/oci_mirror/meta/argument_specs.yml
+++ b/roles/oci_mirror/meta/argument_specs.yml
@@ -74,4 +74,5 @@ argument_specs:
           non-empty, that status is not an empty dict (which would indicate a
           serialization defect), and that kind-specific spec fields are present
           and non-empty (imageDigestMirrors for IDMS, imageTagMirrors for ITMS,
-          sourceType+image for CatalogSource, source for ClusterCatalog).
+          sourceType+image for CatalogSource, source for ClusterCatalog,
+          graphDataImage+releases for UpdateService).

--- a/roles/oci_mirror/meta/argument_specs.yml
+++ b/roles/oci_mirror/meta/argument_specs.yml
@@ -64,3 +64,14 @@ argument_specs:
         required: false
         default: false
         description: Ignore errors during mirroring.
+      om_validate_manifests:
+        type: bool
+        required: false
+        default: true
+        description: >
+          When true, validate all generated manifests in the output directory
+          after mirroring. Checks that apiVersion, kind, and metadata.name are
+          non-empty, that status is not an empty dict (which would indicate a
+          serialization defect), and that kind-specific spec fields are present
+          and non-empty (imageDigestMirrors for IDMS, imageTagMirrors for ITMS,
+          sourceType+image for CatalogSource, source for ClusterCatalog).

--- a/roles/oci_mirror/tasks/mirroring.yml
+++ b/roles/oci_mirror/tasks/mirroring.yml
@@ -49,6 +49,14 @@
       - "idms-oc-mirror.yaml"
   register: _om_image_source_manifest
 
+- name: "Find generated ITMS manifests"
+  ansible.builtin.find:
+    paths: "{{ _om_tmp_dir.path }}"
+    recurse: true
+    patterns:
+      - "itms-oc-mirror.yaml"
+  register: _om_itms_manifest
+
 - name: "Create output directory for manifests"
   ansible.builtin.tempfile:
     state: directory
@@ -76,7 +84,20 @@
   when:
     - _om_catalog_manifest.matched > 0
 
+- name: "Copy ITMS to output directory"
+  ansible.builtin.copy:
+    src: "{{ _om_itms_manifest.files[0].path }}"
+    dest: "{{ _om_output_dir.path }}/{{ _om_itms_manifest.files[0].path | basename }}"
+    mode: "0644"
+    remote_src: true
+  when:
+    - _om_itms_manifest.matched > 0
+
 - name: Expose manifests output directory
   ansible.builtin.set_fact:
     om_output_dir: "{{ _om_output_dir.path }}"
   when: _om_output_dir is defined
+
+- name: Validate generated manifests
+  ansible.builtin.include_tasks: validate-manifests.yml
+  when: om_validate_manifests | bool

--- a/roles/oci_mirror/tasks/validate-manifests.yml
+++ b/roles/oci_mirror/tasks/validate-manifests.yml
@@ -1,0 +1,57 @@
+---
+- name: "Find all YAML manifests in the output directory"
+  ansible.builtin.find:
+    paths: "{{ _om_output_dir.path }}"
+    patterns: "*.yaml"
+    recurse: false
+  register: _om_manifest_files
+  changed_when: false
+
+- name: "Parse and validate each manifest"
+  vars:
+    _manifest: "{{ lookup('file', item.path) | from_yaml }}"
+    _path: "{{ item.path }}"
+    _basename: "{{ item.path | basename }}"
+    _idms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'idms-') | list }}"
+    _itms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'itms-') | list }}"
+    _cs_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cs-') | list }}"
+    _cc_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cc-') | list }}"
+  ansible.builtin.assert:
+    that:
+      - _manifest.apiVersion is defined and _manifest.apiVersion | length > 0
+      - _manifest.kind is defined and _manifest.kind | length > 0
+      - _manifest.metadata is defined
+      - _manifest.metadata.name is defined and _manifest.metadata.name | length > 0
+      - not (_manifest.status is defined and _manifest.status == {})
+      - >-
+        not (_basename in (_idms_files | map(attribute='path') | map('basename') | list))
+        or (_manifest.spec is defined
+            and _manifest.spec.imageDigestMirrors is defined
+            and _manifest.spec.imageDigestMirrors | length > 0)
+      - >-
+        not (_basename in (_itms_files | map(attribute='path') | map('basename') | list))
+        or (_manifest.spec is defined
+            and _manifest.spec.imageTagMirrors is defined
+            and _manifest.spec.imageTagMirrors | length > 0)
+      - >-
+        not (_basename in (_cs_files | map(attribute='path') | map('basename') | list))
+        or (_manifest.spec is defined
+            and _manifest.spec.sourceType is defined
+            and _manifest.spec.sourceType | length > 0
+            and _manifest.spec.image is defined
+            and _manifest.spec.image | length > 0)
+      - >-
+        not (_basename in (_cc_files | map(attribute='path') | map('basename') | list))
+        or (_manifest.spec is defined
+            and _manifest.spec.source is defined)
+    fail_msg: >-
+      Manifest validation failed for {{ _basename }}:
+      apiVersion={{ _manifest.apiVersion | default('empty') }},
+      kind={{ _manifest.kind | default('empty') }},
+      name={{ _manifest.metadata.name | default('empty') }},
+      status={{ _manifest.status | default('not set') }}.
+      Check that the manifest is complete and non-empty.
+    success_msg: "Manifest {{ _basename }} passed validation."
+  loop: "{{ _om_manifest_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"

--- a/roles/oci_mirror/tasks/validate-manifests.yml
+++ b/roles/oci_mirror/tasks/validate-manifests.yml
@@ -5,18 +5,12 @@
     patterns: "*.yaml"
     recurse: false
   register: _om_manifest_files
-  changed_when: false
 
 - name: "Parse and validate each manifest"
   vars:
     _manifest: "{{ lookup('file', item.path) | from_yaml }}"
     _path: "{{ item.path }}"
     _basename: "{{ item.path | basename }}"
-    _idms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'idms-') | list }}"
-    _itms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'itms-') | list }}"
-    _cs_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cs-') | list }}"
-    _cc_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cc-') | list }}"
-    _us_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'update-service-') | list }}"
   ansible.builtin.assert:
     that:
       - _manifest.apiVersion is defined and _manifest.apiVersion | length > 0
@@ -25,28 +19,28 @@
       - _manifest.metadata.name is defined and _manifest.metadata.name | length > 0
       - not (_manifest.status is defined and _manifest.status == {})
       - >-
-        not (_basename in (_idms_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('idms-')
         or (_manifest.spec is defined
             and _manifest.spec.imageDigestMirrors is defined
             and _manifest.spec.imageDigestMirrors | length > 0)
       - >-
-        not (_basename in (_itms_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('itms-')
         or (_manifest.spec is defined
             and _manifest.spec.imageTagMirrors is defined
             and _manifest.spec.imageTagMirrors | length > 0)
       - >-
-        not (_basename in (_cs_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('cs-')
         or (_manifest.spec is defined
             and _manifest.spec.sourceType is defined
             and _manifest.spec.sourceType | length > 0
             and _manifest.spec.image is defined
             and _manifest.spec.image | length > 0)
       - >-
-        not (_basename in (_cc_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('cc-')
         or (_manifest.spec is defined
             and _manifest.spec.source is defined)
       - >-
-        not (_basename in (_us_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('update-service-')
         or ((_manifest.spec | default({})).graphDataImage is defined
             and (_manifest.spec | default({})).graphDataImage | length > 0
             and (_manifest.spec | default({})).releases is defined

--- a/roles/oci_mirror/tasks/validate-manifests.yml
+++ b/roles/oci_mirror/tasks/validate-manifests.yml
@@ -16,6 +16,7 @@
     _itms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'itms-') | list }}"
     _cs_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cs-') | list }}"
     _cc_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cc-') | list }}"
+    _us_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'update-service-') | list }}"
   ansible.builtin.assert:
     that:
       - _manifest.apiVersion is defined and _manifest.apiVersion | length > 0
@@ -44,6 +45,12 @@
         not (_basename in (_cc_files | map(attribute='path') | map('basename') | list))
         or (_manifest.spec is defined
             and _manifest.spec.source is defined)
+      - >-
+        not (_basename in (_us_files | map(attribute='path') | map('basename') | list))
+        or ((_manifest.spec | default({})).graphDataImage is defined
+            and (_manifest.spec | default({})).graphDataImage | length > 0
+            and (_manifest.spec | default({})).releases is defined
+            and (_manifest.spec | default({})).releases | length > 0)
     fail_msg: >-
       Manifest validation failed for {{ _basename }}:
       apiVersion={{ _manifest.apiVersion | default('empty') }},

--- a/tests/integration/targets/oci_mirror_manifests/files/bad/idms-empty-status.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/bad/idms-empty-status.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: idms-oc-mirror
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - registry.lab.example.com:5000/openshift4
+      source: quay.io/openshift-release-dev/ocp-release
+status: {}

--- a/tests/integration/targets/oci_mirror_manifests/files/bad/update-service-empty-spec.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/bad/update-service-empty-spec.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: updateservice.operator.openshift.io/v1
+kind: UpdateService
+metadata:
+  name: update-service-empty-spec
+  namespace: openshift-update-service
+spec:
+  graphDataImage: ""
+  releases: ""

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/cc-redhat-operators.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/cc-redhat-operators.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: catalogd.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: cc-redhat-operators
+spec:
+  source:
+    type: Image
+    image:
+      ref: registry.lab.example.com:5000/redhat/redhat-operator-index:v4.17
+      pollInterval: 24h

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/cs-redhat-operators.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/cs-redhat-operators.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: cs-redhat-operators
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: registry.lab.example.com:5000/redhat/redhat-operator-index:v4.14
+  displayName: Red Hat Operators (mirrored)
+  publisher: Red Hat

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/idms-oc-mirror.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/idms-oc-mirror.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: idms-oc-mirror
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - registry.lab.example.com:5000/openshift4
+      source: quay.io/openshift-release-dev/ocp-release
+    - mirrors:
+        - registry.lab.example.com:5000/openshift4
+      source: quay.io/openshift-release-dev/ocp-v4.0-art-dev

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/itms-oc-mirror.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/itms-oc-mirror.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: itms-oc-mirror
+spec:
+  imageTagMirrors:
+    - mirrors:
+        - registry.lab.example.com:5000/ubi8
+      source: registry.access.redhat.com/ubi8

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/update-service-oc-mirror.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/update-service-oc-mirror.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: updateservice.operator.openshift.io/v1
+kind: UpdateService
+metadata:
+  name: update-service-oc-mirror
+  namespace: openshift-update-service
+spec:
+  graphDataImage: registry.lab.example.com:5000/updateservice/graph-data:latest
+  releases: registry.lab.example.com:5000/openshift-release-dev/ocp-release
+  replicas: 2

--- a/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
+++ b/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
@@ -1,0 +1,77 @@
+---
+- name: Integration tests for oci_mirror manifest validation
+  hosts: testhost
+  gather_facts: false
+  tasks:
+
+    - name: Create temp directory for valid manifests
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_valid.
+      register: _test_valid_dir
+
+    - name: Create temp directory for bad manifests
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_bad.
+      register: _test_bad_dir
+
+    - name: Copy valid manifest fixtures to temp directory
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ _test_valid_dir.path }}/{{ item | basename }}"
+        mode: "0644"
+      loop:
+        - "files/valid/idms-oc-mirror.yaml"
+        - "files/valid/itms-oc-mirror.yaml"
+        - "files/valid/cs-redhat-operators.yaml"
+        - "files/valid/cc-redhat-operators.yaml"
+
+    - name: Validate valid manifests — should succeed
+      vars:
+        _om_output_dir:
+          path: "{{ _test_valid_dir.path }}"
+      ansible.builtin.include_role:
+        name: redhatci.ocp.oci_mirror
+        tasks_from: validate-manifests.yml
+
+    - name: Copy bad manifest fixture to temp directory
+      ansible.builtin.copy:
+        src: "files/bad/idms-empty-status.yaml"
+        dest: "{{ _test_bad_dir.path }}/idms-oc-mirror.yaml"
+        mode: "0644"
+
+    - name: Validate bad manifests — should fail
+      block:
+        - name: Run validation on bad manifest (expected to fail)
+          vars:
+            _om_output_dir:
+              path: "{{ _test_bad_dir.path }}"
+          ansible.builtin.include_role:
+            name: redhatci.ocp.oci_mirror
+            tasks_from: validate-manifests.yml
+
+        - name: Fail if validation did not raise an error
+          ansible.builtin.fail:
+            msg: "Validation should have failed for manifest with empty status but did not."
+
+      rescue:
+        - name: Confirm that the validation failure mentions empty status
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - "'empty' in (ansible_failed_result.msg | default(''))"
+            fail_msg: >-
+              Validation failed but the error message did not mention 'empty'.
+              Got: {{ ansible_failed_result.msg | default('no message') }}
+
+      always:
+        - name: Clean up valid temp directory
+          ansible.builtin.file:
+            path: "{{ _test_valid_dir.path }}"
+            state: absent
+
+        - name: Clean up bad temp directory
+          ansible.builtin.file:
+            path: "{{ _test_bad_dir.path }}"
+            state: absent

--- a/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
+++ b/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
@@ -26,6 +26,7 @@
         - "files/valid/itms-oc-mirror.yaml"
         - "files/valid/cs-redhat-operators.yaml"
         - "files/valid/cc-redhat-operators.yaml"
+        - "files/valid/update-service-oc-mirror.yaml"
 
     - name: Validate valid manifests — should succeed
       vars:
@@ -34,6 +35,33 @@
       ansible.builtin.include_role:
         name: redhatci.ocp.oci_mirror
         tasks_from: validate-manifests.yml
+
+    - name: "AC4 — Verify apiVersion matches expected schema per kind (GitOps/ACM compliance)"
+      vars:
+        _api_version_map:
+          ImageDigestMirrorSet: "config.openshift.io/v1"
+          ImageTagMirrorSet: "config.openshift.io/v1"
+          CatalogSource: "operators.coreos.com/v1alpha1"
+          ClusterCatalog: "catalogd.operatorframework.io/v1"
+          UpdateService: "updateservice.operator.openshift.io/v1"
+        _manifest: "{{ lookup('file', item.path) | from_yaml }}"
+        _kind: "{{ _manifest.kind | default('') }}"
+        _expected_api: "{{ _api_version_map[_kind] | default('') }}"
+      ansible.builtin.assert:
+        that:
+          - _kind not in _api_version_map or _manifest.apiVersion == _expected_api
+        fail_msg: >-
+          AC4 apiVersion mismatch in {{ item.path | basename }}:
+          kind={{ _kind }},
+          expected apiVersion={{ _expected_api }},
+          got={{ _manifest.apiVersion | default('empty') }}.
+        success_msg: >-
+          AC4 passed for {{ item.path | basename }}:
+          kind={{ _kind }}, apiVersion={{ _manifest.apiVersion | default('empty') }}.
+      loop: "{{ _om_manifest_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+      when: _om_manifest_files.files | length > 0
 
     - name: Copy bad manifest fixture to temp directory
       ansible.builtin.copy:
@@ -74,4 +102,46 @@
         - name: Clean up bad temp directory
           ansible.builtin.file:
             path: "{{ _test_bad_dir.path }}"
+            state: absent
+
+    - name: Create temp directory for bad UpdateService manifest
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_bad_us.
+      register: _test_bad_us_dir
+
+    - name: Validate bad UpdateService manifest — should fail
+      block:
+        - name: Copy bad UpdateService fixture to temp directory
+          ansible.builtin.copy:
+            src: "files/bad/update-service-empty-spec.yaml"
+            dest: "{{ _test_bad_us_dir.path }}/update-service-oc-mirror.yaml"
+            mode: "0644"
+
+        - name: Run validation on bad UpdateService manifest (expected to fail)
+          vars:
+            _om_output_dir:
+              path: "{{ _test_bad_us_dir.path }}"
+          ansible.builtin.include_role:
+            name: redhatci.ocp.oci_mirror
+            tasks_from: validate-manifests.yml
+
+        - name: Fail if UpdateService validation did not raise an error
+          ansible.builtin.fail:
+            msg: "Validation should have failed for UpdateService with empty spec but did not."
+
+      rescue:
+        - name: Confirm that the UpdateService validation failure mentions empty
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - "'empty' in (ansible_failed_result.msg | default(''))"
+            fail_msg: >-
+              UpdateService validation failed but the error message did not mention 'empty'.
+              Got: {{ ansible_failed_result.msg | default('no message') }}
+
+      always:
+        - name: Clean up bad UpdateService temp directory
+          ansible.builtin.file:
+            path: "{{ _test_bad_us_dir.path }}"
             state: absent

--- a/tests/integration/targets/oci_mirror_manifests/runme.sh
+++ b/tests/integration/targets/oci_mirror_manifests/runme.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+dir=$(dirname "$0")
+
+exec ansible-playbook -v -i $dir/../../inventory $dir/oci_mirror_manifests.yml
+
+# runme.sh ends here

--- a/tests/integration/targets/oci_mirror_manifests/runme.sh
+++ b/tests/integration/targets/oci_mirror_manifests/runme.sh
@@ -2,6 +2,6 @@
 
 dir=$(dirname "$0")
 
-exec ansible-playbook -v -i $dir/../../inventory $dir/oci_mirror_manifests.yml
+exec ansible-playbook -v -i "$dir"/../../inventory "$dir"/oci_mirror_manifests.yml
 
 # runme.sh ends here


### PR DESCRIPTION
## Summary

- Added `validate-manifests.yml` task with IDMS, ITMS, CatalogSource, ClusterCatalog, and **UpdateService** validation checks; filename matching simplified to use `startswith()` Jinja2 tests for cleaner, more readable assertions
- Integrated ITMS Find+Copy into `mirroring.yml`, added `om_validate_manifests` variable (default true) in defaults, argument_specs, and README
- Added integration test target (`oci_mirror_manifests`) with valid/bad fixtures, including GitOps/ACM apiVersion compliance checks (AC4), standalone `hack/validate_manifests.sh` script, and `docs/manifest-audit-process.md` audit checklist

## Changes

- `roles/oci_mirror/tasks/validate-manifests.yml`: New task validating IDMS/ITMS/CatalogSource/ClusterCatalog/**UpdateService** fields; uses `startswith()` for filename prefix checks instead of per-iteration list filtering
- `roles/oci_mirror/tasks/mirroring.yml`: ITMS Find+Copy integration
- `roles/oci_mirror/defaults/main.yml`: Added `om_validate_manifests` variable (default: true)
- `roles/oci_mirror/meta/argument_specs.yml`: Documented `om_validate_manifests` argument
- `roles/oci_mirror/README.md`: Documentation for new variable
- `tests/integration/targets/oci_mirror_manifests/`: Integration test with valid/bad fixtures, including AC4 GitOps/ACM apiVersion compliance
- `tests/integration/targets/oci_mirror_manifests/runme.sh`: Quoted `$dir` expansions to prevent word-splitting on paths with spaces
- `hack/validate_manifests.sh`: Standalone validation script
- `docs/manifest-audit-process.md`: Audit process checklist

## Implementation complete ✅

- [x] **UpdateService** resource type validation is included in `validate-manifests.yml` (`update-service-` prefix check; asserts `spec.graphDataImage` and `spec.releases`)
- [x] **GitOps/ACM policy compliance test scenario** — implemented in `oci_mirror_manifests` integration test as "AC4 — Verify apiVersion matches expected schema per kind", mapping all 5 kinds (IDMS, ITMS, CatalogSource, ClusterCatalog, UpdateService) to expected apiVersions
- [x] CI checks have passed

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)