### PR TITLE
Pin default container images

### DIFF
--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -9,7 +9,7 @@ install_config_appends_file: install-config-appends.yml
 registry_auth_file: registry-auths.json
 disconnected_registry_user: ""
 disconnected_registry_password: ""
-webserver_cache_image: "quay.io/fedora/httpd-24:latest"
+webserver_cache_image: "quay.io/fedora/httpd-24@sha256:23707ed98ca972e949ecd3da5bc47c7bd9036e5b1aedb5f404a42f819c73e948"  # tag: latest, date: 20260729
 webserver_caching_port: "{{ webserver_caching_port_container }}"
 webserver_caching_port_container: 8080
 registry_creation: false

--- a/roles/nfs_external_storage/defaults/main.yml
+++ b/roles/nfs_external_storage/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
 nes_namespace: openshift-nfs-storage
-nes_provisioner_image: "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2"
+# tag: v4.0.2, date: 20260729
+nes_provisioner_image: >-
+  registry.k8s.io/sig-storage/nfs-subdir-external-provisioner@sha256:63d5e04551ec8b5aae83b6f35938ca5ddc50a88d85492d9731810c31591fa4c9
 ...

--- a/roles/setup_http_store/defaults/main.yml
+++ b/roles/setup_http_store/defaults/main.yml
@@ -4,7 +4,7 @@ http_dir: /opt/http_store
 http_data_dir: "{{ http_dir }}/data"
 http_port: 80
 # Note if you change this you might have to change the env vars and volumes for podman task
-container_image: quay.io/fedora/httpd-24:latest
+container_image: quay.io/fedora/httpd-24@sha256:23707ed98ca972e949ecd3da5bc47c7bd9036e5b1aedb5f404a42f819c73e948  # tag: latest, date: 20260729
 file_owner: "{{ ansible_env.USER }}"
 file_group: "{{ file_owner }}"
 http_store_ephemeral: false

--- a/roles/sno_installer/defaults/main.yml
+++ b/roles/sno_installer/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for sno_installer
 cache_enabled: true
 si_cache_dir: "/opt/cache"
-webserver_caching_image: "quay.io/fedora/httpd-24:latest"
+webserver_caching_image: "quay.io/fedora/httpd-24@sha256:23707ed98ca972e949ecd3da5bc47c7bd9036e5b1aedb5f404a42f819c73e948"  # tag: latest, date: 20260729
 webserver_caching_port_container: 8080
 webserver_caching_port: "{{ webserver_caching_port_container }}"
 url_passed: false


### PR DESCRIPTION
##### SUMMARY

Stop using tag to ensure we are consuming the expected images.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDctMjlUMjE6MjQ6MjJ8MzU2MDkwNTQ2MGY4OTZkZTFlYjY1NzJmOWJhYzVkM2Y1NWNlNTMxMw==
Gitleaks-Hash: 7f836f737b6ad900582b2a0fb8d34fce16427d8b492edb2775792adfd702dc2b

##### ISSUE TYPE

- Nominal change

##### Tests

- [x] TestBos2: virt - https://www.distributed-ci.io/jobs/f609503f-f2bb-4b00-a25b-a0d3986fe4d9
- [x] TestBos2Sno: sno - https://www.distributed-ci.io/jobs/3f32f6f5-3ccc-48fb-8b87-2d9061d10b22
- [x] Testvcp: ocp-4.22-vanilla openshift-vanilla:ansible_extravars=dci_force_mirroring:true - https://www.distributed-ci.io/jobs/8dd9082d-e20d-4fe2-a45d-68b6fd08e930

---

Test-hints: no-check
