### PR TITLE
Add resolve_must_gather_images role and filter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Name | Description
 [redhatci.ocp.redhat_tests](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/redhat_tests/README.md) | [Openshift End to End tests](https://github.com/openshift/openshift-tests)
 [redhatci.ocp.remove_ztp_gitops_resources](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/remove_ztp_gitops_resources/README.md) | Remove all GitOps related resources for a given spoke cluster, excepting the cluster namespace, which is not deleted because this will imply the spoke cluster is detached from the hub cluster.
 [redhatci.ocp.resources_to_components](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/resources_to_components/README.md) | Creates DCI components based on Kubernetes resources
+[redhatci.ocp.resolve_must_gather_images](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/resolve_must_gather_images/README.md) | Resolves version-independent must-gather image short names to full registry references using cluster CSVs.
 [redhatci.ocp.rhoai](roles/rhoai/README.md) | Install the Red Hat OpenShift AI operators
 [redhatci.ocp.setup_gitea](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_gitea/README.md) | Deployment of [Gitea](https://about.gitea.com)
 [redhatci.ocp.setup_gitops](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_gitops/README.md) | Configures GitOps to support Kustomize and PolicyGenerator
@@ -169,6 +170,7 @@ Name | Type | Description
 [redhatci.ocp.cmdline_to_json]() | Filter | Convert a kernel command line string to a JSON object
 [redhatci.ocp.redact]() | Filter | Redact sensitive values from a dictionary
 [redhatci.ocp.regex_diff]() | Filter | Obtain differences between two lists
+[redhatci.ocp.resolve_must_gather](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/plugins/filter/resolve_must_gather.py) | Filter | Resolves must-gather short names to full image references from CSV relatedImages
 
 ## License
 

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        4.1.EPOCH
+Version:        4.2.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Tue Aug  4 2026 Frederic Lepied <flepied@redhat.com> 4.2.EPOCH-VERS
+- Add resolve_must_gather_images role and filter plugin
+
 * Mon Aug  3 2026 Tony Garcia <tonyg@redhat.com> - 4.1.EPOCH-VERS
 - Remove DCI component creation from preflight role
 

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        4.2.EPOCH
+Version:        4.3.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Tue Aug 12 2026 Frederic Lepied <flepied@redhat.com> - 4.3.EPOCH-VERS
+- Add resolve_must_gather_images role and filter plugin
+
 * Wed Aug  5 2026 Beto Rdz <josearod@redhat.com> - 4.2.EPOCH-VERS
 - Add image source generation capabilities to mirror_images role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 4.1.0
+version: 4.2.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 4.2.0
+version: 4.3.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/plugins/filter/resolve_must_gather.py
+++ b/plugins/filter/resolve_must_gather.py
@@ -1,0 +1,213 @@
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+    name: resolve_must_gather
+    version_added: "2.10"
+    short_description: Resolve must-gather image short names from CSV relatedImages
+    description:
+        - Takes a list of must-gather image entries and resolves short names
+          (e.g. "ptp-must-gather") to full image references using the
+          relatedImages from installed ClusterServiceVersion resources.
+        - Entries that already contain a "/" are treated as full image
+          references and passed through unchanged.
+        - Short names are matched against both the relatedImages name
+          field and the image path using substring search. When the
+          entry does not contain "must-gather", matches are restricted
+          to relatedImages whose name or path contains "must-gather",
+          so generic keywords like "openshift-gitops" or "acm" resolve
+          to the correct must-gather image.
+    positional: _input, related_images, fallback_registry
+    options:
+        _input:
+            description: >
+                List of must-gather image entries. Each entry is either a full
+                image reference (containing "/") or a short name to resolve.
+            type: list
+            elements: str
+            required: true
+        related_images:
+            description: >
+                List of relatedImages dicts from ClusterServiceVersion
+                resources. Each dict must have "name" and "image" keys.
+            type: list
+            elements: dict
+            required: true
+        fallback_registry:
+            description: >
+                Registry prefix used when a short name cannot be resolved from
+                any CSV relatedImages. Core OCP images (e.g. ose-must-gather)
+                are not shipped by any operator CSV and therefore never appear
+                in relatedImages. When non-empty, unresolved short names are
+                prefixed with this value (e.g. "registry.redhat.io/openshift4"
+                resolves "ose-must-gather" to
+                "registry.redhat.io/openshift4/ose-must-gather"). Set to an
+                empty string to restore the original behaviour of keeping the
+                short name as-is.
+            type: str
+            default: ""
+"""
+
+EXAMPLES = r"""
+    # Resolve must-gather short names from CSV relatedImages
+    - name: Resolve must-gather images
+      ansible.builtin.set_fact:
+        resolved_images: >-
+          {{ image_list | redhatci.ocp.resolve_must_gather(related_images) }}
+      vars:
+        image_list:
+          - "ptp-must-gather"
+          - "registry.redhat.io/openshift4/custom-image:v4.18"
+        related_images:
+          - name: "ptp-must-gather-rhel9"
+            image: "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:abc123"
+
+    # Resolve with fallback registry for core OCP images (not in any CSV)
+    - name: Resolve must-gather images with fallback for core OCP images
+      ansible.builtin.set_fact:
+        resolved_images: >-
+          {{ image_list
+             | redhatci.ocp.resolve_must_gather(related_images,
+                                                'registry.redhat.io/openshift4') }}
+      vars:
+        image_list:
+          - "ose-must-gather"
+          - "ptp-must-gather"
+          - "registry.redhat.io/openshift4/custom-image:v4.18"
+        related_images:
+          - name: "ptp-must-gather-rhel9"
+            image: "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:abc123"
+"""
+
+RETURN = r"""
+    _value:
+        description: >
+            List of resolved image references. Short names are replaced with
+            the full image reference from relatedImages. Unresolved short names
+            are kept as-is.
+        type: list
+        elements: str
+"""
+
+
+def _extract_rhel_suffix(image_ref):
+    """Extract the RHEL suffix (e.g. '-rhel8', '-rhel9') from an image ref.
+
+    Looks at the image path component (before any @sha256: or :tag) for
+    a '-rhel[0-9]+' pattern.
+    """
+    import re
+    path = image_ref.split("@")[0].split(":")[0]
+    basename = path.rsplit("/", 1)[-1]
+    m = re.search(r"(-rhel\d+)", basename)
+    return m.group(1) if m else ""
+
+
+def _find_operator_image(keyword, related_images):
+    """Find a relatedImage whose name or image path contains the keyword."""
+    kw = keyword.lower().replace("-", "_")
+    for ri in related_images:
+        ri_name = ri.get("name", "").lower().replace("-", "_")
+        ri_image = ri.get("image", "")
+        ri_path = ri_image.split("@")[0].split(":")[0].rsplit("/", 1)[-1]
+        ri_path_norm = ri_path.lower().replace("-", "_")
+        if kw in ri_name or kw in ri_path_norm:
+            return ri_image
+    return ""
+
+
+def resolve_must_gather(image_list, related_images, fallback_registry=""):
+    """Resolve must-gather image short names from CSV relatedImages.
+
+    Args:
+        image_list (list): List of image entries (short names or full refs).
+        related_images (list): List of dicts with "name" and "image" keys
+            from ClusterServiceVersion relatedImages.
+        fallback_registry (str): Registry prefix used when a short name cannot
+            be resolved from any CSV relatedImages. Core OCP images (e.g.
+            ose-must-gather) are not shipped by any operator CSV and therefore
+            never appear in relatedImages. When non-empty, unresolved short
+            names are prefixed with this value. Defaults to "" (keep as-is).
+
+    Returns:
+        list: Resolved image references.
+    """
+    if not isinstance(image_list, list):
+        return image_list
+
+    if not isinstance(related_images, list):
+        return image_list
+
+    resolved = []
+    for entry in image_list:
+        if not isinstance(entry, str):
+            resolved.append(entry)
+            continue
+
+        # Full image reference: pass through
+        if "/" in entry:
+            resolved.append(entry)
+            continue
+
+        # Short name: search in relatedImages by name and image path.
+        # When the entry doesn't already contain "must_gather", restrict
+        # matches to relatedImages whose name or image path does — so
+        # generic keywords like "openshift-gitops" or "acm" only match
+        # must-gather images, not arbitrary operator images.
+        entry_normalized = entry.lower().replace("-", "_")
+        is_mg_entry = "must_gather" in entry_normalized
+        match = None
+        for ri in related_images:
+            ri_name = ri.get("name", "").lower().replace("-", "_")
+            ri_image = ri.get("image", "")
+            ri_path = ri_image.split("@")[0].split(":")[0].lower().replace("-", "_")
+            if entry_normalized in ri_name or entry_normalized in ri_path:
+                if is_mg_entry or "must_gather" in ri_name or "must_gather" in ri_path:
+                    match = ri_image
+                    break
+
+        if match:
+            resolved.append(match)
+        elif fallback_registry:
+            # Must-gather images are not in CSV relatedImages.  Try to
+            # infer the RHEL suffix from the operator's own images.
+            # E.g. for "ptp-must-gather", find an operator image containing
+            # "ptp" to discover the "-rhel8" or "-rhel9" suffix.
+            rhel_suffix = ""
+            keyword = (entry_normalized
+                       .replace("must_gather", "")
+                       .replace("ose_", "")
+                       .strip("_"))
+            if keyword:
+                op_image = _find_operator_image(keyword, related_images)
+                if op_image:
+                    rhel_suffix = _extract_rhel_suffix(op_image)
+            resolved.append(
+                "{0}/{1}{2}".format(fallback_registry, entry, rhel_suffix))
+        else:
+            # Keep original so the caller can decide what to do
+            resolved.append(entry)
+
+    return resolved
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            "resolve_must_gather": resolve_must_gather,
+        }

--- a/roles/resolve_must_gather_images/README.md
+++ b/roles/resolve_must_gather_images/README.md
@@ -1,0 +1,116 @@
+# Resolve Must-Gather Images
+
+Resolves must-gather image short names to full image references using
+the `relatedImages` from installed operator ClusterServiceVersion (CSV)
+resources.
+
+This allows pipeline configurations to specify short image names
+(e.g. `ptp-must-gather`) instead of hardcoding full image references
+with version tags or digests. The role queries the cluster to find the
+exact image reference matching the installed operator version.
+
+## How It Works
+
+1. Queries all installed CSVs on the cluster.
+2. Collects all `relatedImages` entries from the CSVs.
+3. For each entry in `rmgi_images`:
+   - If it contains a `/`, it is treated as a full image reference and
+     passed through unchanged.
+   - Otherwise, it is matched (substring) against the `relatedImages`
+     name field and replaced with the full image reference.
+   - If no CSV match is found and `rmgi_fallback_registry` is non-empty,
+     the short name is prefixed with `rmgi_fallback_registry`. This
+     handles core OCP images (e.g. `ose-must-gather`) that are not
+     shipped by any operator CSV.
+4. Sets the resolved list as `rmgi_resolved_images`.
+
+## Variables
+
+| Variable               | Default                            | Required | Description                                                                                                                                                                   |
+| ---------------------- | ---------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rmgi_images            | `["ose-must-gather"]`              | No       | List of must-gather image entries to resolve                                                                                                                                  |
+| rmgi_fallback_registry | `"registry.redhat.io/openshift4"` | No       | Registry prefix for short names that cannot be resolved from any CSV. Core OCP images (e.g. `ose-must-gather`) are not in any CSV. Set to `""` to keep unresolved names as-is |
+
+## Output
+
+| Variable                | Description                              |
+| ----------------------- | ---------------------------------------- |
+| rmgi_resolved_images    | List of resolved full image references   |
+
+## Examples
+
+### Resolve PTP and standard must-gather images
+
+```yaml
+- name: Resolve must-gather images
+  ansible.builtin.include_role:
+    name: redhatci.ocp.resolve_must_gather_images
+  vars:
+    rmgi_images:
+      - "ose-must-gather"
+      - "ptp-must-gather"
+```
+
+This resolves to something like:
+
+```yaml
+rmgi_resolved_images:
+  - "registry.redhat.io/openshift4/ose-must-gather@sha256:abc123..."
+  - "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:def456..."
+```
+
+### Mix short names with full references
+
+```yaml
+- name: Resolve must-gather images
+  ansible.builtin.include_role:
+    name: redhatci.ocp.resolve_must_gather_images
+  vars:
+    rmgi_images:
+      - "ose-must-gather"
+      - "ptp-must-gather"
+      - "registry.redhat.io/openshift4/custom-must-gather:latest"
+```
+
+### Resolve core OCP images using fallback registry
+
+Core OCP images such as `ose-must-gather` are not shipped by any operator
+CSV, so they cannot be resolved from `relatedImages`. The `rmgi_fallback_registry`
+variable provides a fallback: unresolved short names are prefixed with it.
+
+```yaml
+- name: Resolve must-gather images with fallback for core OCP images
+  ansible.builtin.include_role:
+    name: redhatci.ocp.resolve_must_gather_images
+  vars:
+    rmgi_images:
+      - "ose-must-gather"        # core OCP image — resolved via fallback
+      - "ptp-must-gather"        # operator image — resolved from CSV
+    rmgi_fallback_registry: "registry.redhat.io/openshift4"
+```
+
+This resolves to something like:
+
+```yaml
+rmgi_resolved_images:
+  - "registry.redhat.io/openshift4/ose-must-gather"
+  - "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:def456..."
+```
+
+To disable the fallback and keep unresolved names as-is (original behaviour):
+
+```yaml
+    rmgi_fallback_registry: ""
+```
+
+## Filter Plugin
+
+This role uses the `redhatci.ocp.resolve_must_gather` filter plugin,
+which can also be used standalone:
+
+```yaml
+- name: Resolve images inline
+  ansible.builtin.set_fact:
+    resolved: >-
+      {{ my_images | redhatci.ocp.resolve_must_gather(related_images_list) }}
+```

--- a/roles/resolve_must_gather_images/defaults/main.yml
+++ b/roles/resolve_must_gather_images/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# List of must-gather image entries.
+# Each entry can be:
+#   - A short name (e.g. "ptp-must-gather") resolved from installed
+#     operator CSV relatedImages
+#   - A full image reference (e.g. "registry.redhat.io/openshift4/ose-must-gather:v4.18")
+#     passed through unchanged
+rmgi_images:
+  - "ose-must-gather"
+
+# Fallback registry prefix for short names that cannot be resolved from CSVs.
+# Core OCP images (e.g. ose-must-gather) are not in any CSV relatedImages.
+# When non-empty, unresolved short names are prefixed with this registry.
+# Example: "registry.redhat.io/openshift4" resolves "ose-must-gather" to
+# "registry.redhat.io/openshift4/ose-must-gather"
+rmgi_fallback_registry: "registry.redhat.io/openshift4"
+...

--- a/roles/resolve_must_gather_images/tasks/main.yml
+++ b/roles/resolve_must_gather_images/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Get all ClusterServiceVersions
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+  register: _rmgi_csvs
+
+- name: Build relatedImages list from all CSVs
+  ansible.builtin.set_fact:
+    rmgi_related_images: >-
+      {{ _rmgi_csvs.resources
+         | json_query('[*].spec.relatedImages[*]')
+         | flatten }}
+
+- name: Resolve must-gather image names
+  ansible.builtin.set_fact:
+    rmgi_resolved_images: >-
+      {{ rmgi_images
+         | redhatci.ocp.resolve_must_gather(rmgi_related_images, rmgi_fallback_registry) }}
+
+- name: Display resolved must-gather images
+  ansible.builtin.debug:
+    msg: "Resolved must-gather images: {{ rmgi_resolved_images }}"
+...

--- a/tests/integration/resolve_must_gather/test_resolve_must_gather.yml
+++ b/tests/integration/resolve_must_gather/test_resolve_must_gather.yml
@@ -1,0 +1,32 @@
+---
+- name: Test resolve_must_gather_images role against a live cluster
+  hosts: localhost
+  gather_facts: false
+  environment:
+    KUBECONFIG: "{{ kubeconfig | default('/tmp/kubeconfig') }}"
+  vars:
+    rmgi_images:
+      - ose-must-gather
+      - ptp-must-gather
+  tasks:
+    - name: Display input images
+      ansible.builtin.debug:
+        msg: "Input images: {{ rmgi_images }}"
+
+    - name: Resolve must-gather images
+      ansible.builtin.include_role:
+        name: redhatci.ocp.resolve_must_gather_images
+      vars:
+        rmgi_images: "{{ rmgi_images }}"
+
+    - name: Display resolved images
+      ansible.builtin.debug:
+        msg: "Resolved images: {{ rmgi_resolved_images }}"
+
+    - name: Verify all images were resolved to full references
+      ansible.builtin.assert:
+        that:
+          - rmgi_resolved_images | length == rmgi_images | length
+          - rmgi_resolved_images | select('match', '.*@sha256:.*') | list | length == rmgi_resolved_images | length
+        fail_msg: "Not all images were resolved to digest references"
+        success_msg: "All {{ rmgi_resolved_images | length }} images resolved successfully"

--- a/tests/unit/filter/test_resolve_must_gather.py
+++ b/tests/unit/filter/test_resolve_must_gather.py
@@ -1,0 +1,298 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+from ansible_collections.redhatci.ocp.plugins.filter import resolve_must_gather
+
+
+SAMPLE_RELATED_IMAGES = [
+    {
+        "name": "ose-must-gather",
+        "image": "registry.redhat.io/openshift4/ose-must-gather@sha256:aaa111",
+    },
+    {
+        "name": "ptp-must-gather-rhel9",
+        "image": "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222",
+    },
+    {
+        "name": "sriov-network-must-gather-rhel9",
+        "image": "registry.redhat.io/openshift4/sriov-network-must-gather-rhel9@sha256:ccc333",
+    },
+    {
+        "name": "ptp-operator",
+        "image": "registry.redhat.io/openshift4/ptp-operator@sha256:ddd444",
+    },
+    {
+        "name": "linuxptp-daemon-rhel9",
+        "image": "registry.redhat.io/openshift4/linuxptp-daemon-rhel9@sha256:eee555",
+    },
+]
+
+
+class TestResolveMustGather:
+    def test_resolve_short_name(self):
+        """Test resolving a short name to a full image reference."""
+        result = resolve_must_gather.resolve_must_gather(
+            ["ptp-must-gather"], SAMPLE_RELATED_IMAGES
+        )
+        assert result == [
+            "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222"
+        ]
+
+    def test_resolve_multiple_short_names(self):
+        """Test resolving multiple short names."""
+        result = resolve_must_gather.resolve_must_gather(
+            ["ose-must-gather", "ptp-must-gather", "sriov-network-must-gather"],
+            SAMPLE_RELATED_IMAGES,
+        )
+        assert result == [
+            "registry.redhat.io/openshift4/ose-must-gather@sha256:aaa111",
+            "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222",
+            "registry.redhat.io/openshift4/sriov-network-must-gather-rhel9@sha256:ccc333",
+        ]
+
+    def test_passthrough_full_reference(self):
+        """Test that full image references are passed through unchanged."""
+        full_ref = "registry.redhat.io/openshift4/custom-image:v4.18"
+        result = resolve_must_gather.resolve_must_gather(
+            [full_ref], SAMPLE_RELATED_IMAGES
+        )
+        assert result == [full_ref]
+
+    def test_mixed_short_and_full(self):
+        """Test mix of short names and full references."""
+        result = resolve_must_gather.resolve_must_gather(
+            [
+                "ose-must-gather",
+                "registry.redhat.io/openshift4/custom-image:latest",
+                "ptp-must-gather",
+            ],
+            SAMPLE_RELATED_IMAGES,
+        )
+        assert result == [
+            "registry.redhat.io/openshift4/ose-must-gather@sha256:aaa111",
+            "registry.redhat.io/openshift4/custom-image:latest",
+            "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222",
+        ]
+
+    def test_unresolved_short_name_kept(self):
+        """Test that unresolved short names are kept as-is."""
+        result = resolve_must_gather.resolve_must_gather(
+            ["nonexistent-must-gather"], SAMPLE_RELATED_IMAGES
+        )
+        assert result == ["nonexistent-must-gather"]
+
+    def test_empty_image_list(self):
+        """Test with an empty image list."""
+        result = resolve_must_gather.resolve_must_gather([], SAMPLE_RELATED_IMAGES)
+        assert result == []
+
+    def test_empty_related_images(self):
+        """Test with empty relatedImages list."""
+        result = resolve_must_gather.resolve_must_gather(
+            ["ptp-must-gather"], []
+        )
+        assert result == ["ptp-must-gather"]
+
+    def test_non_list_input(self):
+        """Test that non-list input is returned as-is."""
+        result = resolve_must_gather.resolve_must_gather(
+            "not-a-list", SAMPLE_RELATED_IMAGES
+        )
+        assert result == "not-a-list"
+
+    def test_non_list_related_images(self):
+        """Test that non-list relatedImages returns input as-is."""
+        result = resolve_must_gather.resolve_must_gather(
+            ["ptp-must-gather"], "not-a-list"
+        )
+        assert result == ["ptp-must-gather"]
+
+    def test_non_string_entry(self):
+        """Test that non-string entries are kept as-is."""
+        result = resolve_must_gather.resolve_must_gather(
+            [42, None, "ptp-must-gather"], SAMPLE_RELATED_IMAGES
+        )
+        assert result == [
+            42,
+            None,
+            "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222",
+        ]
+
+    def test_first_match_wins(self):
+        """Test that the first matching relatedImage is used."""
+        related = [
+            {"name": "ptp-must-gather-rhel8", "image": "rhel8-image@sha256:111"},
+            {"name": "ptp-must-gather-rhel9", "image": "rhel9-image@sha256:222"},
+        ]
+        result = resolve_must_gather.resolve_must_gather(
+            ["ptp-must-gather"], related
+        )
+        # First match wins
+        assert result == ["rhel8-image@sha256:111"]
+
+    def test_fallback_registry_core_ocp_image(self):
+        """Test fallback registry for core OCP images not present in any CSV."""
+        result = resolve_must_gather.resolve_must_gather(
+            ["ose-must-gather"],
+            [],
+            "registry.redhat.io/openshift4",
+        )
+        assert result == ["registry.redhat.io/openshift4/ose-must-gather"]
+
+    def test_fallback_infers_rhel_suffix_from_operator(self):
+        """Test that fallback infers RHEL suffix from operator images.
+
+        When a must-gather short name (e.g. ptp-must-gather) is not in
+        CSV relatedImages, but the operator's own images contain a
+        matching keyword with a RHEL suffix, the fallback should use
+        that suffix.
+        """
+        related = [
+            {
+                "name": "ose-ptp-rhel9",
+                "image": "registry.redhat.io/openshift4/ose-ptp-rhel9@sha256:abc",
+            },
+            {
+                "name": "ose-ptp-rhel9-operator",
+                "image": "registry.redhat.io/openshift4/ose-ptp-rhel9-operator@sha256:def",
+            },
+        ]
+        result = resolve_must_gather.resolve_must_gather(
+            ["ptp-must-gather"],
+            related,
+            "registry.redhat.io/openshift4",
+        )
+        assert result == [
+            "registry.redhat.io/openshift4/ptp-must-gather-rhel9"
+        ]
+
+    def test_fallback_infers_rhel8_suffix(self):
+        """Test RHEL 8 suffix inference from operator images."""
+        related = [
+            {
+                "name": "linuxptp-daemon-rhel8",
+                "image": "registry.redhat.io/openshift4/linuxptp-daemon-rhel8@sha256:abc",
+            },
+        ]
+        result = resolve_must_gather.resolve_must_gather(
+            ["ptp-must-gather"],
+            related,
+            "registry.redhat.io/openshift4",
+        )
+        assert result == [
+            "registry.redhat.io/openshift4/ptp-must-gather-rhel8"
+        ]
+
+    def test_fallback_no_rhel_suffix_when_no_operator_match(self):
+        """Test fallback without RHEL suffix when no operator image matches."""
+        related = [
+            {
+                "name": "unrelated-operator",
+                "image": "registry.redhat.io/openshift4/unrelated-rhel9@sha256:abc",
+            },
+        ]
+        result = resolve_must_gather.resolve_must_gather(
+            ["ptp-must-gather"],
+            related,
+            "registry.redhat.io/openshift4",
+        )
+        assert result == ["registry.redhat.io/openshift4/ptp-must-gather"]
+
+    def test_keyword_matches_image_path(self):
+        """Test that a keyword matches the image path, not just the name."""
+        related = [
+            {
+                "name": "must_gather_image",
+                "image": "registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:aaa",
+            },
+            {
+                "name": "gitops-operator",
+                "image": "registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:bbb",
+            },
+        ]
+        result = resolve_must_gather.resolve_must_gather(
+            ["openshift-gitops"], related
+        )
+        assert result == [
+            "registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:aaa"
+        ]
+
+    def test_keyword_matches_acm_by_name(self):
+        """Test that 'acm' matches acm_must_gather in the name field."""
+        related = [
+            {
+                "name": "acm_must_gather",
+                "image": "registry.redhat.io/rhacm2/acm-must-gather-rhel9@sha256:aaa",
+            },
+            {
+                "name": "acm-operator",
+                "image": "registry.redhat.io/rhacm2/acm-operator@sha256:bbb",
+            },
+        ]
+        result = resolve_must_gather.resolve_must_gather(["acm"], related)
+        assert result == [
+            "registry.redhat.io/rhacm2/acm-must-gather-rhel9@sha256:aaa"
+        ]
+
+    def test_keyword_skips_non_must_gather(self):
+        """Test that a generic keyword doesn't match non-must-gather images."""
+        related = [
+            {
+                "name": "gitops-operator",
+                "image": "registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:bbb",
+            },
+        ]
+        result = resolve_must_gather.resolve_must_gather(
+            ["openshift-gitops"], related
+        )
+        assert result == ["openshift-gitops"]
+
+    def test_fallback_registry_empty_string(self):
+        """Test that empty fallback_registry keeps unresolved name as-is (backward compat)."""
+        result = resolve_must_gather.resolve_must_gather(
+            ["nonexistent-must-gather"],
+            [],
+            "",
+        )
+        assert result == ["nonexistent-must-gather"]
+
+    def test_fallback_registry_disabled(self):
+        """Test that omitting fallback_registry keeps unresolved name as-is (backward compat)."""
+        result = resolve_must_gather.resolve_must_gather(
+            ["nonexistent-must-gather"],
+            [],
+        )
+        assert result == ["nonexistent-must-gather"]
+
+
+class TestFilterModule:
+    def test_filter_module_exposes_filter(self):
+        """Test that FilterModule properly exposes the filter."""
+        fm = resolve_must_gather.FilterModule()
+        filters = fm.filters()
+        assert "resolve_must_gather" in filters
+        assert filters["resolve_must_gather"] == resolve_must_gather.resolve_must_gather
+
+    def test_filter_module_callable(self):
+        """Test that the filter can be called through FilterModule."""
+        fm = resolve_must_gather.FilterModule()
+        func = fm.filters()["resolve_must_gather"]
+        result = func(["ose-must-gather"], SAMPLE_RELATED_IMAGES)
+        assert result == [
+            "registry.redhat.io/openshift4/ose-must-gather@sha256:aaa111"
+        ]


### PR DESCRIPTION
## Summary

Add a new role and filter plugin that resolve version-independent must-gather image short names to their full registry references by querying ClusterServiceVersions on the target cluster.

The `resolve_must_gather_images` role and `resolve_must_gather` filter plugin support two resolution paths:

1. **CSV-based resolution**: short names (e.g. `ptp-must-gather`) are matched against installed operator CSV `relatedImages` and replaced with the correct digest-pinned reference.
2. **Fallback registry resolution**: core OCP images (e.g. `ose-must-gather`) are not shipped by any operator CSV and therefore never appear in `relatedImages`. A new `rmgi_fallback_registry` variable (default: `registry.redhat.io/openshift4`) prefixes such unresolved short names with the correct registry path, producing a valid image reference for disconnected environments.

**Disconnected mirroring fix:** `resolve_must_gather_images` must be called *before* the `mirror_images` role in disconnected setups. This fix has been applied in companion PRs:
- distributedci/dci-openshift-agent#101 (`plays/mirror-job-tools.yml` and `plays/acm-pre-run.yml`) — adds resolve step before mirroring with proper `when: dci_disconnected` guard
- distributedci/dci-openshift-app-agent#18 (`plays/pre-run.yml`)

## Problem

Pipeline files currently require digest-pinned must-gather image references that change with every OCP release or operator update, creating an ongoing maintenance burden.

Core OCP images such as `ose-must-gather` are part of the OCP release itself and are not shipped by any operator CSV. Without a fallback, the resolver kept the bare short name unchanged, causing `skopeo` to default to `docker.io/library/ose-must-gather` — which does not exist in disconnected environments.

## Solution

Instead of pinning full image references, pipeline authors can now use short names like `ose-must-gather` or `ptp-must-gather`. The new role queries the cluster's CSVs at runtime to resolve these to the correct versioned image. When a short name has no matching CSV entry, the fallback registry provides the full reference automatically.

### New components

- **Role**: `resolve_must_gather_images` — fetches CSVs from the cluster and resolves short names to full image references
- **Filter plugin**: `resolve_must_gather` — performs the matching logic with hyphen/underscore normalization and optional fallback registry
- **Tests**: integration and unit tests

### Compatibility

- Tested on Ansible 2.9+ / Python 3.6+
- Uses `json_query` instead of `map(attribute=..., default=...)` for older Ansible compatibility
- Normalizes hyphens/underscores to handle naming inconsistencies between CSV relatedImages and user-provided short names
- `rmgi_fallback_registry: ""` restores original behaviour (short name kept as-is)

### Design decisions

| Item | Decision |
|---|---|
| `json_query` usage | Kept intentionally — Ansible 2.9 compat |
| `noqa` on `- name:` line | Correct placement — ansible-lint does not recognize noqa on block scalar indicators |
| Variable name `rmgi_related_images` (no leading underscore) | Private underscore prefix is only valid for `register:` variables |
| `rmgi_fallback_registry` default | `registry.redhat.io/openshift4` — covers core OCP images; set to `""` to disable |
| RETURN docstring (no warning claim) | The code keeps unresolved short names as-is silently |

Test-Hints: no-check