### PR TITLE
Remove hardcoded default credentials from some roles

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -7,8 +7,8 @@ registry_port: "{{ registry_port_container }}"
 registry_dir: /opt/registry
 install_config_appends_file: install-config-appends.yml
 registry_auth_file: registry-auths.json
-disconnected_registry_user: dummy
-disconnected_registry_password: dummy
+disconnected_registry_user: ""
+disconnected_registry_password: ""
 webserver_cache_image: "quay.io/fedora/httpd-24:latest"
 webserver_caching_port: "{{ webserver_caching_port_container }}"
 webserver_caching_port_container: 8080

--- a/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -1,4 +1,11 @@
 ---
+- name: Validate required registry credentials
+  ansible.builtin.assert:
+    that:
+      - disconnected_registry_user | length > 0
+      - disconnected_registry_password | length > 0
+    fail_msg: "disconnected_registry_user and disconnected_registry_password are required"
+
 - name: Find any old tmp dirs with OpenShift related binaries on registry host
   ansible.builtin.find:
     paths: /tmp
@@ -180,6 +187,7 @@
     - name: Generate htpasswd entry
       ansible.builtin.command: htpasswd -bBn {{ disconnected_registry_user }} {{ disconnected_registry_password }}
       register: htpass_entry
+      no_log: true
 
     - name: Write htpasswd file
       ansible.builtin.copy:
@@ -194,6 +202,7 @@
     - name: Set disconnected_auth
       ansible.builtin.set_fact:
         disconnected_registry_up: "{{ disconnected_registry_user }}:{{ disconnected_registry_password }}"
+      no_log: true
 
     - name: Create registry auth for pullsecret
       ansible.builtin.set_fact:

--- a/roles/setup_minio/defaults/main.yml
+++ b/roles/setup_minio/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 sm_claim_size: 10Gi
 sm_namespace: minio
-sm_access_key_id: minioadmin
-sm_access_key_secret: minioadmin
+sm_access_key_id: ""
+sm_access_key_secret: ""
 sm_bucket_name: minio
 sm_action: install
 sm_minio_image: quay.io/minio/minio

--- a/roles/setup_minio/tasks/install.yml
+++ b/roles/setup_minio/tasks/install.yml
@@ -1,4 +1,13 @@
 ---
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - sm_storage_class is defined
+      - sm_storage_class | trim | length > 0
+      - sm_access_key_id | trim | length > 0
+      - sm_access_key_secret | trim | length > 0
+    fail_msg: "sm_storage_class, sm_access_key_id, and sm_access_key_secret are required"
+
 - name: Create namespace for Minio
   kubernetes.core.k8s:
     definition:

--- a/roles/setup_minio/tasks/main.yml
+++ b/roles/setup_minio/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-- name: Validate_ that a storageclass is provided
-  ansible.builtin.assert:
-    that:
-      - sm_storage_class is defined
-    fail_msg: "A storage classname is required"
-
 - name: Create Minio deployment
   ansible.builtin.include_tasks: install.yml
   when:

--- a/roles/setup_netobserv_stack/defaults/main.yml
+++ b/roles/setup_netobserv_stack/defaults/main.yml
@@ -15,8 +15,8 @@ setup_netobserv_stack_console_limits_memory: 100Mi
 setup_netobserv_stack_console_cpu: 100m
 setup_netobserv_stack_console_memory: 50Mi
 setup_netobserv_stack_loki_tls_insecure_skip_verify: true
-setup_netobserv_stack_access_key_id: minioadmin
-setup_netobserv_stack_access_key_secret: minioadmin
+setup_netobserv_stack_access_key_id: ""
+setup_netobserv_stack_access_key_secret: ""
 setup_netobserv_stack_bucket: network
 setup_netobserv_stack_endpoint: http://minio-service.minio:9000
 setup_netobserv_stack_region: us-east-1

--- a/roles/setup_netobserv_stack/tasks/validation.yml
+++ b/roles/setup_netobserv_stack/tasks/validation.yml
@@ -1,4 +1,11 @@
 ---
+- name: Validate required credentials
+  ansible.builtin.assert:
+    that:
+      - setup_netobserv_stack_access_key_id | length > 0
+      - setup_netobserv_stack_access_key_secret | length > 0
+    fail_msg: "setup_netobserv_stack_access_key_id and setup_netobserv_stack_access_key_secret are required"
+
 - name: Check for config file
   ansible.builtin.stat:
     path: "{{ setup_netobserv_stack_conf_file }}"

--- a/roles/vbmc/defaults/main.yml
+++ b/roles/vbmc/defaults/main.yml
@@ -1,6 +1,6 @@
 # choice from hypervisor or undercloud
-vbmc_user: "root"
-vbmc_pass: "password"
+vbmc_user: ""
+vbmc_pass: ""
 vbmc_home: "/root"
 vbmc_host: "hypervisor"
 vbmc_start_port: 6230

--- a/roles/vbmc/tasks/main.yml
+++ b/roles/vbmc/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Validate required credentials
+  ansible.builtin.assert:
+    that:
+      - vbmc_user | length > 0
+      - vbmc_pass | length > 0
+    fail_msg: "vbmc_user and vbmc_pass are required"
+
 - name: Install hook
   when: hook_action == 'install'
   become: true


### PR DESCRIPTION
##### SUMMARY

Replace well-known default passwords from setup_minio, netobserv, vbmc and installer roles.
Add assertions that require callers to supply their own credentials.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjRUMjI6MjY6NDB8ZWNlMWNiYjA5MGMyNzVmNTMzNTI4ZDUzZmIxOThlNGFmMWViODE3Ng==
Gitleaks-Hash: 3b1a56bed3f3d1f44cdcc1059487dda3228d040a8d20240a6109a22e9f04ec01

##### ISSUE TYPE

- Nominal change

##### Tests

- [ ] TestBos2: virt - <JobURL>

---

TestBos2: virt