### PR TITLE
Bump certsuite to v5.5.24

### DIFF
--- a/roles/k8s_best_practices_certsuite/defaults/main.yml
+++ b/roles/k8s_best_practices_certsuite/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 kbpc_check_commit_sha: false
-kbpc_version: v5.5.23
+kbpc_version: v5.5.24
 kbpc_repo_org_name: redhat-best-practices-for-k8s
 kbpc_project_name: certsuite
 kbpc_repository: "https://github.com/{{ kbpc_repo_org_name }}/{{ kbpc_project_name }}"
@@ -41,6 +41,8 @@ kbpc_feedback:
   access-control-cluster-role-bindings: ""
   access-control-container-host-port: ""
   access-control-crd-roles: ""
+  access-control-dac-override-capability-check: ""
+  access-control-dac-read-search-capability-check: ""
   access-control-ipc-lock-capability-check: ""
   access-control-namespace: ""
   access-control-namespace-resource-quota: ""
@@ -63,6 +65,7 @@ kbpc_feedback:
   access-control-service-type: ""
   access-control-ssh-daemons: ""
   access-control-sys-admin-capability-check: ""
+  access-control-sys-module-capability-check: ""
   access-control-sys-nice-realtime-capability: ""
   access-control-sys-ptrace-capability: ""
   affiliated-certification-container-is-certified-digest: ""


### PR DESCRIPTION
##### SUMMARY

- Bump certsuite version
- Added coverage for new tests created [here](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3808)

##### ISSUE TYPE

- Bump version

##### Tests

- [x] Test: https://www.distributed-ci.io/jobs/6b3dbdfd-2f11-48c5-8702-d51765676433/jobStates

Test-Hints: no-check