### PR TITLE
Restrict pull-secret file permissions to owner-only read/write

### DIFF
--- a/roles/installer/tasks/20_extract_installer.yml
+++ b/roles/installer/tasks/20_extract_installer.yml
@@ -16,7 +16,7 @@
     dest: "{{ pullsecret_file }}"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: '0644'
+    mode: '0600'
     force: true
   tags:
     - pullsecret
@@ -53,7 +53,7 @@
     dest: "{{ dir }}/pull-secret.txt"
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
-    mode: "0755"
+    mode: "0600"
   become: true
   when:
     - registry_creation|bool


### PR DESCRIPTION
##### SUMMARY

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjlUMTk6MDI6NTB8ZjE3MDI2NjJkZjAyMGNlM2M4YjBlNzUyZmM3MDRkN2U0MGQxOWE4OQ==
Gitleaks-Hash: fd0bf905a725dccdf18c9d1a0d52cfa7a5dd7e3842816021b90334b79522863d

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/ed36288c-166d-4a6d-84fa-e1af5a7a8f35

---

Test-hints: no-check