### PR TITLE
Allow no-mcps in a cluster

### DIFF
--- a/roles/check_resource/tasks/wait-mcp.yml
+++ b/roles/check_resource/tasks/wait-mcp.yml
@@ -6,7 +6,6 @@
   register: _cr_mcp_check
   until:
     - _cr_mcp_check.resources is defined
-    - _cr_mcp_check.resources | length > 0
   retries: "{{ check_wait_retries }}"
   delay: "{{ check_wait_delay }}"
   no_log: true


### PR DESCRIPTION
##### SUMMARY

Do not fail if MCPs are not present in the cluster. HCP clusters do not use MCP but the Kind is present

```
$ oc get machineconfigpool -A
No resources found
```

Test-hint: no-check
