### PR TITLE
[kvirt_vm] allow to define annotations, affinity and readiness probe

### DIFF
--- a/roles/kvirt_vm/README.md
+++ b/roles/kvirt_vm/README.md
@@ -43,6 +43,9 @@ Always, Halted, Manual, RerunOnFailure.
 | interfaces                    | virtio/masquerade             | no          | Network interface definitions
 | labels                        |                               | no          | A dictionary with labels for the VM
 | networks                      | Pod network                   | no          | VM network definitions
+| annotations                   |                               | no          | A dictionary with annotations for the VM
+| affinity_group                |                               | no          | Name of affinity group to schedule VMs. Currently the template only defines Anti-affinity to deploy VMs in different nodes.
+| readiness_probe               |                               | no          | A dictionary with settings for the readiness probe
 
 ## Usage examples
 

--- a/roles/kvirt_vm/templates/vm-template.yml.j2
+++ b/roles/kvirt_vm/templates/vm-template.yml.j2
@@ -37,6 +37,11 @@ spec:
     metadata:
       annotations:
         vm.kubevirt.io/os: "{{ vm.os | default(kvirt_vm_os) }}"
+{% if vm.annotations is defined %}
+{% for key, value in vm.annotations.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
       labels:
         kubevirt.io/domain: "{{ vm.namespace | default(kvirt_vm_namespace) }}"
 {% if vm.labels is defined %}
@@ -45,6 +50,19 @@ spec:
 {% endfor %}
 {% endif %}
     spec:
+{% if vm.affinity_group is defined %}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: affinity_group_{{ vm.affinity_group }}
+                operator: Exists
+            topologyKey: kubernetes.io/hostname
+{% endif %}
+{% if vm.readiness_probe is defined and vm.readiness_probe %}
+{{ vm.readiness_probe | to_nice_yaml(indent=2) | indent(6, first=True) }}
+{% endif %}
 {% if vm.node_selector is defined %}
       nodeSelector: {{ vm.node_selector }}
 {% endif %}


### PR DESCRIPTION
Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMTVUMDE6MzM6MDF8ZjBjMWJjMjExYjJkMDlhZWU0OTM2ODUwYTkyNzdmY2I1ODUwYWNhZQ==
Gitleaks-Hash: 3cffc72ce1d886fd20bae8f29224d5bd9fca7b6bfc9942c65f37c719e128d2b8

##### SUMMARY

[kvirt_vm] allow to define annotations, affinity and readiness probe

##### ISSUE TYPE

Enhanced Feature

##### Tests

- [x] https://www.distributed-ci.io/jobs/63cd4a31-1ade-4302-aaa6-dc7ed692816c

---

Test-hints: no-check
