### PR TITLE
Pass htpasswd passwords via stdin and suppress credential logging

### DIFF
--- a/roles/installer/tasks/15_disconnected_registry_create.yml
+++ b/roles/installer/tasks/15_disconnected_registry_create.yml
@@ -185,7 +185,9 @@
       become: true
 
     - name: Generate htpasswd entry
-      ansible.builtin.command: htpasswd -bBn {{ disconnected_registry_user }} {{ disconnected_registry_password }}
+      ansible.builtin.command:
+        cmd: htpasswd -iBn {{ disconnected_registry_user }}
+        stdin: "{{ disconnected_registry_password }}"
       register: htpass_entry
       no_log: true
 

--- a/roles/setup_mirror_registry/tasks/setup_registry.yml
+++ b/roles/setup_mirror_registry/tasks/setup_registry.yml
@@ -32,9 +32,12 @@
         - "{{ registry_dir_data }}"
 
 - name: Generate htpasswd entry
-  ansible.builtin.command: htpasswd -bBn {{ disconnected_registry_user }} {{ disconnected_registry_password }}
+  ansible.builtin.command:
+    cmd: htpasswd -iBn {{ disconnected_registry_user }}
+    stdin: "{{ disconnected_registry_password }}"
   register: htpass_entry
   changed_when: false
+  no_log: true
 
 - name: Write htpasswd file
   ansible.builtin.copy:

--- a/roles/setup_sushy_tools/tasks/main.yml
+++ b/roles/setup_sushy_tools/tasks/main.yml
@@ -55,9 +55,12 @@
           no_log: true
 
         - name: Generate htpasswd entry
-          ansible.builtin.command: htpasswd -bBn {{ item.user }} {{ item.password }}
+          ansible.builtin.command:
+            cmd: htpasswd -iBn {{ item.user }}
+            stdin: "{{ item.password }}"
           register: htpass_entries
           changed_when: false
+          no_log: true
           loop: "{{ user_password_combinations | dict2items(key_name='user', value_name='password') }}"
 
         - name: Write htpasswd file


### PR DESCRIPTION
##### SUMMARY

Switch htpasswd from -b (password on argv) to -i (password on stdin) in installer, setup_mirror_registry and setup_sushy_tools roles. Add no_log: true where missing to prevent credentials from appearing in Ansible output and log collectors.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjlUMTc6NDk6MTR8Y2E0YjE5M2ZlYmY3ODJhOWZmMmVmZWRkMmQ1Mjg0ZGU0ODZlNTY5Zg==
Gitleaks-Hash: de5aeea7ff8d826afb77d4776fae6597858f8a4686aeaa0d67bbb080810c9cb6

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/792bbc9d-a1ba-4b40-b558-008b329eed66/jobStates

---

Test-hints: no-check
