### PR TITLE
Using yaml instead of text operations to manipulate the image source files

### DIFF
--- a/roles/mirror_catalog/tasks/append_image_source_mirrors.yml
+++ b/roles/mirror_catalog/tasks/append_image_source_mirrors.yml
@@ -1,0 +1,50 @@
+---
+- name: Validate append Image Source inputs
+  ansible.builtin.assert:
+    that:
+      - ais_file is defined
+      - ais_file | length
+      - ais_images is defined
+      - ais_images | length
+      - ais_registry is defined
+      - ais_registry | length
+
+- name: Load Image Source manifest documents
+  ansible.builtin.set_fact:
+    _ais_documents: "{{ lookup('file', ais_file) | from_yaml_all | list }}"
+
+- name: Build mirror entries for Image Source append
+  ansible.builtin.set_fact:
+    _ais_new_entries: "{{ _ais_new_entries | default([]) + [_ais_entry] }}"
+  vars:
+    _ais_entry:
+      mirrors:
+        - "{{ ais_registry }}/{{ (item.split('@')[0].split('/')[1:]) | join('/') }}"
+      source: "{{ item.split('@')[0] }}"
+  loop: "{{ ais_images }}"
+
+- name: Merge mirror entries into Image Source documents
+  ansible.builtin.set_fact:
+    _ais_updated_documents: "{{ _ais_updated_documents | default([]) + [_ais_updated_doc] }}"
+  vars:
+    _ais_mirror_key: >-
+      {{
+        'imageDigestMirrors' if item.kind == 'ImageDigestMirrorSet'
+        else 'imageTagMirrors' if item.kind == 'ImageTagMirrorSet'
+        else 'repositoryDigestMirrors'
+      }}
+    _ais_existing: "{{ item.spec[_ais_mirror_key] | default([]) }}"
+    _ais_merged: "{{ (_ais_existing + _ais_new_entries) | unique(attribute='source') }}"
+    _ais_updated_doc: >-
+      {{
+        item | combine({'spec': item.spec | combine({_ais_mirror_key: _ais_merged})}, recursive=True)
+        if item.kind in ['ImageDigestMirrorSet', 'ImageTagMirrorSet', 'ImageContentSourcePolicy']
+        else item
+      }}
+  loop: "{{ _ais_documents }}"
+
+- name: Write updated Image Source file
+  ansible.builtin.copy:
+    dest: "{{ ais_file }}"
+    content: "{{ _ais_updated_documents | map('to_yaml') | join('\n---\n') }}"  # noqa: jinja[invalid]
+    mode: "0644"

--- a/roles/operator_sdk/tasks/mirroring.yml
+++ b/roles/operator_sdk/tasks/mirroring.yml
@@ -61,17 +61,14 @@
     oo_index: "{{ mc_catalog_digest }}"
 
 - name: Append operator-sdk images to Image Sources
+  ansible.builtin.include_role:
+    name: redhatci.ocp.mirror_catalog
+    tasks_from: append_image_source_mirrors
   vars:
     scorecard_basic_images: "{{ [scorecard_test_img, scorecard_storage_img, scorecard_untar_img] }}"
-  ansible.builtin.blockinfile:
-    block: |
-      # Scorecard container
-        - mirrors:
-          - {{ scorecard_dci_local_registry }}/{{ '/'.join(item.split('@')[0].split('/')[1:]) }}
-          source: {{ item.split('@')[0] }}
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.split('@')[0] }}"
-    path: "{{ scorecard_is_file }}"
-  loop: "{{ scorecard_basic_images }}"
+    ais_file: "{{ scorecard_is_file }}"
+    ais_images: "{{ scorecard_basic_images }}"
+    ais_registry: "{{ scorecard_dci_local_registry }}"
 
 - name: Display new Image Source file to be applied
   ansible.builtin.debug:
@@ -79,7 +76,7 @@
 
 - name: Apply Image Source File
   kubernetes.core.k8s:
-    definition: "{{ lookup('file', scorecard_is_file) }}"
+    definition: "{{ lookup('file', scorecard_is_file) | from_yaml_all | list }}"
 
 - name: Wait for MCP status
   ansible.builtin.include_role:

--- a/roles/operator_sdk/tasks/teardown.yml
+++ b/roles/operator_sdk/tasks/teardown.yml
@@ -2,7 +2,7 @@
 - name: Delete Image Source from cluster
   kubernetes.core.k8s:
     state: absent
-    definition: "{{ lookup('file', scorecard_is_file) }}"
+    definition: "{{ lookup('file', scorecard_is_file) | from_yaml_all | list }}"
 
 - name: Wait for MCP status
   ansible.builtin.include_role:

--- a/roles/preflight/tasks/mirroring.yml
+++ b/roles/preflight/tasks/mirroring.yml
@@ -63,18 +63,17 @@
     oo_index: "{{ mc_catalog_digest }}"
 
 - name: Append pre-flight images to Image Sources
-  ansible.builtin.blockinfile:
-    block: |
-        - mirrors:
-          - {{ dci_local_registry }}/{{ '/'.join(item.split('@')[0].split('/')[1:]) }}
-          source: {{ item.split('@')[0] }}
-    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.split('@')[0] }}"
-    path: "{{ preflight_is_file }}"
-  loop: "{{ preflight_images }}"
+  ansible.builtin.include_role:
+    name: redhatci.ocp.mirror_catalog
+    tasks_from: append_image_source_mirrors
+  vars:
+    ais_file: "{{ preflight_is_file }}"
+    ais_images: "{{ preflight_images }}"
+    ais_registry: "{{ dci_local_registry }}"
 
 - name: Apply Image Source file
   kubernetes.core.k8s:
-    definition: "{{ lookup('file', preflight_is_file) }}"
+    definition: "{{ lookup('file', preflight_is_file) | from_yaml_all | list }}"
 
 - name: Wait for MCP status
   ansible.builtin.include_role:

--- a/roles/preflight/tasks/teardown.yml
+++ b/roles/preflight/tasks/teardown.yml
@@ -5,7 +5,7 @@
     - name: Delete Image Source from cluster
       kubernetes.core.k8s:
         state: absent
-        definition: "{{ lookup('file', preflight_is_file) }}"
+        definition: "{{ lookup('file', preflight_is_file) | from_yaml_all | list }}"
 
     - name: Wait for MCP status
       ansible.builtin.include_role:


### PR DESCRIPTION
##### SUMMARY

The preflight and operator_sdk roles are affected by an error due to the use of blockinfile operations to extend the contents in the image source files.

The blockinfile module ignores the yaml structure of these files and may corrupt it when appending new content.

This PR, creates a "run on request" tasks file into the mirror_catalog role and replaces the use of the blockinfile module with calls to this tasks file from the prefligh and operator_sdk roles. The append_image_source_mirrors.yml tasks file is able to edit the IS files in a yaml aware mode.

Note the tasks file was added to the mirror_catalog role and not to one of the affected roles, because the mirror_catalog role is the one that initially creates the IS file and thus the tasks are resusable and shared among the affected roles.

Fixes CILAB-2760

##### ISSUE TYPE

- Bug

##### Tests

- [ ] Testvcp: ocp-4.18-vanilla example-cnf - <JobURL>
- [ ] TestvcpWorkload: operator-sdk - <JobURL>

---

Testvcp: ocp-4.18-vanilla example-cnf
TestvcpWorkload: operator-sdk
