### PR TITLE
mirror_catalog | update condition to set digest in catalog

### DIFF
--- a/roles/mirror_catalog/tasks/main.yml
+++ b/roles/mirror_catalog/tasks/main.yml
@@ -12,7 +12,7 @@
     mc_catalog_digest: "{{ mc_catalog }}"
 
 - name: Set Digest in catalog
-  when: not mc_catalog | regex_search('@sha256sum:')
+  when: not mc_catalog | regex_search('@sha256(sum)?:')
   block:
     - name: Get catalog Digest
       ansible.builtin.shell:


### PR DESCRIPTION
##### SUMMARY

With the current condition, cases like [this](https://www.distributed-ci.io/jobs/e8c7a993-fd85-48de-bdd1-f08e63072f38/jobStates?sort=date&task=0ff8d0f9-5c4a-488e-bac6-2e6c5f61a255), where the catalog already includes the digest with `@sha256:...`, are again calculating the digest and appending it to the catalog, resulting in an [incorrect](https://www.distributed-ci.io/jobs/e8c7a993-fd85-48de-bdd1-f08e63072f38/jobStates?sort=date&task=46f66cad-6e1b-4779-bc86-88d8828e0548) format, such as `@sha256@sha256:...` 

Setting `sum` keyword as optional, so that we consider we have a digest for both `@sha256sum:` and `@sha256:` cases

##### ISSUE TYPE

- Bug

##### Tests

- [x] Correctly skipping the digest retrieval task if the image already has a digest: https://www.distributed-ci.io/jobs/fba2cfcd-2802-4c9f-a186-ff2395b6f2c4/jobStates?sort=date&task=81ffdb59-dc13-4849-b3f9-a2dc6b355a43

Test-Hints: no-check