### PR TITLE
Fix regex backreferences broken by YAML quoting change

### DIFF
--- a/roles/include_components/tasks/track_dev_git_repo.yml
+++ b/roles/include_components/tasks/track_dev_git_repo.yml
@@ -27,8 +27,8 @@
     type: "{{ repo_url.stdout | basename | regex_replace('[.]git$', '') }}"
     url: >-
       {{ repo_url.stdout
-      | regex_replace('^(.*):(.*)@(.*)', 'https://\\3')
-      | regex_replace('^ssh://(.*)@(.*)', 'https://\\2')
+      | regex_replace('^(.*):(.*)@(.*)', 'https://\3')
+      | regex_replace('^ssh://(.*)@(.*)', 'https://\2')
       | regex_replace('[.]git$', '')
       }}/commit/{{ _ic_last_commit_id.stdout }}
     state: present

--- a/roles/include_components/tasks/track_git_repo.yml
+++ b/roles/include_components/tasks/track_git_repo.yml
@@ -33,8 +33,8 @@
         type: "{{ repo_url.stdout | basename | regex_replace('[.]git$', '') }}"
         url: >-
           {{ repo_url.stdout
-          | regex_replace('^(.*)@(.*):(.*)', 'https://\\2/\\3')
-          | regex_replace('^ssh://(.*)@(.*)', 'https://\\2')
+          | regex_replace('^(.*)@(.*):(.*)', 'https://\2/\3')
+          | regex_replace('^ssh://(.*)@(.*)', 'https://\2')
           | regex_replace('[.]git$', '')
           }}/commit/{{ last_commit_id.stdout }}
         state: present


### PR DESCRIPTION
##### SUMMARY

The url field in the include_component role was changed from double quoted YAML string to `>-` block scalar.

In quoted strings, \\2 and \\3 are escape sequences that produce the regex backreferences \2 and \3. Meanwhile, block scalars have no escape processing, so \\2 and \\3 were passed through literally, producing URLs like https://\\3/commit/<sha> instead of the expected https://github.com/<org>/<repo>/commit/<sha>.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDgtMDNUMjE6MjY6NTN8NTY2MzQ4MzQ0YjAzOTMwMTU5MWZhOTU2NjA4NzJlMmFhM2U1ZDk5OA==
Gitleaks-Hash: a2698ca966932080d6cd0361650ca305cb1d909ee2beed4259358d521aaa9675

See examples:
Bug: https://www.distributed-ci.io/jobs/f1a30a89-0465-401b-b5e1-6a804e43f20a/jobStates?sort=date&task=91a2f961-2e08-48c8-8196-46745797f43a
Expected: https://www.distributed-ci.io/jobs/59aa8f73-92bb-48a6-bda7-6b5bb68e8a59/jobStates?sort=date&task=b786d37c-ba48-47a2-b7ed-7d44cce24ad1

##### ISSUE TYPE

- Bug

##### Tests

- [x] preflight-green - https://www.distributed-ci.io/jobs/e908cb27-49f8-4973-a1ce-cc093778d8cb

Test-hints: no-check
