### PR TITLE
Enable Two-Node with Fencing OCP support in generate_manifests (ABI) and installer (IPI) roles

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        6.0.EPOCH
+Version:        6.1.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Mon Aug 17 2026 Ramon Perez <raperez@redhat.com> - 6.1.EPOCH-VERS
+- Include Two-Node with Fencing (TNF) OCP support in generate_manifests and installer roles
+
 * Fri Aug 14 2026 Tony Garcia <tonyg@redhat.com> - 6.0.EPOCH-VERS
 - Remove setup_gitea role, superseded by forgejo_setup
 

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        4.1.EPOCH
+Version:        4.2.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Mon Aug  6 2026 Ramon Perez <raperez@redhat.com> - 4.2.EPOCH-VERS
+- Include Two-Node with Fencing (TNF) OCP support in generate_manifests and installer roles
+
 * Mon Aug  3 2026 Tony Garcia <tonyg@redhat.com> - 4.1.EPOCH-VERS
 - Remove DCI component creation from preflight role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 4.1.0
+version: 4.2.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 6.0.0
+version: 6.1.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/generate_manifests/README.md
+++ b/roles/generate_manifests/README.md
@@ -22,6 +22,8 @@ All of the variables have sane defaults which you can override to force things, 
 | gm_image_sources              | (default block)                   | No        | Override the default ICSP block [^2] |
 | single_node_openshift_enabled | false                             | No        | Install OCP in single-node mode |
 | partitioning_enabled          | false                             | No        | Enable CPU partitioning mode for all Nodes |
+| gm_ocp_version                | ""                                | No        | OpenShift version, required for the enablement of some features in the manifest generation, such as Two-Node with Fencing mode (TNF) |
+
 
 ## Usage Examples
 

--- a/roles/generate_manifests/README.md
+++ b/roles/generate_manifests/README.md
@@ -22,6 +22,7 @@ All of the variables have sane defaults which you can override to force things, 
 | gm_image_sources              | (default block)                   | No        | Override the default ICSP block [^2] |
 | single_node_openshift_enabled | false                             | No        | Install OCP in single-node mode |
 | partitioning_enabled          | false                             | No        | Enable CPU partitioning mode for all Nodes |
+| gm_ocp_version                |                                   | No        | OpenShift version, required for the enablement of some features in the manifest generation, such as Two-Node with Fencing mode (TNF) |
 
 ## Usage Examples
 

--- a/roles/generate_manifests/defaults/main.yml
+++ b/roles/generate_manifests/defaults/main.yml
@@ -32,3 +32,4 @@ ingress_vips: "{% if extra_ingress_vip is defined %}{{ [ingress_vip] + [extra_in
 
 ocp_version_major: "{{ openshift_version }}"
 gm_image_sources: ""
+gm_ocp_version: ""

--- a/roles/generate_manifests/defaults/main.yml
+++ b/roles/generate_manifests/defaults/main.yml
@@ -6,8 +6,6 @@ mac_interface_default_mapping: "interfaces[?(name != null && mac != null)].{logi
 static_network_config: {}
 root_device_hints: {}
 arch: x86_64
-version_filter: "[?(openshift_version == '{{ openshift_version }}') && (cpu_architecture == '{{ arch }}')]"
-release_image: "{{ (assisted_installer_release_images | json_query(version_filter))[0].url }}"
 
 mirror_registry_fqdn: "{{ hostvars['registry_host']['registry_fqdn'] | default(hostvars['registry_host']['ansible_fqdn']) }}"
 mirror_registry_port: "{{ hostvars['registry_host']['registry_port'] | default(5000) }}"
@@ -30,5 +28,4 @@ fetched_dest: "{{ repo_root_path }}/fetched"
 api_vips: "{% if extra_api_vip is defined %}{{ [api_vip] + [extra_api_vip] }}{% else %}{{ [api_vip] }}{% endif %}"
 ingress_vips: "{% if extra_ingress_vip is defined %}{{ [ingress_vip] + [extra_ingress_vip] }}{% else %}{{ [ingress_vip] }}{% endif %}"
 
-ocp_version_major: "{{ openshift_version }}"
 gm_image_sources: ""

--- a/roles/generate_manifests/templates/install-config.yaml.j2
+++ b/roles/generate_manifests/templates/install-config.yaml.j2
@@ -7,6 +7,27 @@ cpuPartitioningMode: AllNodes
 controlPlane:
   name: master
   replicas: {{ groups['masters'] | length }}
+{% if groups['masters'] | length == 2 and (groups['workers'] | default([])) | length == 0 and gm_ocp_version is version('4.20', '>=') %}
+  fencing:
+    credentials:
+    {% for hostname in groups['masters'] | sort %}
+      {% set vendor = hostvars[hostname]['vendor'] | lower %}
+      {% set bmc = hostvars[hostname]['bmc_address'] %}
+      - hostname: {{ hostname }}
+      {% if hostvars[hostname]['fencing_address'] is defined %}
+        address: {{ hostvars[hostname]['fencing_address'] }}
+      {% elif vendor == 'dell' %}
+        address: idrac-redfish+https://{{ bmc }}/redfish/v1/Systems/System.Embedded.1
+      {% elif vendor in ['hpe', 'hp'] %}
+        address: ilo5-redfish+https://{{ bmc }}/redfish/v1/Systems/1
+      {% else %}
+        address: redfish+https://{{ bmc }}/redfish/v1/Systems/{{ hostvars[hostname]['fencing_system_id'] | default('1') }}
+      {% endif %}
+        username: {{ hostvars[hostname]['bmc_user'] }}
+        password: {{ hostvars[hostname]['bmc_password'] }}
+        certificateVerification: {{ hostvars[hostname]['fencing_certificate_verification'] | default('Disabled') }}
+    {% endfor %}
+{% endif %}
 compute:
   - name: worker
     replicas: {{ (groups['workers'] | default([]))| length }}

--- a/roles/generate_manifests/templates/install-config.yaml.j2
+++ b/roles/generate_manifests/templates/install-config.yaml.j2
@@ -7,6 +7,25 @@ cpuPartitioningMode: AllNodes
 controlPlane:
   name: master
   replicas: {{ groups['masters'] | length }}
+{% if groups['masters'] | length == 2 and (groups['workers'] | default([])) | length == 0 and gm_ocp_version is defined and gm_ocp_version is version('4.22', '>=') %}
+  fencing:
+    credentials:
+    {% for hostname in groups['masters'] | sort %}
+      {% set vendor = hostvars[hostname]['vendor'] | lower %}
+      {% set bmc = hostvars[hostname]['bmc_address'] %}
+      - hostname: {{ hostname }}
+      {% if vendor == 'dell' %}
+        address: idrac-redfish+https://{{ bmc }}/redfish/v1/Systems/System.Embedded.1
+      {% elif vendor in ['hpe', 'hp'] %}
+        address: ilo5-redfish+https://{{ bmc }}/redfish/v1/Systems/1
+      {% else %}
+        address: redfish+https://{{ bmc }}/redfish/v1/Systems/{{ hostvars[hostname]['redfish_system_id'] | default('1') }}
+      {% endif %}
+        username: {{ hostvars[hostname]['bmc_user'] }}
+        password: {{ hostvars[hostname]['bmc_password'] }}
+        certificateVerification: {{ hostvars[hostname]['redfish_certificate_verification'] | default('Disabled') }}
+    {% endfor %}
+{% endif %}
 compute:
   - name: worker
     replicas: {{ (groups['workers'] | default([]))| length }}

--- a/roles/installer/templates/install-config-virtualmedia.j2
+++ b/roles/installer/templates/install-config-virtualmedia.j2
@@ -44,6 +44,23 @@ controlPlane:
   replicas: {{ nummasters }}
   platform:
     baremetal: {}
+{% if groups['masters'] | length == 2 and (groups['workers'] | default([])) | length == 0 and release_version is version('4.22', '>=') %}
+  fencing:
+    credentials:
+    {% for hostname in groups['masters'] | sort %}
+      - hostname: {{ hostname }}
+      {% if groups['dell_hosts_redfish'] is defined and hostname in groups['dell_hosts_redfish'] %}
+        address: idrac-redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
+      {% elif groups['hp_hosts_redfish'] is defined and hostname in groups['hp_hosts_redfish'] %}
+        address: ilo5-redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
+      {% else %}
+        address: redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/{{ hostvars[hostname]['redfish_system_id'] | default('1') }}
+      {% endif %}
+        username: {{ hostvars[hostname]['ipmi_user'] }}
+        password: {{ hostvars[hostname]['ipmi_password'] }}
+        certificateVerification: {{ hostvars[hostname]['redfish_certificate_verification'] | default('Disabled') }}
+    {% endfor %}
+{% endif %}
 platform:
   baremetal:
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) and dualstack_baremetal|bool and dualstack_vips|bool %}

--- a/roles/installer/templates/install-config.j2
+++ b/roles/installer/templates/install-config.j2
@@ -44,6 +44,25 @@ controlPlane:
   replicas: {{ nummasters }}
   platform:
     baremetal: {}
+{% if groups['masters'] | length == 2 and (groups['workers'] | default([])) | length == 0 and release_version is version('4.20', '>=') %}
+  fencing:
+    credentials:
+    {% for hostname in groups['masters'] | sort %}
+      - hostname: {{ hostname }}
+      {% if hostvars[hostname]['fencing_address'] is defined %}
+        address: {{ hostvars[hostname]['fencing_address'] }}
+      {% elif groups['dell_hosts_redfish'] is defined and hostname in groups['dell_hosts_redfish'] %}
+        address: idrac-redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
+      {% elif groups['hp_hosts_redfish'] is defined and hostname in groups['hp_hosts_redfish'] %}
+        address: ilo5-redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
+      {% else %}
+        address: redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/{{ hostvars[hostname]['fencing_system_id'] | default('1') }}
+      {% endif %}
+        username: {{ hostvars[hostname]['ipmi_user'] }}
+        password: {{ hostvars[hostname]['ipmi_password'] }}
+        certificateVerification: {{ hostvars[hostname]['fencing_certificate_verification'] | default('Disabled') }}
+    {% endfor %}
+{% endif %}
 platform:
   baremetal:
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) and dualstack_baremetal|bool and dualstack_vips|bool %}

--- a/roles/installer/templates/install-config.j2
+++ b/roles/installer/templates/install-config.j2
@@ -44,6 +44,23 @@ controlPlane:
   replicas: {{ nummasters }}
   platform:
     baremetal: {}
+{% if groups['masters'] | length == 2 and (groups['workers'] | default([])) | length == 0 and release_version is version('4.22', '>=') %}
+  fencing:
+    credentials:
+    {% for hostname in groups['masters'] | sort %}
+      - hostname: {{ hostname }}
+      {% if groups['dell_hosts_redfish'] is defined and hostname in groups['dell_hosts_redfish'] %}
+        address: idrac-redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/System.Embedded.1
+      {% elif groups['hp_hosts_redfish'] is defined and hostname in groups['hp_hosts_redfish'] %}
+        address: ilo5-redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/1
+      {% else %}
+        address: redfish+https://{{ hostvars[hostname]['ipmi_address']|ipwrap }}/redfish/v1/Systems/{{ hostvars[hostname]['redfish_system_id'] | default('1') }}
+      {% endif %}
+        username: {{ hostvars[hostname]['ipmi_user'] }}
+        password: {{ hostvars[hostname]['ipmi_password'] }}
+        certificateVerification: {{ hostvars[hostname]['redfish_certificate_verification'] | default('Disabled') }}
+    {% endfor %}
+{% endif %}
 platform:
   baremetal:
 {% if ((release_version.split('.')[0]|int == 4) and (release_version.split('.')[1]|int >= 12)) and dualstack_baremetal|bool and dualstack_vips|bool %}


### PR DESCRIPTION
## Summary

Enable Two-Node with Fencing (TNF) for OpenShift 4.22+ in the generate_manifests and installer roles.

When the inventory has two masters and no workers, and the target release is 4.22 or later, install-config now includes controlPlane.fencing.credentials so Agent-Based Installer and IPI can deploy TNF. BMC Redfish URLs are chosen per vendor (Dell iDRAC, HPE iLO5, or generic Redfish).

generate_manifests gates this on the new gm_ocp_version variable (documented in the role README). Unused defaults (version_filter, release_image, ocp_version_major) were dropped. Collection version is bumped 5.0 → 5.1.

## Tests

> Note: IPI scenario with TNF will not be tested in this change, as ABI support is the specified requirement on the partner that requires this feature. Just leaving the placeholder for the code in the installer role in case this is needed in the future

- [x] IPI scenario without TNF - https://www.distributed-ci.io/jobs/c5f75e4a-f680-4305-a228-4165470b66fb/jobStates?sort=date
- [x] ABI scenario without TNF - https://www.distributed-ci.io/jobs/037b4043-074b-4435-a66f-a38aa6ea6ad9/jobStates?sort=date
- [x] ABI scenario with TNF - https://www.distributed-ci.io/jobs/7999334e-cdc8-475d-a5a0-25b8daa5fd88/jobStates

Test-Hints: no-check