### PR TITLE
Remove DCI component creation from preflight role

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        4.0.EPOCH
+Version:        4.1.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Mon Aug  3 2026 Tony Garcia <tonyg@redhat.com> - 4.1.EPOCH-VERS
+- Remove DCI component creation from preflight role
+
 * Thu Jul 30 2026 Beto Rdz <josearod@redhat.com> - 4.0.EPOCH-VERS
 - Non-backward compatible changes to the image sources plays in acm utils
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 4.0.0
+version: 4.1.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -46,30 +46,28 @@
       # this variable is set in test-runner
       when: preflight_source_dir is defined
 
-    # $ podman run --rm quay.io/opdev/preflight:tag --version
-    # preflight version tag <commit: b6bcc3506c0d84baa0c020f6b776a181b931f57a>
-    - name: Extract commit_id from Preflight image
-      ansible.builtin.shell:
-        cmd: >
-          set -o pipefail;
-          podman run --rm {{ preflight_image }} --version |
-          awk '/commit:/ {gsub(">", "", $NF); print $NF}'
-      register: preflight_commit_id
-      changed_when: false
+    - name: Extract preflight version info
+      when: preflight_source_dir is not defined
+      block:
+        - name: Get preflight version
+          containers.podman.podman_container:
+            name: preflight-version
+            image: "{{ preflight_image }}"
+            command: "--version"
+            detach: false
+            rm: true
+          register: _preflight_version_output
 
-    - name: Create a DCI component from Preflight image
-      ansible.builtin.include_role:
-        name: redhatci.ocp.include_components
-        apply:
-          delegate_to: localhost
-      vars:
-        ic_commit_urls:
-          - "{{ preflight_repo_https }}/commit/{{ preflight_commit_id.stdout }}"
-        ic_gits: []
-        ic_dev_gits: []
-      # TODO: replace ic_* prefix with include_components prefix
-      tags:
-        - skip_ansible_lint
+        - name: Set preflight version facts
+          vars:
+            _preflight_commit_id: >-
+              {{ _preflight_version_output.stdout |
+                 regex_search('commit:\s*(\w+)', '\1') | first }}
+          ansible.builtin.set_fact:
+            preflight_version_info:
+              commit_id: "{{ _preflight_commit_id }}"
+              commit_url: "{{ preflight_repo_https }}/commit/{{ _preflight_commit_id }}"
+              image: "{{ preflight_image }}"
 
     # Retrieve scorecard-test image in advance,
     # to allow its mirroring in the disconnected cluster.


### PR DESCRIPTION
##### SUMMARY

DCI component tracking is a DCI concern and should be handled by the dci-openshift-app-agent, not by the preflight role.
The role now exposes preflight_version_info as a fact for callers to consume. This also fixes duplicate component creation when building preflight from source.

Assisted-by: Claude

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDgtMDRUMTU6MTk6MDF8YmYzN2JjYmFmODZlNDQ5M2ExZTA3ZjlkODEzMTlkMTJmMDExYjU2Yw==
Gitleaks-Hash: 9d434ce06ef258068d75a0010e27996d1899a6909aea7ae9aec3057ad6986cbd

##### ISSUE TYPE

- Bug

##### Tests

- [x] preflight-green - 
  - [x] redhatci.ocp.preflight - Setting facts for current preflight image used -  https://www.distributed-ci.io/jobs/31d35192-ff44-4558-aa90-9797b9d1071a/jobStates?sort=date&task=2f0a9647-291c-4a1e-b439-c7ba465e8319
  - [x] doaa - Component created *after* the role was called - https://www.distributed-ci.io/jobs/31d35192-ff44-4558-aa90-9797b9d1071a/jobStates?sort=date&task=eef71fa6-c378-409d-a270-71f1887deacd

---

Test-hints: no-check