### PR TITLE
[preflight] Keep indentation on image sources

### DIFF
--- a/roles/preflight/tasks/mirroring.yml
+++ b/roles/preflight/tasks/mirroring.yml
@@ -65,6 +65,7 @@
 - name: Append pre-flight images to Image Sources
   ansible.builtin.blockinfile:
     block: |
+      # Mirrors (keep this comment to keep mirrors correctly indented)
         - mirrors:
           - {{ dci_local_registry }}/{{ '/'.join(item.split('@')[0].split('/')[1:]) }}
           source: {{ item.split('@')[0] }}


### PR DESCRIPTION
##### SUMMARY

Previous commit to the mirroring removed a comment that is expected to indent correctly the mirrors in IDMS/ICSP.

Fixes an issue introduced in #1005 

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDgtMThUMTY6MDE6NTV8NjVhNjNmMTIyM2I1ZDk0MjRlOTViMTYxMDc4NThhODQ4ZDcwZTRjNg==
Gitleaks-Hash: 790ee11a7b1445699f0f90a2a030b159a3fd5c1ee2a8331ac1f52051ae7cc964

##### ISSUE TYPE

- Bug

##### Tests

- [x] example-cnf: https://www.distributed-ci.io/jobs/3649985b-64d8-4a75-ac9e-5e7ba8c13a1b

Test-hints: no-check