### PR TITLE
Fix preflight-release workflow authentication for git push

### DIFF
--- a/.github/workflows/preflight-release.yml
+++ b/.github/workflows/preflight-release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          persist-credentials: false
+          token: ${{ secrets.DCIBOT_TOKEN }}
 
       - name: Get Preflight latest release
         id: preflight_latest


### PR DESCRIPTION
##### SUMMARY

Use DCIBOT_TOKEN via the checkout action's token parameter to restore git push credentials, broken in PR #972. Since Jul 21st: https://github.com/redhatci/ansible-collection-redhatci-ocp/actions/workflows/preflight-release.yml

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjlUMTY6NTg6NTZ8ZTliZDRkMzQ0YmMxM2MyZTc2MDdlZDVlMmQ2NjcxMmQ3YTg4YjVjNQ==
Gitleaks-Hash: 0111b728408fe9943516a7975331bccd0a2eb4c0818d33b05d5069b9fa61d855

##### ISSUE TYPE

- Bug

##### Tests

Test-Hint: no-check