### PR TITLE
Use bootstrapOSImage before 4.22

### DIFF
--- a/roles/installer/templates/install-config-virtualmedia.j2
+++ b/roles/installer/templates/install-config-virtualmedia.j2
@@ -92,7 +92,7 @@ platform:
 {% if externalMACAddress is defined %}
     externalMACAddress: {{ externalMACAddress }}
 {% endif %}
-{% if bootstraposimage is defined and bootstraposimage|length %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 22)) and (bootstraposimage is defined and bootstraposimage|length)) %}
     bootstrapOSImage: {{ bootstraposimage }}
 {% endif %}
 {% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 10)) and (clusterosimage is defined and clusterosimage|length)) %}

--- a/roles/installer/templates/install-config.j2
+++ b/roles/installer/templates/install-config.j2
@@ -85,7 +85,7 @@ platform:
     externalMACAddress: '{{ externalMACAddress }}'
 {% endif %}
 {% endif %}
-{% if bootstraposimage is defined and bootstraposimage|length %}
+{% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 22)) and (bootstraposimage is defined and bootstraposimage|length)) %}
     bootstrapOSImage: {{ bootstraposimage }}
 {% endif %}
 {% if (((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int < 10)) and (clusterosimage is defined and clusterosimage|length)) %}


### PR DESCRIPTION
##### SUMMARY

bootstrapOSImage is useless starting 4.22 and this could break the Cluster Baremetal Operator

- [x] 4.22 - https://www.distributed-ci.io/jobs/d9cfdcad-8ab4-4dac-9a3c-f66d31482ddd/jobStates
- [x] 5.0  - https://www.distributed-ci.io/jobs/06da0cc8-c6c5-4214-a2ac-73aace7d8e85/jobStates
