### PR TITLE
Make digest verification optional in mirror_images role

### DIFF
--- a/roles/mirror_images/README.md
+++ b/roles/mirror_images/README.md
@@ -27,6 +27,7 @@ remapping is required.
 | mi_random_tag    | false              | No       | Copy to a random destination tag to avoid overwriting existing mirror content
 | mi_is_type       | `idms`             | No       | Image Source file type: `icsp` (ImageContentSourcePolicy) or `idms` (ImageDigestMirrorSet + ImageTagMirrorSet). See note above about ICSP and tags.
 | mi_is_name       | auto-generated     | No       | Metadata name for the Image Source resource. Default: `mirrored-images-<8-char-random>` each role run. Set explicitly to pin the name across runs.
+| mi_verify_digest | false              | No       | When `true`, verify that the source and destination image digests match after a failed copy. When `false` (default), only verify that the destination image exists. Set to `false` when mirroring may occur in a separate step or access to the source registry is limited.
 
 ## Requirements
 

--- a/roles/mirror_images/defaults/main.yml
+++ b/roles/mirror_images/defaults/main.yml
@@ -3,3 +3,4 @@ mi_dst_org: ""
 mi_random_tag: false
 mi_is_type: "idms"
 mi_is_name: ""
+mi_verify_digest: false

--- a/roles/mirror_images/tasks/mirror-images.yml
+++ b/roles/mirror_images/tasks/mirror-images.yml
@@ -70,8 +70,10 @@
       register: _mi_src_inspect
       failed_when: false
       changed_when: false
+      when:
+        - mi_verify_digest | bool
 
-    - name: Inspect destination image digest
+    - name: Inspect destination image
       ansible.builtin.command: >
         skopeo inspect
         --no-tags
@@ -84,22 +86,22 @@
         --format '{{ "{{" }} .Digest {{ "}}" }}'
         docker://{{ _tgt_image_location }}
       register: _mi_dst_inspect
-      failed_when: false
-      changed_when: false
+      failed_when: _mi_dst_inspect.rc != 0
 
     - name: Verify source and destination digests match
       ansible.builtin.assert:
         that:
           - _mi_src_inspect.rc == 0
-          - _mi_dst_inspect.rc == 0
           - (_mi_src_inspect.stdout | trim) is match('^sha[0-9]+:')
           - (_mi_src_inspect.stdout | trim) == (_mi_dst_inspect.stdout | trim)
         fail_msg: >-
           skopeo copy failed for {{ image }} and destination
-          {{ _tgt_image_location }} is missing or does not match the source
+          {{ _tgt_image_location }} does not match the source
           digest (source={{ _mi_src_inspect.stdout | default('') | trim }},
           destination={{ _mi_dst_inspect.stdout | default('') | trim }},
           copy_error={{ _mi_skopeo_copy.msg | default(_mi_skopeo_copy.stderr | default('')) }}).
+      when:
+        - mi_verify_digest | bool
 
     - name: Record mirrored image mapping
       ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY

The digest comparison added in the rescue block can be too restrictive for environments where mirroring occurs in a separate step or access to the source registry is limited.
Add mi_verify_digest (default: false) to control this behavior, this returns the previous behavior to the role

Assisted-by: Claude

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDgtMTFUMjI6MDI6MTB8NDJkYjNkOTJkMzNlOWJmNWMxZWNlNWUwNGQyMWVhZjZiNTlkMTdjMA==
Gitleaks-Hash: 076e5c98c8b436f557f08f9700e98374ab52090f58477d556567646b2412c09a

##### ISSUE TYPE

- Bug
- 
##### Tests

- [x] openshift-vcp - https://www.distributed-ci.io/jobs/c7ba98f3-ef42-40e1-8f6e-1d06f9bf62fe/jobStates?sort=date&task=81ef43e4-e098-4cbd-8272-f25438713a1b

---

Test-hints: no-check