### PR TITLE
Fix git components never being created or attached to DCI jobs

### DIFF
--- a/roles/include_components/tasks/track_git_repo.yml
+++ b/roles/include_components/tasks/track_git_repo.yml
@@ -17,37 +17,43 @@
   register: _ic_search_git_component
   when: last_commit_id.rc == 0
 
-- name: Create component if not found
+- name: Create git repo component
+  ansible.legacy.dci_component:
+    display_name: "{{ repo_url.stdout | basename | regex_replace('[.]git$', '') }} {{ last_commit_id.stdout[:7] }}"
+    version: "{{ last_commit_id.stdout[:7] }}"
+    uid: "{{ last_commit_id.stdout }}"
+    team_id: "{{ job_info['job']['team_id'] }}"
+    topic_id: "{{ job_info['job']['topic_id'] }}"
+    type: "{{ repo_url.stdout | basename | regex_replace('[.]git$', '') }}"
+    url: >-
+      {{ repo_url.stdout
+      | regex_replace('^(.*)@(.*):(.*)', 'https://\\2/\\3')
+      | regex_replace('^ssh://(.*)@(.*)', 'https://\\2')
+      | regex_replace('[.]git$', '')
+      }}/commit/{{ last_commit_id.stdout }}
+    state: present
+  register: _ic_created_git_component
   when:
-    - _ic_search_git_component is defined
-    - _ic_search_git_component is not changed
     - last_commit_id.rc == 0
-  block:
-    - name: Create git repo component
-      ansible.legacy.dci_component:
-        display_name: "{{ repo_url.stdout | basename | regex_replace('[.]git$', '') }} {{ last_commit_id.stdout[:7] }}"
-        version: "{{ last_commit_id.stdout[:7] }}"
-        uid: "{{ last_commit_id.stdout }}"
-        team_id: "{{ job_info['job']['team_id'] }}"
-        topic_id: "{{ job_info['job']['topic_id'] }}"
-        type: "{{ repo_url.stdout | basename | regex_replace('[.]git$', '') }}"
-        url: >-
-          {{ repo_url.stdout
-          | regex_replace('^(.*)@(.*):(.*)', 'https://\2/\3')
-          | regex_replace('^ssh://(.*)@(.*)', 'https://\2')
-          | regex_replace('[.]git$', '')
-          }}/commit/{{ last_commit_id.stdout }}
-        state: present
-      register: git_component
+    - _ic_search_git_component.components | default([]) | length == 0
 
-    - name: Attach git component to the job
-      ansible.legacy.dci_job_component:
-        component_id: "{{ git_component.component.id }}"
-        job_id: " {{ job_id }} "
-      register: job_component_result
-      until: job_component_result is not failed
-      retries: 5
-      delay: 20
+- name: Set git component ID
+  ansible.builtin.set_fact:
+    ic_git_component_id: >-
+      {{ _ic_created_git_component.component.id
+         if _ic_search_git_component.components | default([]) | length == 0
+         else _ic_search_git_component.components[0].id }}
+  when: last_commit_id.rc == 0
+
+- name: Attach git component to the job
+  ansible.legacy.dci_job_component:
+    component_id: "{{ ic_git_component_id }}"
+    job_id: " {{ job_id }} "
+  register: job_component_result
+  until: job_component_result is not failed
+  retries: 5
+  delay: 20
+  when: last_commit_id.rc == 0
 
 - name: Add repository name to list
   vars:


### PR DESCRIPTION
The dci_component module with state=search always returns changed=True
on a successful API call (status 200), regardless of whether any
components were found. The condition `is not changed` was therefore
always False, causing the entire create+attach block to be skipped.

Fix by checking the actual search results list instead, and move the
attach step outside the create block so that existing components are
also attached to new jobs.

TestBos2Workload: control-plane