### PR TITLE
Allow the mirror_images role to generate mirroring manifests

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        4.1.EPOCH
+Version:        4.2.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Wed Aug  5 2026 Beto Rdz <josearod@redhat.com> - 4.2.EPOCH-VERS
+- Add image source generation capabilities to mirror_images role
+
 * Mon Aug  3 2026 Tony Garcia <tonyg@redhat.com> - 4.1.EPOCH-VERS
 - Remove DCI component creation from preflight role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 4.1.0
+version: 4.2.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/mirror_images/README.md
+++ b/roles/mirror_images/README.md
@@ -1,23 +1,49 @@
 # Mirror Images
 
-Mirrors images from one repository to another.
+Mirrors images from one repository to another and generates an Image Source
+manifest in a temporary file: `ImageContentSourcePolicy` (`icsp`), or both
+`ImageDigestMirrorSet` and `ImageTagMirrorSet` (`idms`, for OCP 4.14+).
+
+Mirroring always copies the listed images regardless of `mi_is_type`. The
+generated Image Source is optional for callers that only need the mirror.
+
+**ICSP and tags:** `icsp` emits `repositoryDigestMirrors` only. That remaps
+digest pulls (`repo@sha256:...`), not `registry/repo:tag` pulls. If you apply
+the ICSP and workloads still pull by tag, those pulls will not use the mirror.
+Use digest-pinned `mi_images`, or set `mi_is_type=idms` (IDMS + ITMS) when tag
+remapping is required.
 
 ## Variables
 
-| Variable         | Default    | Required | Description
-| ---------------- | ---------- | -------- | -----------
-| mi_images        | undefined  | Yes      | List of images to mirror
-| mi_registry      | undefined  | Yes      | The registry target where to copy the images
-| mi_authfile      | undefined  | No       | An authfile with permissions to pull/push images to/from registries
-| mi_dst_authfile  | undefined  | No       | An authfile with permissions to push the target images
-| mi_options       | undefined  | No       | skopeo options while copying the images
-| mi_src_authfile  | undefined  | No       | An authfile with permissions to pull the source images
-| mi_dst_org       | ""         | No       | The organization target where to copy the images
-| mi_random_tag    | false      | No       | Set a random tag on the target registry
+| Variable         | Default            | Required | Description
+| ---------------- | ------------------ | -------- | -----------
+| mi_images        | undefined          | Yes      | List of images to mirror (tags or digests)
+| mi_registry      | undefined          | Yes      | The registry target where to copy the images
+| mi_authfile      | undefined          | No       | An authfile with permissions to pull/push images to/from registries
+| mi_dst_authfile  | undefined          | No       | An authfile with permissions to push the target images
+| mi_options       | undefined          | No       | skopeo options while copying the images
+| mi_src_authfile  | undefined          | No       | An authfile with permissions to pull the source images
+| mi_dst_org       | ""                 | No       | The organization target where to copy the images
+| mi_random_tag    | false              | No       | Copy to a random destination tag to avoid overwriting existing mirror content
+| mi_is_type       | `icsp`             | No       | Image Source file type: `icsp` (ImageContentSourcePolicy) or `idms` (ImageDigestMirrorSet + ImageTagMirrorSet). See note above about ICSP and tags.
+| mi_is_name       | auto-generated     | No       | Metadata name for the Image Source resource. Default: `mirrored-images-<8-char-random>` each role run. Set explicitly to pin the name across runs.
 
 ## Requirements
 
 - [Skopeo](https://github.com/containers/skopeo/blob/main/install.md)
+
+## Outputs
+
+The role always generates an Image Source manifest and copies it into a temporary file with an `imagesource_mirror_images.` prefix. When `mi_is_type` is `idms`, the file contains an IDMS and, unless `mi_random_tag` is true, an ITMS.
+
+- `mi_is_file.path`: Path to the generated Image Source file.
+- `mi_image_mirrors`: List of mappings used to build the manifest:
+  - `source`: source repository
+  - `mirror`: mirror repository
+  - `target`: full destination reference that was copied (includes tag)
+  - `tag_preserved`: `false` when `mi_random_tag` rewrote the destination tag
+
+The Image Source file can be applied directly to a running cluster.
 
 ## Usage example
 
@@ -28,6 +54,7 @@ Mirrors images from one repository to another.
   ansible.builtin.include_role:
     name: redhatci.ocp.mirror_images
   vars:
+    mi_is_type: "idms"
     mi_images:
       -  quay.io/centos/centos:stream10-development
     mi_registry: registry.example.com
@@ -50,5 +77,24 @@ Mirrors images from one repository to another.
     mi_src_authfile: /path/to/pullsecret-to-pull-from-private-image
     mi_options: "--preserve-digests"
     mi_dst_org: "some/path"
+    mi_is_type: "idms"
 ```
+
 The use of `mi_dst_org`: "some/path" will copy the new images into a new repository organization. For instance if the source image is quay.io/centos/centos:stream9, the destination will be my.registry.local:4443/some/path/centos:stream9
+
+* Apply the generated Image Source manifest
+
+```yaml
+- name: Mirror images
+  ansible.builtin.include_role:
+    name: redhatci.ocp.mirror_images
+  vars:
+    mi_images:
+      - quay.io/example/image@sha256:abc123
+    mi_registry: my.registry.local:4443
+    mi_is_type: "idms"
+
+- name: Apply Image Source file
+  kubernetes.core.k8s:
+    definition: "{{ lookup('file', mi_is_file.path) | from_yaml_all | list }}"
+```

--- a/roles/mirror_images/README.md
+++ b/roles/mirror_images/README.md
@@ -25,7 +25,7 @@ remapping is required.
 | mi_src_authfile  | undefined          | No       | An authfile with permissions to pull the source images
 | mi_dst_org       | ""                 | No       | The organization target where to copy the images
 | mi_random_tag    | false              | No       | Copy to a random destination tag to avoid overwriting existing mirror content
-| mi_is_type       | `icsp`             | No       | Image Source file type: `icsp` (ImageContentSourcePolicy) or `idms` (ImageDigestMirrorSet + ImageTagMirrorSet). See note above about ICSP and tags.
+| mi_is_type       | `idms`             | No       | Image Source file type: `icsp` (ImageContentSourcePolicy) or `idms` (ImageDigestMirrorSet + ImageTagMirrorSet). See note above about ICSP and tags.
 | mi_is_name       | auto-generated     | No       | Metadata name for the Image Source resource. Default: `mirrored-images-<8-char-random>` each role run. Set explicitly to pin the name across runs.
 
 ## Requirements

--- a/roles/mirror_images/defaults/main.yml
+++ b/roles/mirror_images/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 mi_dst_org: ""
 mi_random_tag: false
-...
+mi_is_type: "idms"
+mi_is_name: ""

--- a/roles/mirror_images/tasks/generate-image-source.yml
+++ b/roles/mirror_images/tasks/generate-image-source.yml
@@ -1,0 +1,43 @@
+---
+- name: Group mirrored images by source repository
+  ansible.builtin.set_fact:
+    mi_grouped_mirrors: >-
+      {{
+        mi_grouped_mirrors | default([]) + [{
+          'source': item,
+          'mirrors': mi_image_mirrors
+            | selectattr('source', 'equalto', item)
+            | map(attribute='mirror')
+            | list
+            | unique
+            | list
+        }]
+      }}
+  loop: "{{ mi_image_mirrors | map(attribute='source') | list | unique | list }}"
+
+- name: Create temporary Image Source file
+  ansible.builtin.tempfile:
+    state: file
+    prefix: "imagesource_mirror_images."
+  register: _mi_is_file
+
+- name: Write Image Source manifest
+  vars:
+    _mi_is_name: >-
+      {{
+        mi_is_name
+        if (mi_is_name | length > 0)
+        else (
+          'mirrored-images-' ~ (
+            lookup('community.general.random_string', length=8, special=false, upper=false) | lower
+          )
+        )
+      }}
+  ansible.builtin.template:
+    src: image-source.yaml.j2
+    dest: "{{ _mi_is_file.path }}"
+    mode: "0644"
+
+- name: Expose Image Source file path
+  ansible.builtin.set_fact:
+    mi_is_file: "{{ _mi_is_file }}"

--- a/roles/mirror_images/tasks/generate-image-source.yml
+++ b/roles/mirror_images/tasks/generate-image-source.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     mi_grouped_mirrors: >-
       {{
-        mi_grouped_mirrors | default([]) + [{
+        mi_grouped_mirrors + [{
           'source': item,
           'mirrors': mi_image_mirrors
             | selectattr('source', 'equalto', item)

--- a/roles/mirror_images/tasks/main.yml
+++ b/roles/mirror_images/tasks/main.yml
@@ -8,7 +8,7 @@
       - mi_is_type | lower in ['idms', 'icsp']
     fail_msg: >-
       mi_registry and mi_images are required.
-      mi_is_type must be 'idms' or 'icsp' (got '{{ mi_is_type | default('') }}').
+      mi_is_type must be 'idms' or 'icsp' (got '{{ mi_is_type }}').
 
 - name: Initialize mirrored image mappings
   ansible.builtin.set_fact:

--- a/roles/mirror_images/tasks/main.yml
+++ b/roles/mirror_images/tasks/main.yml
@@ -1,13 +1,25 @@
 ---
-- name: Validate_ inputs
+- name: Validate inputs
   ansible.builtin.assert:
     that:
       - mi_registry is defined
       - mi_images is defined
       - mi_images | length
+      - mi_is_type | lower in ['idms', 'icsp']
+    fail_msg: >-
+      mi_registry and mi_images are required.
+      mi_is_type must be 'idms' or 'icsp' (got '{{ mi_is_type | default('') }}').
+
+- name: Initialize mirrored image mappings
+  ansible.builtin.set_fact:
+    mi_image_mirrors: []
+    mi_grouped_mirrors: []
 
 - name: "Mirror images"
   ansible.builtin.include_tasks: mirror-images.yml
   loop: "{{ mi_images }}"
   loop_control:
     loop_var: image
+
+- name: Generate Image Source manifest
+  ansible.builtin.include_tasks: generate-image-source.yml

--- a/roles/mirror_images/tasks/mirror-images.yml
+++ b/roles/mirror_images/tasks/mirror-images.yml
@@ -13,6 +13,9 @@
       {{ _image_name }}{%- if _image_tag | length %}{{ _image_tag }}{%- endif -%}
       {%- endif -%}
     _tgt_image_location: "{{ mi_registry }}{% if _image_org_path | length %}/{{ _image_org_path }}{% endif %}/{{ _image_img_path }}"
+    _src_ref: "{{ image.split('@')[0] }}"
+    _source_repo: "{{ (_src_ref.split('/')[:-1] + [_src_ref.split('/')[-1].split(':')[0]]) | join('/') }}"
+    _mirror_repo: "{{ (_tgt_image_location.split('/')[:-1] + [_tgt_image_location.split('/')[-1].split(':')[0]]) | join('/') }}"
   block:
     - name: "Mirror image"
       ansible.builtin.command:
@@ -40,18 +43,72 @@
       delay: 5
       until: _mi_skopeo_copy is not failed
 
+    - name: Record mirrored image mapping
+      ansible.builtin.set_fact:
+        mi_image_mirrors: >-
+          {{
+            mi_image_mirrors + [{
+              'source': _source_repo,
+              'mirror': _mirror_repo,
+              'target': _tgt_image_location,
+              'tag_preserved': not (mi_random_tag | bool)
+            }]
+          }}
+
   rescue:
-    - name: "Image already mirrored"
+    - name: Inspect source image digest
       ansible.builtin.command: >
         skopeo inspect
-        {% if mi_authfile is defined %}
+        --no-tags
+        {% if mi_src_authfile is defined %}
+        --authfile {{ mi_src_authfile }}
+        {% elif mi_authfile is defined %}
         --authfile {{ mi_authfile }}
         {% endif %}
+        --format '{{ "{{" }} .Digest {{ "}}" }}'
+        docker://{{ image }}
+      register: _mi_src_inspect
+      failed_when: false
+      changed_when: false
+
+    - name: Inspect destination image digest
+      ansible.builtin.command: >
+        skopeo inspect
+        --no-tags
         {% if mi_dst_authfile is defined %}
         --authfile {{ mi_dst_authfile }}
+        {% elif mi_authfile is defined %}
+        --authfile {{ mi_authfile }}
         {% endif %}
         --tls-verify=false
+        --format '{{ "{{" }} .Digest {{ "}}" }}'
         docker://{{ _tgt_image_location }}
-      register: _mi_inspect
-      failed_when: _mi_inspect.rc != 0
-...
+      register: _mi_dst_inspect
+      failed_when: false
+      changed_when: false
+
+    - name: Verify source and destination digests match
+      ansible.builtin.assert:
+        that:
+          - _mi_src_inspect.rc == 0
+          - _mi_dst_inspect.rc == 0
+          - (_mi_src_inspect.stdout | trim) is match('^sha[0-9]+:')
+          - (_mi_src_inspect.stdout | trim) == (_mi_dst_inspect.stdout | trim)
+        fail_msg: >-
+          skopeo copy failed for {{ image }} and destination
+          {{ _tgt_image_location }} is missing or does not match the source
+          digest (source={{ _mi_src_inspect.stdout | default('') | trim }},
+          destination={{ _mi_dst_inspect.stdout | default('') | trim }},
+          copy_error={{ _mi_skopeo_copy.msg | default(_mi_skopeo_copy.stderr | default('')) }}).
+
+    - name: Record mirrored image mapping
+      ansible.builtin.set_fact:
+        mi_image_mirrors: >-
+          {{
+            mi_image_mirrors + [{
+              'source': _source_repo,
+              'mirror': _mirror_repo,
+              'target': _tgt_image_location,
+              'tag_preserved': not (mi_random_tag | bool)
+            }]
+          }}

--- a/roles/mirror_images/templates/image-source.yaml.j2
+++ b/roles/mirror_images/templates/image-source.yaml.j2
@@ -12,7 +12,7 @@ spec:
 {% endfor %}
     source: {{ entry.source }}
 {% endfor %}
-{% if not (mi_random_tag | default(false) | bool) %}
+{% if not (mi_random_tag | bool) %}
 ---
 apiVersion: config.openshift.io/v1
 kind: ImageTagMirrorSet

--- a/roles/mirror_images/templates/image-source.yaml.j2
+++ b/roles/mirror_images/templates/image-source.yaml.j2
@@ -1,0 +1,45 @@
+{% if mi_is_type | lower == 'idms' %}
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: {{ _mi_is_name }}
+spec:
+  imageDigestMirrors:
+{% for entry in mi_grouped_mirrors %}
+  - mirrors:
+{% for mirror in entry.mirrors %}
+    - {{ mirror }}
+{% endfor %}
+    source: {{ entry.source }}
+{% endfor %}
+{% if not (mi_random_tag | default(false) | bool) %}
+---
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: {{ _mi_is_name }}
+spec:
+  imageTagMirrors:
+{% for entry in mi_grouped_mirrors %}
+  - mirrors:
+{% for mirror in entry.mirrors %}
+    - {{ mirror }}
+{% endfor %}
+    source: {{ entry.source }}
+{% endfor %}
+{% endif %}
+{% else %}
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: {{ _mi_is_name }}
+spec:
+  repositoryDigestMirrors:
+{% for entry in mi_grouped_mirrors %}
+  - mirrors:
+{% for mirror in entry.mirrors %}
+    - {{ mirror }}
+{% endfor %}
+    source: {{ entry.source }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

Allow the generation of mirroring manifest for the mirrored images that will allow to pull images in connected or disconnected environments

Test-hint: no-check