### PR TITLE
Enable TLS verification, supress credential logging

### DIFF
--- a/roles/jenkins_job_launcher/defaults/main.yml
+++ b/roles/jenkins_job_launcher/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 jjl_delay_seconds: 60
+jjl_validate_certs: true
 ...

--- a/roles/jenkins_job_launcher/tasks/main.yml
+++ b/roles/jenkins_job_launcher/tasks/main.yml
@@ -12,7 +12,7 @@
   ansible.builtin.uri:
     url: "{{ jjl_job_url }}/buildWithParameters/"
     method: POST
-    validate_certs: false
+    validate_certs: "{{ jjl_validate_certs }}"
     user: "{{ jjl_username }}"
     password: "{{ jjl_token }}"
     force_basic_auth: true
@@ -22,21 +22,23 @@
     headers:
       Content-Type: application/x-www-form-urlencoded
   register: queue_build_number
+  no_log: true
 
 - name: Get jenkins build number
   ansible.builtin.uri:
     url: '{{ queue_build_number.location }}/api/json'
     method: GET
-    validate_certs: false
+    validate_certs: "{{ jjl_validate_certs }}"
     user: "{{ jjl_username }}"
     password: "{{ jjl_token }}"
   register: jenkins_build_number
+  no_log: true
 
 - name: Wait for Jenkins status code
   ansible.builtin.uri:
     url: "{{ jenkins_build_number.json.executable.url }}/api/json"
     method: GET
-    validate_certs: false
+    validate_certs: "{{ jjl_validate_certs }}"
     user: "{{ jjl_username }}"
     password: "{{ jjl_token }}"
   register: in_progress
@@ -46,6 +48,7 @@
     - not in_progress.json.inProgress | bool
   retries: 200
   delay: "{{ jjl_delay_seconds }}" # total of 3hrs 20 minutes.
+  no_log: true
 
 - name: Fail if result is not SUCCESS
   ansible.builtin.fail:


### PR DESCRIPTION
##### SUMMARY

Default validate_certs to true via a new jjl_validate_certs variable, allowing callers with self-signed certs to opt out explicitly. Add no_log: true to all three uri tasks to prevent the Jenkins API token from appearing in Ansible output and log collectors.

Assited-by: Claude

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjRUMjE6NDE6MTV8OTFiZjQ3OTA4MDBiY2M4ZjU4NDVhNDMxZTA0ZjNhZTgxMGE3NmM2ZQ==
Gitleaks-Hash: 9121e58a51137ff258f8dd918ed004bb39ce91063d82eabb3465c0ffd7424e95

##### ISSUE TYPE

- Enhanced Feature

##### Tests

Test-Hint: no-check
