### PR TITLE
WIP: Add role to auto-resolve must-gather images

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Name | Description
 [redhatci.ocp.pyxis](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/pyxis/README.md) | Interacts with Pyxis API to submit Preflight certification results
 [redhatci.ocp.redhat_tests](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/redhat_tests/README.md) | [Openshift End to End tests](https://github.com/openshift/openshift-tests)
 [redhatci.ocp.remove_ztp_gitops_resources](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/remove_ztp_gitops_resources/README.md) | Remove all GitOps related resources for a given spoke cluster, excepting the cluster namespace, which is not deleted because this will imply the spoke cluster is detached from the hub cluster.
+[redhatci.ocp.resolve_must_gather_images](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/resolve_must_gather_images/README.md) | Resolves must-gather short names to fully-qualified image references using installed operator metadata
 [redhatci.ocp.resources_to_components](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/resources_to_components/README.md) | Creates DCI components based on Kubernetes resources
 [redhatci.ocp.rhoai](roles/rhoai/README.md) | Install the Red Hat OpenShift AI operators
 [redhatci.ocp.setup_gitea](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_gitea/README.md) | Deployment of [Gitea](https://about.gitea.com)
@@ -169,6 +170,7 @@ Name | Type | Description
 [redhatci.ocp.cmdline_to_json]() | Filter | Convert a kernel command line string to a JSON object
 [redhatci.ocp.redact]() | Filter | Redact sensitive values from a dictionary
 [redhatci.ocp.regex_diff]() | Filter | Obtain differences between two lists
+[redhatci.ocp.resolve_must_gather]() | Filter | Resolve a must-gather short name to a full image reference from a list of related images
 
 ## License
 

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        4.2.EPOCH
+Version:        4.3.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Thu Aug 13 2026 Frederic Lepied <flepied@redhat.com> - 4.3.EPOCH-VERS
+- Add resolve_must_gather_images role and resolve_must_gather filter plugin
+
 * Wed Aug  5 2026 Beto Rdz <josearod@redhat.com> - 4.2.EPOCH-VERS
 - Add image source generation capabilities to mirror_images role
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 4.2.0
+version: 4.3.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/plugins/filter/resolve_must_gather.py
+++ b/plugins/filter/resolve_must_gather.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+    name: resolve_must_gather
+    version_added: "4.3.0"
+    short_description: Resolve a must-gather short name to a full image reference
+    description:
+        - Given a short name (e.g. C(must-gather) or C(oc_must_gather)) and a list
+          of fully-qualified image references, returns the first image whose last
+          path segment matches the normalised short name.
+        - Normalisation converts hyphens and slashes to underscores and lowercases
+          the result.  This makes C(must-gather) and C(must_gather) equivalent.
+        - Returns an empty string when no match is found.
+    positional: _input
+    options:
+        _input:
+            description: Short name of the must-gather image to look up.
+            type: str
+            required: true
+        image_list:
+            description: >
+              List of fully-qualified image references to search.
+              Each entry may be a plain tag reference (C(registry/repo/image:tag))
+              or a digest-pinned reference (C(registry/repo/image@sha256:...)).
+            type: list
+            elements: str
+            required: true
+"""
+
+EXAMPLES = r"""
+    - name: Resolve must-gather image from related images
+      ansible.builtin.set_fact:
+        mg_image: "{{ 'must-gather' | redhatci.ocp.resolve_must_gather(csv_images) }}"
+"""
+
+RETURN = r"""
+    _value:
+        description: >
+          The first matching image reference from I(image_list), or an empty
+          string if no match is found.
+        type: str
+"""
+
+
+def _normalize(name):
+    """Normalise a name for comparison: lower-case, replace '-' and '/' with '_'."""
+    return name.replace("-", "_").replace("/", "_").lower()
+
+
+def resolve_must_gather(short_name, image_list):
+    """
+    Return the first image in image_list whose last path segment matches short_name.
+
+    Args:
+        short_name (str): Short name to look up (e.g. 'must-gather').
+        image_list (list): List of fully-qualified image references.
+
+    Returns:
+        str: First matching image reference, or '' if not found.
+    """
+    normalised_target = _normalize(short_name)
+
+    for image in image_list:
+        # Strip digest or tag to get the repository path
+        # e.g. registry.io/org/must-gather@sha256:abc -> registry.io/org/must-gather
+        # e.g. registry.io/org/must-gather:latest    -> registry.io/org/must-gather
+        repo_part = image.split("@")[0].split(":")[0]
+        # Take the last path segment
+        last_segment = repo_part.rstrip("/").rsplit("/", 1)[-1]
+        if _normalize(last_segment) == normalised_target:
+            return image
+
+    return ""
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            "resolve_must_gather": resolve_must_gather,
+        }

--- a/roles/resolve_must_gather_images/README.md
+++ b/roles/resolve_must_gather_images/README.md
@@ -1,0 +1,47 @@
+# redhatci.ocp.resolve_must_gather_images
+
+Resolves a list of must-gather short names (e.g. `must-gather`,
+`ose-must-gather`) to fully-qualified image references by inspecting the
+`relatedImages` field of all `ClusterServiceVersion` resources installed on
+the target cluster.
+
+When a short name cannot be matched in the cluster's image list, the role
+constructs a fallback reference using the configurable registry prefix.
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `rmgi_images` | list | **yes** | — | List of must-gather short names to resolve. |
+| `rmgi_fallback_registry` | str | no | `registry.redhat.io/openshift4` | Registry/repository prefix used when a short name cannot be resolved from the cluster. |
+| `rmgi_kubeconfig` | str | no | `""` | Path to a kubeconfig file. Leave empty to use the currently active context. |
+
+## Outputs
+
+| Variable | Description |
+|----------|-------------|
+| `rmgi_resolved_images` | List of resolved fully-qualified image references (one per entry in `rmgi_images`). |
+| `dci_must_gather_images` | Alias for `rmgi_resolved_images`. Consumed by downstream roles such as `mirror_images`. |
+
+## Usage example
+
+```yaml
+- name: Resolve must-gather images from installed operators
+  ansible.builtin.include_role:
+    name: redhatci.ocp.resolve_must_gather_images
+  vars:
+    rmgi_images:
+      - must-gather
+      - ose-must-gather
+    rmgi_kubeconfig: "{{ kubeconfig_path }}"
+
+- name: Mirror must-gather images to the disconnected registry
+  ansible.builtin.include_role:
+    name: redhatci.ocp.mirror_images
+  vars:
+    mi_images: "{{ dci_must_gather_images }}"
+```
+
+## License
+
+Apache 2.0

--- a/roles/resolve_must_gather_images/defaults/main.yml
+++ b/roles/resolve_must_gather_images/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# List of must-gather short names to resolve (e.g. ["must-gather", "ose-must-gather"])
+rmgi_images: []
+
+# Fallback registry/repository prefix when a short name cannot be resolved from
+# the cluster's installed operators
+rmgi_fallback_registry: "registry.redhat.io/openshift4"
+
+# Path to a kubeconfig file.  Leave empty to use the current active context.
+rmgi_kubeconfig: ""
+...

--- a/roles/resolve_must_gather_images/meta/argument_specs.yml
+++ b/roles/resolve_must_gather_images/meta/argument_specs.yml
@@ -1,0 +1,33 @@
+---
+argument_specs:
+  main:
+    short_description: Resolve must-gather short names to full image references
+    description:
+      - Queries ClusterServiceVersion resources from the target cluster to
+        collect related images, then resolves each short name in
+        I(rmgi_images) to a fully-qualified image reference.
+      - When a short name cannot be matched in the cluster's image list the
+        role falls back to I(rmgi_fallback_registry)/I(item).
+    options:
+      rmgi_images:
+        type: list
+        elements: str
+        required: true
+        description:
+          - List of must-gather short names to resolve.
+          - "Example: [\"must-gather\", \"ose-must-gather\"]"
+      rmgi_fallback_registry:
+        type: str
+        required: false
+        default: "registry.redhat.io/openshift4"
+        description:
+          - Registry and repository prefix used when a short name cannot be
+            resolved from the cluster's installed operators.
+      rmgi_kubeconfig:
+        type: str
+        required: false
+        default: ""
+        description:
+          - Path to a kubeconfig file.
+          - Leave empty to use the currently active kubeconfig context.
+...

--- a/roles/resolve_must_gather_images/tasks/main.yml
+++ b/roles/resolve_must_gather_images/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Validate required role variables
+  ansible.builtin.assert:
+    that:
+      - rmgi_images is defined
+      - rmgi_images | type_debug == "list"
+      - rmgi_fallback_registry | length > 0
+    fail_msg: >
+      rmgi_images must be defined as a list and rmgi_fallback_registry must
+      not be empty.
+
+- name: Retrieve ClusterServiceVersion resources from the cluster
+  kubernetes.core.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    kubeconfig: "{{ rmgi_kubeconfig | default(omit) }}"
+  register: rmgi_csv_list
+  no_log: true
+
+- name: Collect related images from all CSVs
+  ansible.builtin.set_fact:
+    rmgi_related_images: >-
+      {{
+        rmgi_csv_list.resources
+        | json_query('[*].spec.relatedImages[*].image')  # noqa: jinja[invalid]
+        | flatten
+        | unique
+      }}
+
+- name: Resolve each must-gather short name to a full image reference
+  ansible.builtin.set_fact:
+    rmgi_resolved_images: >-
+      {{
+        rmgi_resolved_images | default([]) + [
+          (item | redhatci.ocp.resolve_must_gather(rmgi_related_images))
+          if (item | redhatci.ocp.resolve_must_gather(rmgi_related_images)) != ''
+          else rmgi_fallback_registry + '/' + item
+        ]
+      }}
+  loop: "{{ rmgi_images }}"
+
+- name: Expose resolved images as dci_must_gather_images  # noqa: redhat-ci[no-role-prefix]
+  ansible.builtin.set_fact:
+    dci_must_gather_images: "{{ rmgi_resolved_images }}"
+...

--- a/tests/unit/filter/test_resolve_must_gather.py
+++ b/tests/unit/filter/test_resolve_must_gather.py
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.redhatci.ocp.plugins.filter import resolve_must_gather
+
+
+class TestResolveMustGather:
+    def test_exact_hyphen_match_returns_sha256_pinned_ref(self):
+        """Exact hyphen name matches a digest-pinned image reference."""
+        image_list = [
+            "registry.redhat.io/openshift4/ose-must-gather@sha256:abc123",
+            "registry.redhat.io/openshift4/ose-network-tools@sha256:def456",
+        ]
+        result = resolve_must_gather.resolve_must_gather("ose-must-gather", image_list)
+        assert result == "registry.redhat.io/openshift4/ose-must-gather@sha256:abc123"
+
+    def test_underscore_vs_hyphen_normalisation_matches(self):
+        """Underscore in short_name matches a hyphenated image segment."""
+        image_list = [
+            "registry.redhat.io/openshift4/ose-network-tools@sha256:def456",
+            "registry.redhat.io/openshift4/ose-must-gather@sha256:abc123",
+        ]
+        result = resolve_must_gather.resolve_must_gather("ose_must_gather", image_list)
+        assert result == "registry.redhat.io/openshift4/ose-must-gather@sha256:abc123"
+
+    def test_no_match_returns_empty_string(self):
+        """Returns empty string when no image matches the short name."""
+        image_list = [
+            "registry.redhat.io/openshift4/ose-network-tools@sha256:def456",
+            "registry.redhat.io/openshift4/ose-cli@sha256:ghi789",
+        ]
+        result = resolve_must_gather.resolve_must_gather("ose-must-gather", image_list)
+        assert result == ""
+
+    def test_filter_module_exposes_resolve_must_gather_callable(self):
+        """FilterModule.filters() exposes 'resolve_must_gather' as a callable."""
+        filter_module = resolve_must_gather.FilterModule()
+        filters = filter_module.filters()
+        assert "resolve_must_gather" in filters
+        assert callable(filters["resolve_must_gather"])


### PR DESCRIPTION
## Summary

- Added `resolve_must_gather` filter plugin (`plugins/filter/resolve_must_gather.py`) with unit tests for name-matching logic (hyphen/underscore normalization)
- Added `resolve_must_gather_images` role (defaults, meta/argument_specs, tasks, README) that queries cluster CSVs, extracts relatedImages, and returns digest-pinned refs
- Registered both in collection README.md, bumped `galaxy.yml` version 4.2.0→4.3.0 and spec version 4.2.EPOCH→4.3.EPOCH with changelog entry

## Changes

- `plugins/filter/resolve_must_gather.py`: new filter plugin for must-gather image name matching
- `tests/unit/filter/test_resolve_must_gather.py`: unit tests for the filter plugin
- `roles/resolve_must_gather_images/defaults/main.yml`: role defaults
- `roles/resolve_must_gather_images/meta/argument_specs.yml`: role argument specifications
- `roles/resolve_must_gather_images/tasks/main.yml`: role tasks
- `roles/resolve_must_gather_images/README.md`: role documentation
- `README.md`: registered new role and filter plugin in collection index
- `galaxy.yml`: version bump 4.2.0→4.3.0
- `ansible-collection-redhatci-ocp.spec`: version bump 4.2.EPOCH→4.3.EPOCH with changelog entry

## Status

⚠️ CI checks have not yet passed — keeping as draft for further iteration.

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)