### PR TITLE
Update GHA (setup-python, ansible)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.12
 
@@ -100,7 +100,7 @@ jobs:
       matrix:
         ansible:
           - stable-2.9          # used by DCI on RHEL8
-          - stable-2.20         # latest stable version
+          - stable-2.21         # latest stable version
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -116,7 +116,7 @@ jobs:
           path: ${{ matrix.ansible }}/ansible_collections/redhatci/ocp
 
       - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.12
 


### PR DESCRIPTION
##### SUMMARY

Latest stable version of ansible is now 2.21
Update setup-python GHA

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjRUMTY6Mjg6MDZ8ZjEyNGFmMjQ2ZmM3Y2Q1Y2ZlODEyY2Y5ZjRiYzRlZjEyMDYxZGIyZg==
Gitleaks-Hash: cc2b03b13a54aac1d764d788275f67de687663192c4377a17b9edc6d00429da0

##### ISSUE TYPE

- Nominal change

##### Tests

Test-Hint: no-check