### PR TITLE
example-cnf | Improve log gathering of TRexApp

### DIFF
--- a/roles/example_cnf_deploy/scripts/get-example-cnf-results.sh
+++ b/roles/example_cnf_deploy/scripts/get-example-cnf-results.sh
@@ -72,12 +72,8 @@ echo
 
 echo "> App"
 echo
-INTERMEDIATE_FILE_NAME=trexapp_logs.txt
-$OC_BINARY logs -n "$APP_NAMESPACE" "$TREXAPP_POD" | tail -n60 > "$INTERMEDIATE_FILE_NAME"
-START_LINE=$(cat -n "$INTERMEDIATE_FILE_NAME" | grep "Packets lost from 0 to 1" | awk '{print $1}')
-## This is the only command that prints something
-tail -n+"$START_LINE" $INTERMEDIATE_FILE_NAME
-rm $INTERMEDIATE_FILE_NAME
+$OC_BINARY logs -n "$APP_NAMESPACE" "$TREXAPP_POD" \
+    | grep -oE '(Packets lost from|Total packets lost).*'
 
 echo
 echo


### PR DESCRIPTION
##### SUMMARY

Right now, there are cases like [this one](https://www.distributed-ci.io/files/d5be823a-e918-4faa-9326-b701caf648d1) where TRexApp results are not displayed in the example-cnf summary results because the filter we currently use is not enough to reach the line where the results are showed.

Changing the filter to use `grep -oE` instead.

##### ISSUE TYPE

- Bug

##### Tests

- [x] Updated log gathering: https://www.distributed-ci.io/files/fa30373b-a40a-4d25-8ac6-9d1bfb604431

Test-Hints: no-check