### PR TITLE
[kvr] Add hashed support to configurations in kvr

### DIFF
--- a/roles/kubevirt_redfish/defaults/main.yml
+++ b/roles/kubevirt_redfish/defaults/main.yml
@@ -13,6 +13,7 @@ kr_config_file: ""
 
 kr_vm_configs: []
 kr_vm_username: admin
+kr_hashed: true
 
 # Options: legacy, enhanced
 kr_system_id_convention: "legacy"

--- a/roles/kubevirt_redfish/meta/argument_specs.yml
+++ b/roles/kubevirt_redfish/meta/argument_specs.yml
@@ -95,6 +95,14 @@ argument_specs:
             required: true
             description: BMC password for Redfish authentication.
 
+      kr_hashed:
+        type: bool
+        required: false
+        default: true
+        description: >
+          Hash BMC passwords using bcrypt.
+          When false, passwords are stored in plaintext (legacy).
+
       kr_system_id_convention:
         type: str
         required: false

--- a/roles/kubevirt_redfish/tasks/config-vars.yml
+++ b/roles/kubevirt_redfish/tasks/config-vars.yml
@@ -36,7 +36,12 @@
       {% endfor %}
       {% for uname, udata in _users.items() %}
           - username: "{{ uname }}"
+      {% if not kr_hashed %}
             password: "{{ udata.password }}"
+      {% else %}
+            password:
+              hash: "{{ udata.password | password_hash('bcrypt') }}"
+      {% endif %}
             chassis:
       {% for c in udata.chassis %}
               - "{{ c }}"


### PR DESCRIPTION
##### SUMMARY

KubeVirt-Redfish (kvr) provides a new hashing functionality for authentication, adding this feature as default, but still allowing the old authentication for legacy reasons.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjNUMTY6MzI6NDB8ZTY0ZDEwYmNlMjcxMjRjNjc3ZTM3ZjJiYzE0Y2FiZmNkYjA5ZjcxNQ==
Gitleaks-Hash: e5a5b8ef70f4ec40589a6e14569f9b5d37266751ac72bc9fcffe1d7d1dab533c

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x]  ocp-4.23-spoke-ztp - https://www.distributed-ci.io/jobs/a72156ba-35f6-43fd-ab54-d8ad35c62d70/jobStates?sort=date

Test-hints: no-check