### PR TITLE
Fix defaults and skip log collection if no pods found

### DIFF
--- a/roles/get_logs_from_namespace/README.md
+++ b/roles/get_logs_from_namespace/README.md
@@ -10,8 +10,8 @@ Extracts multiple logs from pods and events in a Namespace.
 
 | Variable | Default   | Required | Description                                        |
 | -------- | --------- | -------- | -------------------------------------------------- |
-| glfn_dir | undefined | No       | Path to the dir where extracted logs will be saved |
-| glfn_ns  | undefined | Yes      | Namespace to extract logs from                     |
+| glfn_dir | /var/tmp/ | Yes      | Path to the dir where extracted logs will be saved |
+| glfn_ns  | default   | Yes      | Namespace to extract logs from                     |
 | glfn_oc  | undefined | Yes      | Path to the oc client                              |
 
 ## Examples

--- a/roles/get_logs_from_namespace/defaults/main.yml
+++ b/roles/get_logs_from_namespace/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-get_logs_ns: default
-get_logs_folder: "{{ job_logs.path }}"
+glfn_ns: default
+glfn_dir: "/var/tmp/"

--- a/roles/get_logs_from_namespace/tasks/main.yml
+++ b/roles/get_logs_from_namespace/tasks/main.yml
@@ -27,7 +27,7 @@
 
     - name: Logs path
       ansible.builtin.debug:
-        msg: "{{ job_logs.path }}"
+        msg: "{{ glfn_dir }}"
 
 - name: Display the logs directory path
   ansible.builtin.debug:
@@ -52,9 +52,12 @@
     --namespace={{ glfn_ns }}
     --all-containers=true
     {{ item }}
-    > {{ glfn_dir }}/{{ item }}.log ;
-    [ -s {{ glfn_dir }}/{{ item }}.log ] || rm -f {{ glfn_dir }}/{{ item }}.log
+    &> {{ glfn_dir }}/{{ item }}.log ;
+    [ -s {{ glfn_dir }}/{{ item }}.log ] ||
+    rm -f {{ glfn_dir }}/{{ item }}.log
   loop: "{{ pod_list | json_query('resources[*].metadata.name') }}"
+  when: pod_list.resources | length > 0
+  changed_when: false
 
 - name: "Get pods status from namespace"
   ansible.builtin.shell: >
@@ -62,13 +65,17 @@
     --namespace={{ glfn_ns }}
     --show-labels
     --output=wide
-    > {{ glfn_dir }}/{{ glfn_ns }}_status.log ;
-    [ -s {{ glfn_dir }}/{{ glfn_ns }}_status.log ] || rm -f {{ glfn_dir }}/{{ glfn_ns }}_status.log
+    &> {{ glfn_dir }}/{{ glfn_ns }}_status.log ;
+    [ -s {{ glfn_dir }}/{{ glfn_ns }}_status.log ] ||
+    rm -f {{ glfn_dir }}/{{ glfn_ns }}_status.log
+  changed_when: false
 
 - name: "Get events from namespace"
   ansible.builtin.shell: >
     {{ glfn_oc }} get events
     --namespace={{ glfn_ns }}
-    > {{ glfn_dir }}/{{ glfn_ns }}_events.log ;
-    [ -s {{ glfn_dir }}/{{ glfn_ns }}_events.log ] || rm -f {{ glfn_dir }}/{{ glfn_ns }}_events.log
+    &> {{ glfn_dir }}/{{ glfn_ns }}_events.log ;
+    [ -s {{ glfn_dir }}/{{ glfn_ns }}_events.log ] ||
+    rm -f {{ glfn_dir }}/{{ glfn_ns }}_events.log
+  changed_when: false
 ...


### PR DESCRIPTION
##### SUMMARY
get_logs_from_namespace role defines a stale defaults which were not used by the role. Fixed them.
Also added condition before trying to collect logs from pods.

##### ISSUE TYPE

Enhanced Feature

Test-Hints: no-check


