### PR TITLE
feat: add Dell iDRAC SSH and HP iLO SSH console support to conserver role

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -63,6 +63,7 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 * Wed Aug 13 2026 Frederic Lepied <flepied@redhat.com> - 5.0.EPOCH-VERS
 - Remove monitor_agent_based_installer role (monitoring moved to dci-openshift-agent)
+- Add SSH console support for Dell iDRAC and HP iLO in conserver role
 
 * Tue Aug 12 2026 Frederic Lepied <flepied@redhat.com> - 4.3.EPOCH-VERS
 - Add resolve_must_gather_images role and filter plugin

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -58,12 +58,14 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 * Mon Aug 17 2026 Ramon Perez <raperez@redhat.com> - 6.1.EPOCH-VERS
 - Include Two-Node with Fencing (TNF) OCP support in generate_manifests and installer roles
 
+* Sat Aug 15 2026 Frederic Lepied <flepied@redhat.com> - 6.1.EPOCH-VERS
+- Add SSH console support for Dell iDRAC and HP iLO in conserver role
+
 * Fri Aug 14 2026 Tony Garcia <tonyg@redhat.com> - 6.0.EPOCH-VERS
 - Remove setup_gitea role, superseded by forgejo_setup
 
 * Wed Aug 13 2026 Frederic Lepied <flepied@redhat.com> - 5.0.EPOCH-VERS
 - Remove monitor_agent_based_installer role (monitoring moved to dci-openshift-agent)
-- Add SSH console support for Dell iDRAC and HP iLO in conserver role
 
 * Tue Aug 12 2026 Frederic Lepied <flepied@redhat.com> - 4.3.EPOCH-VERS
 - Add resolve_must_gather_images role and filter plugin

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -4,7 +4,8 @@ This folder contains the playbooks that support the Ansible roles of the collect
 ## Playbook list
 | Role                                                                                                                                 | Name                       | Description
 |--------------------------------------------------------------------------------------------------------------------------------------|----------------------------|------------------------------------------------------------------------------------------------------
-| [redhatci.ocp.multibench_run](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/multibench_run/README.md)  |  multibench_setup_host.yml | This playbook installs the crucible binaries needed for the proper execution of the Multi-bench role. 
+| [redhatci.ocp.multibench_run](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/multibench_run/README.md)  |  multibench_setup_host.yml | This playbook installs the crucible binaries needed for the proper execution of the Multi-bench role.
+| [redhatci.ocp.conserver](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/conserver/README.md)            |  conserver-setup.yml       | This playbook configures conserver for one or more clusters, supporting IPMI SOL, libvirt socket, Dell iDRAC SSH, and HP iLO SSH console types.
 
 ## Multi-bench playbook
 ### Variables
@@ -27,3 +28,30 @@ The playbook will be run on the host `multibench`, make sure it is correctly def
           ansible_user: root
 ```
 Also, the installation needs to be run as root, verify that the ansible_user is correctly set.
+
+## Conserver setup playbook
+### Variables
+
+| Variable              | Default     | Type         | Required | Description                                                     |
+|-----------------------|-------------|--------------|----------|-----------------------------------------------------------------|
+| conserver_jumphost    | `localhost`  | string      | false    | Inventory hostname of the host running conserver                |
+| conserver_clusters    | —           | list(string) | true     | List of cluster group names to configure consoles for           |
+
+### Requirements
+Each cluster group must exist in your inventory, with nodes having the appropriate
+`console_type` and BMC credential host variables set. See the
+[conserver role README](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/conserver/README.md)
+for details.
+
+Example:
+```yaml
+  children:
+    cluster1:
+      hosts:
+        node1.cluster1.example.com:
+          name: node1
+          console_type: dell_idrac_ssh
+          bmc_address: 192.168.1.10
+          bmc_user: root
+          bmc_password: calvin
+```

--- a/playbooks/conserver-setup.yml
+++ b/playbooks/conserver-setup.yml
@@ -13,12 +13,24 @@
   hosts: "{{ conserver_jumphost | default('localhost') }}"
   gather_facts: false
   tasks:
+    - name: Validate conserver_clusters entries exist in inventory groups
+      ansible.builtin.assert:
+        that:
+          - cluster_item in groups
+        fail_msg: >-
+          Cluster group '{{ cluster_item }}' is not defined in the inventory.
+          Ensure each entry in conserver_clusters corresponds to an
+          inventory group.
+      loop: "{{ conserver_clusters }}"
+      loop_control:
+        loop_var: cluster_item
+
     - name: Configure conserver role for each cluster
       ansible.builtin.include_role:
         name: redhatci.ocp.conserver
       loop: "{{ conserver_clusters }}"
       loop_control:
-        loop_var: item
+        loop_var: cluster_item
       vars:
-        cluster: "{{ item }}"
-        cluster_nodes: "{{ groups[item] | default([]) }}"
+        conserver_cluster: "{{ cluster_item }}"
+        conserver_cluster_nodes: "{{ groups[cluster_item] | default([]) }}"

--- a/playbooks/conserver-setup.yml
+++ b/playbooks/conserver-setup.yml
@@ -1,0 +1,24 @@
+---
+# Configure conserver for one or more clusters.
+#
+# Variables:
+#   conserver_jumphost   - inventory hostname of the conserver host (default: localhost)
+#   conserver_clusters   - list of cluster group names to configure (required)
+#
+# Example:
+#   ansible-playbook playbooks/conserver-setup.yml \
+#     -e conserver_jumphost=jumphost.example.com \
+#     -e '{"conserver_clusters": ["cluster1", "cluster2"]}'
+- name: Configure conserver for all clusters
+  hosts: "{{ conserver_jumphost | default('localhost') }}"
+  gather_facts: false
+  tasks:
+    - name: Configure conserver role for each cluster
+      ansible.builtin.include_role:
+        name: redhatci.ocp.conserver
+      loop: "{{ conserver_clusters }}"
+      loop_control:
+        loop_var: item
+      vars:
+        cluster: "{{ item }}"
+        cluster_nodes: "{{ groups[item] | default([]) }}"

--- a/roles/conserver/README.md
+++ b/roles/conserver/README.md
@@ -1,0 +1,113 @@
+# conserver
+
+This role installs and configures [conserver](https://www.conserver.com/) to provide
+serial console access to cluster nodes. It supports four console types:
+
+- **IPMI Serial-over-LAN (SOL)** — classic IPMI SOL via ipmitool
+- **Libvirt socket** — virtual machine consoles via socat/UNIX socket
+- **Dell iDRAC SSH** — Dell iDRAC serial console via SSH (`console com2`)
+- **HP iLO SSH** — HP iLO virtual serial port via SSH (`vsp`)
+
+## Requirements
+
+- `conserver`, `conserver-client`, `ipmitool`, `socat`, and `sshpass` packages
+  (installed automatically by the role).
+- For Dell iDRAC SSH and HP iLO SSH console types, SSH access to the BMC must
+  be enabled and the `sshpass` package must be available on the conserver host.
+
+## Role Variables
+
+### Role-level variables (set per invocation)
+
+| Variable      | Type         | Required | Description                                                                                    |
+|---------------|--------------|----------|------------------------------------------------------------------------------------------------|
+| `cluster`     | string       | yes      | Cluster name. Used to namespace log directories and conserver config file names.               |
+| `cluster_nodes` | list(str)  | yes      | List of inventory hostnames in the cluster to configure consoles for.                          |
+
+### Host variables (set per node in inventory)
+
+| Variable                          | Type    | Required | Default  | Description                                                                                              |
+|-----------------------------------|---------|----------|----------|----------------------------------------------------------------------------------------------------------|
+| `console_type`                    | string  | no       | `ipmi`   | Console type: `ipmi`, `dell_idrac_ssh`, or `hp_ilo_ssh`. If unset and `socket_console` is true, libvirt socket is used. |
+| `socket_console`                  | boolean | no       | `false`  | Set to `true` to use a libvirt socket console (overrides `console_type`).                                |
+| `bmc_address` / `ipmi_address`    | string  | yes*     | —        | BMC/IPMI hostname or IP address. `bmc_address` takes precedence over `ipmi_address`.                     |
+| `bmc_user` / `ipmi_user`          | string  | yes*     | —        | BMC/IPMI username. `bmc_user` takes precedence over `ipmi_user`.                                         |
+| `bmc_password` / `ipmi_password`  | string  | yes*     | —        | BMC/IPMI password. `bmc_password` takes precedence over `ipmi_password`.                                 |
+| `ipmi_port`                       | integer | no       | `623`    | IPMI UDP port (IPMI SOL only).                                                                           |
+| `name`                            | string  | yes      | —        | Short hostname used as console name in conserver (e.g. `node1`).                                         |
+
+*Required for IPMI SOL, Dell iDRAC SSH, and HP iLO SSH console types.
+
+### Accumulated lists (managed internally)
+
+| Variable                       | Type      | Default | Description                                                                   |
+|--------------------------------|-----------|---------|-------------------------------------------------------------------------------|
+| `conserver_sol_hosts`          | list(str) | `[]`    | Nodes auto-detected as supporting IPMI SOL. Populated during role execution.  |
+| `conserver_socket_hosts`       | list(str) | `[]`    | Nodes configured for libvirt socket console. Populated during role execution. |
+| `conserver_dell_idrac_ssh_hosts` | list(str) | `[]` | Nodes configured for Dell iDRAC SSH console. Populated during role execution. |
+| `conserver_hp_ilo_ssh_hosts`   | list(str) | `[]`    | Nodes configured for HP iLO SSH console. Populated during role execution.     |
+
+## Example Inventory
+
+```yaml
+all:
+  hosts:
+    # IPMI SOL node (classic)
+    node-ipmi-1:
+      name: node-ipmi-1
+      bmc_address: 192.168.1.10
+      bmc_user: admin
+      bmc_password: secret
+
+    # Libvirt socket console (virtual machine)
+    node-libvirt-1:
+      name: node-libvirt-1
+      socket_console: true
+
+    # Dell iDRAC SSH console
+    node-idrac-1:
+      name: node-idrac-1
+      console_type: dell_idrac_ssh
+      bmc_address: 192.168.1.20
+      bmc_user: root
+      bmc_password: calvin
+
+    # HP iLO SSH console
+    node-ilo-1:
+      name: node-ilo-1
+      console_type: hp_ilo_ssh
+      bmc_address: 192.168.1.30
+      bmc_user: Administrator
+      bmc_password: secret
+
+  children:
+    mycluster:
+      hosts:
+        node-ipmi-1:
+        node-libvirt-1:
+        node-idrac-1:
+        node-ilo-1:
+```
+
+## Example Playbook
+
+```yaml
+---
+- name: Configure conserver for a cluster
+  hosts: conserver_host
+  gather_facts: false
+  tasks:
+    - name: Configure conserver
+      ansible.builtin.include_role:
+        name: redhatci.ocp.conserver
+      vars:
+        cluster: mycluster
+        cluster_nodes: "{{ groups['mycluster'] }}"
+```
+
+For multi-cluster setups, use the `playbooks/conserver-setup.yml` playbook
+which loops over `conserver_clusters` automatically.
+
+## License
+
+Apache-2.0

--- a/roles/conserver/README.md
+++ b/roles/conserver/README.md
@@ -21,8 +21,8 @@ serial console access to cluster nodes. It supports four console types:
 
 | Variable      | Type         | Required | Description                                                                                    |
 |---------------|--------------|----------|------------------------------------------------------------------------------------------------|
-| `cluster`     | string       | yes      | Cluster name. Used to namespace log directories and conserver config file names.               |
-| `cluster_nodes` | list(str)  | yes      | List of inventory hostnames in the cluster to configure consoles for.                          |
+| `conserver_cluster` | string  | yes      | Cluster name. Used to namespace log directories and conserver config file names.               |
+| `conserver_cluster_nodes` | list(str) | yes | List of inventory hostnames in the cluster to configure consoles for.                       |
 
 ### Host variables (set per node in inventory)
 
@@ -101,8 +101,8 @@ all:
       ansible.builtin.include_role:
         name: redhatci.ocp.conserver
       vars:
-        cluster: mycluster
-        cluster_nodes: "{{ groups['mycluster'] }}"
+        conserver_cluster: mycluster
+        conserver_cluster_nodes: "{{ groups['mycluster'] }}"
 ```
 
 For multi-cluster setups, use the `playbooks/conserver-setup.yml` playbook

--- a/roles/conserver/defaults/main.yml
+++ b/roles/conserver/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 conserver_sol_hosts: []
 conserver_socket_hosts: []
-...
+conserver_dell_idrac_ssh_hosts: []
+conserver_hp_ilo_ssh_hosts: []

--- a/roles/conserver/files/dell-idrac-ssh.sh
+++ b/roles/conserver/files/dell-idrac-ssh.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -u
+
+HOST="$1"
+USER="$2"
+PASS="$3"
+
+# Handle IPv6 addresses by wrapping in brackets
+case "$HOST" in
+  *:*)
+    SSH_HOST="[$HOST]"
+    ;;
+  *)
+    SSH_HOST="$HOST"
+    ;;
+esac
+
+SSHPASS="$PASS" exec sshpass -e ssh \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o LogLevel=ERROR \
+  -l "$USER" \
+  "$SSH_HOST" \
+  'console com2'

--- a/roles/conserver/files/dell-idrac-ssh.sh
+++ b/roles/conserver/files/dell-idrac-ssh.sh
@@ -16,8 +16,8 @@ case "$HOST" in
 esac
 
 SSHPASS="$PASS" exec sshpass -e ssh \
-  -o StrictHostKeyChecking=no \
-  -o UserKnownHostsFile=/dev/null \
+  -o StrictHostKeyChecking=accept-new \
+  -o UserKnownHostsFile=/var/lib/conserver/.ssh/known_hosts \
   -o LogLevel=ERROR \
   -l "$USER" \
   "$SSH_HOST" \

--- a/roles/conserver/files/hp-ilo-ssh.sh
+++ b/roles/conserver/files/hp-ilo-ssh.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -u
+
+HOST="$1"
+USER="$2"
+PASS="$3"
+
+# Handle IPv6 addresses by wrapping in brackets
+case "$HOST" in
+  *:*)
+    SSH_HOST="[$HOST]"
+    ;;
+  *)
+    SSH_HOST="$HOST"
+    ;;
+esac
+
+SSHPASS="$PASS" exec sshpass -e ssh \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o LogLevel=ERROR \
+  -l "$USER" \
+  "$SSH_HOST" \
+  'vsp'

--- a/roles/conserver/files/hp-ilo-ssh.sh
+++ b/roles/conserver/files/hp-ilo-ssh.sh
@@ -16,8 +16,8 @@ case "$HOST" in
 esac
 
 SSHPASS="$PASS" exec sshpass -e ssh \
-  -o StrictHostKeyChecking=no \
-  -o UserKnownHostsFile=/dev/null \
+  -o StrictHostKeyChecking=accept-new \
+  -o UserKnownHostsFile=/var/lib/conserver/.ssh/known_hosts \
   -o LogLevel=ERROR \
   -l "$USER" \
   "$SSH_HOST" \

--- a/roles/conserver/meta/argument_specs.yml
+++ b/roles/conserver/meta/argument_specs.yml
@@ -1,0 +1,53 @@
+---
+argument_specs:
+  main:
+    short_description: Configure conserver for serial console access
+    description:
+      - Installs and configures the conserver daemon to provide serial console access
+        to cluster nodes via IPMI SOL, libvirt socket, Dell iDRAC SSH, or HP iLO SSH.
+    options:
+      cluster:
+        type: str
+        required: true
+        description:
+          - Name of the cluster. Used to namespace conserver configuration files
+            and log directories.
+      cluster_nodes:
+        type: list
+        elements: str
+        required: true
+        description:
+          - List of inventory hostnames belonging to the cluster. Each host is
+            inspected for its console type and BMC credentials.
+      conserver_sol_hosts:
+        type: list
+        elements: str
+        required: false
+        default: []
+        description:
+          - Accumulates the list of cluster nodes that use IPMI Serial-over-LAN (SOL).
+            Populated automatically during role execution.
+      conserver_socket_hosts:
+        type: list
+        elements: str
+        required: false
+        default: []
+        description:
+          - Accumulates the list of cluster nodes that use a libvirt socket console.
+            Populated automatically during role execution.
+      conserver_dell_idrac_ssh_hosts:
+        type: list
+        elements: str
+        required: false
+        default: []
+        description:
+          - Accumulates the list of cluster nodes that use a Dell iDRAC SSH console.
+            Populated automatically during role execution.
+      conserver_hp_ilo_ssh_hosts:
+        type: list
+        elements: str
+        required: false
+        default: []
+        description:
+          - Accumulates the list of cluster nodes that use an HP iLO SSH console.
+            Populated automatically during role execution.

--- a/roles/conserver/meta/argument_specs.yml
+++ b/roles/conserver/meta/argument_specs.yml
@@ -6,13 +6,13 @@ argument_specs:
       - Installs and configures the conserver daemon to provide serial console access
         to cluster nodes via IPMI SOL, libvirt socket, Dell iDRAC SSH, or HP iLO SSH.
     options:
-      cluster:
+      conserver_cluster:
         type: str
         required: true
         description:
           - Name of the cluster. Used to namespace conserver configuration files
             and log directories.
-      cluster_nodes:
+      conserver_cluster_nodes:
         type: list
         elements: str
         required: true

--- a/roles/conserver/meta/main.yml
+++ b/roles/conserver/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  role_name: conserver
+  author: redhatci
+  description: Configure and manage conserver for serial console access to BMC and virtual hosts
+  license: Apache-2.0
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Fedora
+      versions:
+        - all
+    - name: EL
+      versions:
+        - "9"

--- a/roles/conserver/tasks/config-dell-idrac.yml
+++ b/roles/conserver/tasks/config-dell-idrac.yml
@@ -1,0 +1,24 @@
+---
+- name: Copy dell-idrac-ssh.sh to /usr/local/bin
+  become: true
+  ansible.builtin.copy:
+    dest: /usr/local/bin/dell-idrac-ssh
+    src: dell-idrac-ssh.sh
+    owner: "root"
+    group: "root"
+    mode: "0755"
+
+- name: Create conserver-dell-idrac-{{ cluster }}.cf
+  become: true
+  ansible.builtin.template:
+    dest: "/etc/conserver-dell-idrac-{{ cluster }}.cf"
+    src: conserver-dell-idrac.cf
+    owner: "root"
+    group: "root"
+    mode: "0644"
+
+- name: Add conserver-dell-idrac-{{ cluster }}.cf to conserver.cf
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/conserver.cf
+    line: '#include /etc/conserver-dell-idrac-{{ cluster }}.cf'

--- a/roles/conserver/tasks/config-dell-idrac.yml
+++ b/roles/conserver/tasks/config-dell-idrac.yml
@@ -19,6 +19,7 @@
 
 - name: Create Dell iDRAC conserver config for {{ conserver_cluster }}
   become: true
+  diff: false
   ansible.builtin.template:
     dest: "/etc/conserver-dell-idrac-{{ conserver_cluster }}.cf"
     src: conserver-dell-idrac.cf

--- a/roles/conserver/tasks/config-dell-idrac.yml
+++ b/roles/conserver/tasks/config-dell-idrac.yml
@@ -1,4 +1,13 @@
 ---
+- name: Create SSH known_hosts directory for conserver
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/conserver/.ssh
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: "0700"
+
 - name: Copy dell-idrac-ssh.sh to /usr/local/bin
   become: true
   ansible.builtin.copy:
@@ -8,17 +17,17 @@
     group: "root"
     mode: "0755"
 
-- name: Create conserver-dell-idrac-{{ cluster }}.cf
+- name: Create Dell iDRAC conserver config for {{ conserver_cluster }}
   become: true
   ansible.builtin.template:
-    dest: "/etc/conserver-dell-idrac-{{ cluster }}.cf"
+    dest: "/etc/conserver-dell-idrac-{{ conserver_cluster }}.cf"
     src: conserver-dell-idrac.cf
     owner: "root"
     group: "root"
-    mode: "0644"
+    mode: "0600"
 
-- name: Add conserver-dell-idrac-{{ cluster }}.cf to conserver.cf
+- name: Add Dell iDRAC config include for {{ conserver_cluster }}
   become: true
   ansible.builtin.lineinfile:
     path: /etc/conserver.cf
-    line: '#include /etc/conserver-dell-idrac-{{ cluster }}.cf'
+    line: '#include /etc/conserver-dell-idrac-{{ conserver_cluster }}.cf'

--- a/roles/conserver/tasks/config-hp-ilo.yml
+++ b/roles/conserver/tasks/config-hp-ilo.yml
@@ -8,17 +8,17 @@
     group: "root"
     mode: "0755"
 
-- name: Create conserver-hp-ilo-{{ cluster }}.cf
+- name: Create HP iLO conserver config for {{ conserver_cluster }}
   become: true
   ansible.builtin.template:
-    dest: "/etc/conserver-hp-ilo-{{ cluster }}.cf"
+    dest: "/etc/conserver-hp-ilo-{{ conserver_cluster }}.cf"
     src: conserver-hp-ilo.cf
     owner: "root"
     group: "root"
-    mode: "0644"
+    mode: "0600"
 
-- name: Add conserver-hp-ilo-{{ cluster }}.cf to conserver.cf
+- name: Add HP iLO config include for {{ conserver_cluster }}
   become: true
   ansible.builtin.lineinfile:
     path: /etc/conserver.cf
-    line: '#include /etc/conserver-hp-ilo-{{ cluster }}.cf'
+    line: '#include /etc/conserver-hp-ilo-{{ conserver_cluster }}.cf'

--- a/roles/conserver/tasks/config-hp-ilo.yml
+++ b/roles/conserver/tasks/config-hp-ilo.yml
@@ -1,4 +1,13 @@
 ---
+- name: Create SSH known_hosts directory for conserver
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/conserver/.ssh
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: "0700"
+
 - name: Copy hp-ilo-ssh.sh to /usr/local/bin
   become: true
   ansible.builtin.copy:
@@ -10,6 +19,7 @@
 
 - name: Create HP iLO conserver config for {{ conserver_cluster }}
   become: true
+  diff: false
   ansible.builtin.template:
     dest: "/etc/conserver-hp-ilo-{{ conserver_cluster }}.cf"
     src: conserver-hp-ilo.cf

--- a/roles/conserver/tasks/config-hp-ilo.yml
+++ b/roles/conserver/tasks/config-hp-ilo.yml
@@ -1,0 +1,24 @@
+---
+- name: Copy hp-ilo-ssh.sh to /usr/local/bin
+  become: true
+  ansible.builtin.copy:
+    dest: /usr/local/bin/hp-ilo-ssh
+    src: hp-ilo-ssh.sh
+    owner: "root"
+    group: "root"
+    mode: "0755"
+
+- name: Create conserver-hp-ilo-{{ cluster }}.cf
+  become: true
+  ansible.builtin.template:
+    dest: "/etc/conserver-hp-ilo-{{ cluster }}.cf"
+    src: conserver-hp-ilo.cf
+    owner: "root"
+    group: "root"
+    mode: "0644"
+
+- name: Add conserver-hp-ilo-{{ cluster }}.cf to conserver.cf
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/conserver.cf
+    line: '#include /etc/conserver-hp-ilo-{{ cluster }}.cf'

--- a/roles/conserver/tasks/config-ipmi.yml
+++ b/roles/conserver/tasks/config-ipmi.yml
@@ -6,9 +6,10 @@
     src: conserver-ipmi.cf
     owner: "root"
     group: "root"
-    mode: "0644"
+    mode: "0600"
 
 - name: Add conserver-ipmi.cf to conserver.cf
+  become: true
   ansible.builtin.lineinfile:
     path: /etc/conserver.cf
     line: '#include /etc/conserver-ipmi-{{ conserver_cluster }}.cf'

--- a/roles/conserver/tasks/config-ipmi.yml
+++ b/roles/conserver/tasks/config-ipmi.yml
@@ -2,7 +2,7 @@
 - name: Create conserver-ipmi.cf
   become: true
   ansible.builtin.template:
-    dest: "/etc/conserver-ipmi-{{ cluster }}.cf"
+    dest: "/etc/conserver-ipmi-{{ conserver_cluster }}.cf"
     src: conserver-ipmi.cf
     owner: "root"
     group: "root"
@@ -11,4 +11,4 @@
 - name: Add conserver-ipmi.cf to conserver.cf
   ansible.builtin.lineinfile:
     path: /etc/conserver.cf
-    line: '#include /etc/conserver-ipmi-{{ cluster }}.cf'
+    line: '#include /etc/conserver-ipmi-{{ conserver_cluster }}.cf'

--- a/roles/conserver/tasks/config-libvirt.yml
+++ b/roles/conserver/tasks/config-libvirt.yml
@@ -2,7 +2,7 @@
 - name: Create conserver-libvirt.cf
   become: true
   ansible.builtin.template:
-    dest: "/etc/conserver-libvirt-{{ cluster }}.cf"
+    dest: "/etc/conserver-libvirt-{{ conserver_cluster }}.cf"
     src: conserver-libvirt.cf
     owner: "root"
     group: "root"
@@ -21,4 +21,4 @@
   become: true
   ansible.builtin.lineinfile:
     path: /etc/conserver.cf
-    line: '#include /etc/conserver-libvirt-{{ cluster }}.cf'
+    line: '#include /etc/conserver-libvirt-{{ conserver_cluster }}.cf'

--- a/roles/conserver/tasks/config.yml
+++ b/roles/conserver/tasks/config.yml
@@ -1,4 +1,11 @@
 ---
+- name: Initialize host lists for this cluster
+  ansible.builtin.set_fact:
+    conserver_sol_hosts: []
+    conserver_socket_hosts: []
+    conserver_dell_idrac_ssh_hosts: []
+    conserver_hp_ilo_ssh_hosts: []
+
 - name: Create /var/consoles/{{ cluster }}
   become: true
   ansible.builtin.file:
@@ -9,9 +16,9 @@
 - name: Check for Serial over IPMI
   ansible.builtin.command:
     cmd: >
-      ipmitool -H {{ hostvars[item].ipmi_address }}
-               -U {{ hostvars[item].ipmi_user }}
-               -P {{ hostvars[item].ipmi_password }}
+      ipmitool -H {{ hostvars[item].bmc_address | default(hostvars[item].ipmi_address) }}
+               -U {{ hostvars[item].bmc_user | default(hostvars[item].ipmi_user) }}
+               -P {{ hostvars[item].bmc_password | default(hostvars[item].ipmi_password) }}
                -p {{ hostvars[item].ipmi_port | default(623) }}
                -I lanplus
                sol info
@@ -19,11 +26,16 @@
   ignore_errors: true
   changed_when: true
   loop: "{{ cluster_nodes }}"
+  when: >
+    hostvars[item].console_type | default('ipmi') == 'ipmi' and
+    not (hostvars[item].socket_console | default(false) | bool)
 
 - name: Build list of Serial over IPMI hosts
   ansible.builtin.set_fact:
     conserver_sol_hosts: "{{ conserver_sol_hosts + [item.item] }}"
-  when: item.rc == 0
+  when:
+    - item.rc is defined
+    - item.rc == 0
   loop: "{{ _conserver_sol.results | default([]) }}"
 
 - name: Include IPMI console config
@@ -39,3 +51,23 @@
 - name: Include libvirt console config
   ansible.builtin.include_tasks: config-libvirt.yml
   when: conserver_socket_hosts | length > 0
+
+- name: Build list of Dell iDRAC SSH console hosts
+  ansible.builtin.set_fact:
+    conserver_dell_idrac_ssh_hosts: "{{ conserver_dell_idrac_ssh_hosts + [item] }}"
+  when: hostvars[item].console_type | default('') == 'dell_idrac_ssh'
+  loop: "{{ cluster_nodes }}"
+
+- name: Include Dell iDRAC SSH console config
+  ansible.builtin.include_tasks: config-dell-idrac.yml
+  when: conserver_dell_idrac_ssh_hosts | length > 0
+
+- name: Build list of HP iLO SSH console hosts
+  ansible.builtin.set_fact:
+    conserver_hp_ilo_ssh_hosts: "{{ conserver_hp_ilo_ssh_hosts + [item] }}"
+  when: hostvars[item].console_type | default('') == 'hp_ilo_ssh'
+  loop: "{{ cluster_nodes }}"
+
+- name: Include HP iLO SSH console config
+  ansible.builtin.include_tasks: config-hp-ilo.yml
+  when: conserver_hp_ilo_ssh_hosts | length > 0

--- a/roles/conserver/tasks/config.yml
+++ b/roles/conserver/tasks/config.yml
@@ -6,10 +6,10 @@
     conserver_dell_idrac_ssh_hosts: []
     conserver_hp_ilo_ssh_hosts: []
 
-- name: Create /var/consoles/{{ cluster }}
+- name: Create /var/consoles/{{ conserver_cluster }}
   become: true
   ansible.builtin.file:
-    path: /var/consoles/{{ cluster }}
+    path: /var/consoles/{{ conserver_cluster }}
     mode: "0755"
     state: directory
 
@@ -25,7 +25,7 @@
   register: _conserver_sol
   ignore_errors: true
   changed_when: true
-  loop: "{{ cluster_nodes }}"
+  loop: "{{ conserver_cluster_nodes }}"
   when: >
     hostvars[item].console_type | default('ipmi') == 'ipmi' and
     not (hostvars[item].socket_console | default(false) | bool)
@@ -46,7 +46,7 @@
   ansible.builtin.set_fact:
     conserver_socket_hosts: "{{ conserver_socket_hosts + [item] }}"
   when: hostvars[item].socket_console | default(false) | bool
-  loop: "{{ cluster_nodes }}"
+  loop: "{{ conserver_cluster_nodes }}"
 
 - name: Include libvirt console config
   ansible.builtin.include_tasks: config-libvirt.yml
@@ -55,8 +55,10 @@
 - name: Build list of Dell iDRAC SSH console hosts
   ansible.builtin.set_fact:
     conserver_dell_idrac_ssh_hosts: "{{ conserver_dell_idrac_ssh_hosts + [item] }}"
-  when: hostvars[item].console_type | default('') == 'dell_idrac_ssh'
-  loop: "{{ cluster_nodes }}"
+  when: >
+    hostvars[item].console_type | default('') == 'dell_idrac_ssh' and
+    not (hostvars[item].socket_console | default(false) | bool)
+  loop: "{{ conserver_cluster_nodes }}"
 
 - name: Include Dell iDRAC SSH console config
   ansible.builtin.include_tasks: config-dell-idrac.yml
@@ -65,8 +67,10 @@
 - name: Build list of HP iLO SSH console hosts
   ansible.builtin.set_fact:
     conserver_hp_ilo_ssh_hosts: "{{ conserver_hp_ilo_ssh_hosts + [item] }}"
-  when: hostvars[item].console_type | default('') == 'hp_ilo_ssh'
-  loop: "{{ cluster_nodes }}"
+  when: >
+    hostvars[item].console_type | default('') == 'hp_ilo_ssh' and
+    not (hostvars[item].socket_console | default(false) | bool)
+  loop: "{{ conserver_cluster_nodes }}"
 
 - name: Include HP iLO SSH console config
   ansible.builtin.include_tasks: config-hp-ilo.yml

--- a/roles/conserver/tasks/packages.yml
+++ b/roles/conserver/tasks/packages.yml
@@ -7,5 +7,6 @@
       - conserver-client
       - ipmitool
       - socat
+      - sshpass
     state: present
 ...

--- a/roles/conserver/templates/conserver-dell-idrac.cf
+++ b/roles/conserver/templates/conserver-dell-idrac.cf
@@ -1,15 +1,15 @@
-default {{ cluster }}-idrac {
+default {{ conserver_cluster }}-idrac {
 	# The '&' character is substituted with the console name
-	logfile /var/consoles/{{ cluster }}/&;
+	logfile /var/consoles/{{ conserver_cluster }}/&;
 	timestamp 5mab;
 	master localhost;
 }
 
 {% for host in conserver_dell_idrac_ssh_hosts %}
-console {{ cluster }}-{{ hostvars[host].name }} {
-  include {{ cluster }}-idrac;
+console {{ conserver_cluster }}-{{ hostvars[host].name }} {
+  include {{ conserver_cluster }}-idrac;
   type exec;
-  exec "/usr/local/bin/dell-idrac-ssh {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) }} {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) }} {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) }}";
+  exec "/usr/local/bin/dell-idrac-ssh {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) | quote }} {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) | quote }} {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) | quote }}";
 }
 {% endfor %}
 

--- a/roles/conserver/templates/conserver-dell-idrac.cf
+++ b/roles/conserver/templates/conserver-dell-idrac.cf
@@ -1,0 +1,18 @@
+default {{ cluster }}-idrac {
+	# The '&' character is substituted with the console name
+	logfile /var/consoles/{{ cluster }}/&;
+	timestamp 5mab;
+	master localhost;
+}
+
+{% for host in conserver_dell_idrac_ssh_hosts %}
+console {{ cluster }}-{{ hostvars[host].name }} {
+  include {{ cluster }}-idrac;
+  type exec;
+  exec "/usr/local/bin/dell-idrac-ssh {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) }} {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) }} {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) }}";
+}
+{% endfor %}
+
+access * {
+        trusted 127.0.0.1;
+}

--- a/roles/conserver/templates/conserver-hp-ilo.cf
+++ b/roles/conserver/templates/conserver-hp-ilo.cf
@@ -1,15 +1,15 @@
-default {{ cluster }}-ilo {
+default {{ conserver_cluster }}-ilo {
 	# The '&' character is substituted with the console name
-	logfile /var/consoles/{{ cluster }}/&;
+	logfile /var/consoles/{{ conserver_cluster }}/&;
 	timestamp 5mab;
 	master localhost;
 }
 
 {% for host in conserver_hp_ilo_ssh_hosts %}
-console {{ cluster }}-{{ hostvars[host].name }} {
-  include {{ cluster }}-ilo;
+console {{ conserver_cluster }}-{{ hostvars[host].name }} {
+  include {{ conserver_cluster }}-ilo;
   type exec;
-  exec "/usr/local/bin/hp-ilo-ssh {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) }} {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) }} {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) }}";
+  exec "/usr/local/bin/hp-ilo-ssh {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) | quote }} {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) | quote }} {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) | quote }}";
 }
 {% endfor %}
 

--- a/roles/conserver/templates/conserver-hp-ilo.cf
+++ b/roles/conserver/templates/conserver-hp-ilo.cf
@@ -1,0 +1,18 @@
+default {{ cluster }}-ilo {
+	# The '&' character is substituted with the console name
+	logfile /var/consoles/{{ cluster }}/&;
+	timestamp 5mab;
+	master localhost;
+}
+
+{% for host in conserver_hp_ilo_ssh_hosts %}
+console {{ cluster }}-{{ hostvars[host].name }} {
+  include {{ cluster }}-ilo;
+  type exec;
+  exec "/usr/local/bin/hp-ilo-ssh {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) }} {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) }} {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) }}";
+}
+{% endfor %}
+
+access * {
+        trusted 127.0.0.1;
+}

--- a/roles/conserver/templates/conserver-ipmi.cf
+++ b/roles/conserver/templates/conserver-ipmi.cf
@@ -1,13 +1,13 @@
-default {{ cluster }} {
+default {{ conserver_cluster }} {
 	# The '&' character is substituted with the console name
-	logfile /var/consoles/{{ cluster }}/&;
+	logfile /var/consoles/{{ conserver_cluster }}/&;
 	timestamp 5mab;
 	master localhost;
 }
 
 {% for host in conserver_sol_hosts %}
-console {{ cluster }}-{{ hostvars[host].name }} {
-  include {{ cluster }};
+console {{ conserver_cluster }}-{{ hostvars[host].name }} {
+  include {{ conserver_cluster }};
   type exec;
   exec "/usr/bin/ipmitool -I lanplus -H {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) }} -U {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) }} -P {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) }}  sol deactivate && echo 'Disconnected' ; ulimit -v 31720 ; /usr/bin/ipmitool -I lanplus -H {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) }} -U {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) }} -P {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) }}  sol activate";
 }

--- a/roles/conserver/templates/conserver-ipmi.cf
+++ b/roles/conserver/templates/conserver-ipmi.cf
@@ -9,7 +9,7 @@ default {{ cluster }} {
 console {{ cluster }}-{{ hostvars[host].name }} {
   include {{ cluster }};
   type exec;
-  exec "/usr/bin/ipmitool -I lanplus -H {{ hostvars[host].ipmi_address }} -U {{ hostvars[host].ipmi_user }} -P {{ hostvars[host].ipmi_password }}  sol deactivate && echo 'Disconnected' ; ulimit -v 31720 ; /usr/bin/ipmitool -I lanplus -H {{ hostvars[host].ipmi_address }} -U {{ hostvars[host].ipmi_user }} -P {{ hostvars[host].ipmi_password }}  sol activate";
+  exec "/usr/bin/ipmitool -I lanplus -H {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) }} -U {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) }} -P {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) }}  sol deactivate && echo 'Disconnected' ; ulimit -v 31720 ; /usr/bin/ipmitool -I lanplus -H {{ hostvars[host].bmc_address | default(hostvars[host].ipmi_address) }} -U {{ hostvars[host].bmc_user | default(hostvars[host].ipmi_user) }} -P {{ hostvars[host].bmc_password | default(hostvars[host].ipmi_password) }}  sol activate";
 }
 {% endfor %}
 

--- a/roles/conserver/templates/conserver-libvirt.cf
+++ b/roles/conserver/templates/conserver-libvirt.cf
@@ -4,12 +4,12 @@ default libvirt {
     exec "/usr/local/bin/socat_retry.sh STDIN UNIX-CONNECT:/var/lib/libvirt/consoles/Q";
     execsubst Q=hs;
     timestamp 5mab;
-    logfile /var/consoles/{{ cluster }}/&;
+    logfile /var/consoles/{{ conserver_cluster }}/&;
     master localhost;
 }
 
 {% for host in conserver_socket_hosts %}
-console {{ cluster }}-{{ host }} { include libvirt; host {{ host }}.console; }
+console {{ conserver_cluster }}-{{ host }} { include libvirt; host {{ host }}.console; }
 {% endfor %}
 
 access * {


### PR DESCRIPTION
## Summary

Adds SSH-based console access (Dell iDRAC SSH and HP iLO SSH) to the `conserver` role, complementing existing IPMI SOL support:

- Introduced helper scripts (`dell-idrac-ssh.sh`, `hp-ilo-ssh.sh`) for IPv6-aware SSH console connectivity deployed to `/usr/local/bin/`
- Added `playbooks/conserver-setup.yml` to automate conserver setup from lab inventories using `conserver_cluster` / `conserver_cluster_nodes` variables (fully prefixed to avoid collisions)
- Added argument validation: the playbook asserts each `conserver_clusters` entry exists in inventory groups before running the role, preventing silent failures
- `socket_console: true` properly overrides `console_type` — Dell iDRAC and HP iLO SSH hosts are only built when socket_console is not set
- SSH host-key verification uses `accept-new` + persistent `/var/lib/conserver/.ssh/known_hosts` in both `dell-idrac-ssh.sh` and `hp-ilo-ssh.sh` (no more `StrictHostKeyChecking=no`)
- `diff: false` on template tasks for Dell iDRAC and HP iLO configs prevents `bmc_password` from leaking in `--diff` mode output
- BMC credential variables are shell-quoted in all conserver config templates to prevent injection
- Rendered BMC config files use mode `0600` to protect cleartext credentials (Dell iDRAC, HP iLO, and IPMI)
- `become: true` added to all privileged file operations including the IPMI lineinfile task
- Bumped collection version to 6.1.0

## Changes

- `roles/conserver/meta/main.yml` — new role metadata file
- `roles/conserver/meta/argument_specs.yml` — argument specifications for role variables
- `roles/conserver/defaults/main.yml` — added new host lists for Dell iDRAC and HP iLO SSH consoles
- `roles/conserver/tasks/config.yml` — list pre-initialization, BMC var normalization, new console type detection
- `roles/conserver/tasks/packages.yml` — added `sshpass` package dependency
- `roles/conserver/tasks/config-dell-idrac.yml` — new task file for Dell iDRAC SSH console config; `diff: false` on template task
- `roles/conserver/tasks/config-hp-ilo.yml` — new task file for HP iLO SSH console config; `diff: false` on template task; SSH known_hosts directory creation
- `roles/conserver/tasks/config-ipmi.yml` — mode `0644`→`0600` for cleartext BMC password file; `become: true` added to lineinfile task
- `roles/conserver/templates/conserver-dell-idrac.cf` — conserver config template for Dell iDRAC SSH
- `roles/conserver/templates/conserver-hp-ilo.cf` — conserver config template for HP iLO SSH
- `roles/conserver/templates/conserver-ipmi.cf` — updated BMC var normalization
- `roles/conserver/files/dell-idrac-ssh.sh` — helper script for Dell iDRAC SSH console (IPv6-aware)
- `roles/conserver/files/hp-ilo-ssh.sh` — helper script for HP iLO SSH console (IPv6-aware); updated to `accept-new` + persistent known_hosts
- `roles/conserver/README.md` — full documentation update covering all console types
- `playbooks/conserver-setup.yml` — new playbook for conserver setup from lab inventories
- `playbooks/README.md` — added entry for new conserver-setup playbook
- `galaxy.yml` — version bumped from 6.0.0 to 6.1.0
- `ansible-collection-redhatci-ocp.spec` — new changelog entry (6.1) for SSH console support on Aug 15 2026

##  DCI

Test-Hints: no-check

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)