### PR TITLE
Add tls validation variable in vendor roles

### DIFF
--- a/roles/vendors/hpe/defaults/main.yml
+++ b/roles/vendors/hpe/defaults/main.yml
@@ -3,3 +3,4 @@ boot_iso_url: "{{ discovery_iso_server }}/{{ discovery_iso_name }}"
 bmc_address: "{{ hostvars[target_host]['bmc_address'] }}"
 bmc_user: "{{ hostvars[target_host]['bmc_user'] }}"
 bmc_password: "{{ hostvars[target_host]['bmc_password'] }}"
+bmc_validate_certs: false

--- a/roles/vendors/hpe/tasks/disk.yml
+++ b/roles/vendors/hpe/tasks/disk.yml
@@ -42,5 +42,5 @@
     body: '{"ResetType": "ForceRestart"}'
     body_format: json
     force_basic_auth: true
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true

--- a/roles/vendors/kvm/defaults/main.yml
+++ b/roles/vendors/kvm/defaults/main.yml
@@ -5,5 +5,6 @@ bmc_address: "{{ hostvars[target_host]['bmc_address'] }}"
 base_bmc_address: "{{ secure_sushy_tools | bool | ternary('https', 'http') }}://{{ bmc_address }}"
 bmc_user: "{{ hostvars[target_host]['bmc_user'] | default(omit) }}"
 bmc_password: "{{ hostvars[target_host]['bmc_password'] | default(omit) }}"
+bmc_validate_certs: false
 vm_node_prefix: "{{ cluster_name }}_"
 vm_name: "{{ target_host.startswith(vm_node_prefix) | ternary(target_host, (vm_node_prefix + target_host)) }}"

--- a/roles/vendors/kvm/tasks/disk.yml
+++ b/roles/vendors/kvm/tasks/disk.yml
@@ -17,7 +17,7 @@
     body: { "ResetType": "ForceOff" }
     status_code: [200, 204]
     force_basic_auth: false
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_poweroff
   failed_when: false
@@ -31,7 +31,7 @@
     body_format: json
     body: {}
     status_code: [200, 204]
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_reply
   failed_when: false
@@ -54,7 +54,7 @@
       }
     status_code: [200, 204]
     force_basic_auth: false
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_reply
 
@@ -68,6 +68,6 @@
     body: { "ResetType": "ForceOn" }
     status_code: [200, 204]
     force_basic_auth: false
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_poweron

--- a/roles/vendors/kvm/tasks/eject.yml
+++ b/roles/vendors/kvm/tasks/eject.yml
@@ -11,7 +11,7 @@
     body_format: json
     body: {}
     status_code: [200, 204]
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_reply
   ignore_errors: true

--- a/roles/vendors/kvm/tasks/get-sm.yml
+++ b/roles/vendors/kvm/tasks/get-sm.yml
@@ -6,7 +6,7 @@
     password: "{{ bmc_password }}"
     method: GET
     status_code: [200, 201]
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_reply
 

--- a/roles/vendors/kvm/tasks/iso.yml
+++ b/roles/vendors/kvm/tasks/iso.yml
@@ -16,7 +16,7 @@
     body: { "ResetType": "ForceOff" }
     status_code: [200, 204]
     force_basic_auth: false
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_poweroff
   failed_when: false
@@ -34,7 +34,7 @@
     body: { "Image": "{{ boot_iso_url }}", "Inserted": true }
     status_code: [200, 204]
     force_basic_auth: false
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
     timeout: 120
   register: redfish_reply
@@ -54,7 +54,7 @@
     password: "{{ bmc_password }}"
     method: GET
     status_code: [200, 201]
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_reply
   when: ansible_verbosity >= 1
@@ -82,7 +82,7 @@
       }
     status_code: [200, 204]
     force_basic_auth: false
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_reply
 
@@ -98,7 +98,7 @@
     password: "{{ bmc_password }}"
     method: GET
     status_code: [200, 201]
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_reply
 
@@ -117,7 +117,7 @@
     body: { "ResetType": "ForceRestart" }
     status_code: [200, 204]
     force_basic_auth: false
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_restart
   when: redfish_reply.json.PowerState == "On"
@@ -133,7 +133,7 @@
     # redfish specification: https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.19.0.pdf
     status_code: [200, 201, 202, 204]
     force_basic_auth: false
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_poweron
   when: redfish_reply.json.PowerState == "Off"

--- a/roles/vendors/lenovo/defaults/main.yml
+++ b/roles/vendors/lenovo/defaults/main.yml
@@ -3,3 +3,4 @@ boot_iso_url: "{{ discovery_iso_server }}/{{ discovery_iso_name }}"
 bmc_address: "{{ hostvars[target_host]['bmc_address'] }}"
 bmc_user: "{{ hostvars[target_host]['bmc_user'] }}"
 bmc_password: "{{ hostvars[target_host]['bmc_password'] }}"
+bmc_validate_certs: false

--- a/roles/vendors/lenovo/tasks/disk.yml
+++ b/roles/vendors/lenovo/tasks/disk.yml
@@ -12,7 +12,7 @@
         body: {"Image": null, "Inserted": false}
         status_code: [200, 204]
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
       register: redfish_reply
 
@@ -33,7 +33,7 @@
         }
         status_code: [200, 204]
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
       register: redfish_reply
 
@@ -47,6 +47,6 @@
         body: {"ResetType": "ForceRestart"}
         status_code: [200, 204]
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
       register: redfish_reply

--- a/roles/vendors/lenovo/tasks/eject.yml
+++ b/roles/vendors/lenovo/tasks/eject.yml
@@ -9,7 +9,7 @@
     body: {"Image": null, "Inserted": false}
     status_code: [200, 204]
     force_basic_auth: true
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
   register: redfish_reply
 

--- a/roles/vendors/lenovo/tasks/iso.yml
+++ b/roles/vendors/lenovo/tasks/iso.yml
@@ -12,7 +12,7 @@
         body: {"ResetType": "On"}
         status_code: [200, 204]
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
       register: redfish_reply
 
@@ -34,7 +34,7 @@
         body: {"Image":"{{ boot_iso_url }}", "Inserted": true}
         status_code: [200, 204]
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
       register: redfish_reply
 
@@ -60,7 +60,7 @@
         }
         status_code: [200, 204]
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
       register: redfish_reply
 
@@ -86,7 +86,7 @@
         }
         status_code: [200, 204]
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
       register: redfish_reply
 
@@ -105,7 +105,7 @@
         body: {"ResetType": "ForceRestart"}
         status_code: [200, 204]
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
       register: redfish_reply
 

--- a/roles/vendors/supermicro/defaults/main.yml
+++ b/roles/vendors/supermicro/defaults/main.yml
@@ -3,3 +3,4 @@ boot_iso_url: "{{ discovery_iso_server }}/{{ discovery_iso_name }}"
 bmc_address: "{{ hostvars[target_host]['bmc_address'] }}"
 bmc_user: "{{ hostvars[target_host]['bmc_user'] }}"
 bmc_password: "{{ hostvars[target_host]['bmc_password'] }}"
+bmc_validate_certs: false

--- a/roles/vendors/supermicro/tasks/disk.yml
+++ b/roles/vendors/supermicro/tasks/disk.yml
@@ -17,7 +17,7 @@
             user: "{{ bmc_user }}"
             password: "{{ bmc_password }}"
             method: GET
-            validate_certs: false
+            validate_certs: "{{ bmc_validate_certs }}"
             force_basic_auth: true
             return_content: true
           register: cd1_contents
@@ -33,7 +33,7 @@
               Accept: application/json
             body: {}
             body_format: json
-            validate_certs: false
+            validate_certs: "{{ bmc_validate_certs }}"
             force_basic_auth: true
             return_content: true
           when: cd1_contents.json.Inserted | bool
@@ -49,7 +49,7 @@
               Accept: application/json
             body: {}
             body_format: json
-            validate_certs: false
+            validate_certs: "{{ bmc_validate_certs }}"
             force_basic_auth: true
             return_content: true
 
@@ -65,7 +65,7 @@
         body: '{"Boot":{"BootSourceOverrideEnabled":"Continuous","BootSourceOverrideTarget":"Hdd"}}' # Despite what the docs say HDD is not the correct value
         body_format: json
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true
 
     - name: Restart the SuperMicro
@@ -80,5 +80,5 @@
         body: '{"ResetType": "ForceRestart"}'
         body_format: json
         force_basic_auth: true
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         return_content: true

--- a/roles/vendors/supermicro/tasks/eject.yml
+++ b/roles/vendors/supermicro/tasks/eject.yml
@@ -5,7 +5,7 @@
     user: "{{ bmc_user }}"
     password: "{{ bmc_password }}"
     method: GET
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     force_basic_auth: true
     return_content: true
   register: cd1_contents
@@ -22,7 +22,7 @@
       Accept: application/json
     body: {}
     body_format: json
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     force_basic_auth: true
     return_content: true
   when:
@@ -40,7 +40,7 @@
       Accept: application/json
     body: {}
     body_format: json
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     force_basic_auth: true
     return_content: true
   when:

--- a/roles/vendors/supermicro/tasks/iso.yml
+++ b/roles/vendors/supermicro/tasks/iso.yml
@@ -31,7 +31,7 @@
     body: '{"Boot":{"BootSourceOverrideEnabled":"Once","BootSourceOverrideTarget": "{{ boot_source_override_target }}"}}'
     body_format: json
     force_basic_auth: true
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true
 
 - name: Restart the SuperMicro
@@ -46,5 +46,5 @@
     body: '{"ResetType": "ForceRestart"}'
     body_format: json
     force_basic_auth: true
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     return_content: true

--- a/roles/vendors/supermicro/tasks/mount.yml
+++ b/roles/vendors/supermicro/tasks/mount.yml
@@ -5,7 +5,7 @@
     user: "{{ bmc_user }}"
     password: "{{ bmc_password }}"
     method: GET
-    validate_certs: false
+    validate_certs: "{{ bmc_validate_certs }}"
     force_basic_auth: true
     return_content: true
   register: cd1_contents
@@ -26,7 +26,7 @@
           Accept: application/json
         body: {"Image": "{{ boot_iso_url }}"}
         body_format: json
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         force_basic_auth: true
         return_content: true
         status_code: 202
@@ -50,7 +50,7 @@
           Accept: application/json
         body: {"Image": "{{ boot_iso_url }}"}
         body_format: json
-        validate_certs: false
+        validate_certs: "{{ bmc_validate_certs }}"
         force_basic_auth: true
         return_content: true
         status_code: 200


### PR DESCRIPTION
##### SUMMARY

Replace hardcoded validate_certs: false with a configurable bmc_validate_certs variable across hpe, kvm, lenovo and supermicro vendor roles. Defaults to false to preserve current behavior for labs with self-signed BMC certificates.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjlUMTc6Mzk6MDN8NzdjZjdlMTZjOTdjOGUwZTgwMGQ1ZWNjOTFiYTFiNDgwNzcwM2ExOA==
Gitleaks-Hash: 8fd8b581e5ce6b39a7f392e5ab4cfa0b48365c7c5c7a32e560457c7cd3116725

##### ISSUE TYPE

- Enhanced Feature

##### Tests


- [x] TestBos2: abi - https://www.distributed-ci.io/jobs/0d5a0220-cd11-4eb2-9be7-23d096e75cb7

---

Test-hints: no-check