### PR TITLE
Add NetworkPolicy for IPv6 and restrict CIDR

### DIFF
--- a/roles/acm/utils/README.md
+++ b/roles/acm/utils/README.md
@@ -20,6 +20,7 @@ Brings functionality that is commonly used among those roles.
 | utils_iso_url                       | None                                | disconnect-agent                 | The URL to the ISO image to use in the Assisted Images service.
 | utils_root_fs_url                   | None                                | disconnect-agent                 | The URL to the rootfs image to use in the Assisted Images service.
 | utils_os_image_url                  | None                                | allow-ais-http-egress            | OS/RHCOS image URL used to derive the egress port for assisted-image-service.
+| utils_os_image_host_ips             | []                                  | allow-ais-http-egress            | Optional IPv4/IPv6 list for egress. When empty, resolve in-cluster via openshift-dns.
 | utils_policy_retries                | 30                                  | validate-policies                | Number of retries for policy validation.
 | utils_policy_delay                  | 10                                  | validate-policies                | Delay in seconds between retries for policy validation.
 | utils_policy_namespace              | default                             | validate-policies                | The namespace where the ACM policies are deployed.
@@ -133,12 +134,18 @@ This task generates the `utils_acm_registries` variable containing the transform
 
 Creates a NetworkPolicy so assisted-image-service can reach an OS image URL on ports
 other than 443. Runs only when the MultiClusterEngine CR has
-`spec.networkPolicies` set and `enabled: true`.
+`spec.networkPolicies` set and `enabled: true`. Host addresses come from
+`utils_os_image_host_ips` when set; otherwise they are resolved in-cluster via an
+openshift-dns pod. Egress is limited to those IPv4 (/32) and IPv6 (/128) addresses.
 
 ```yaml
 - name: Allow AIS egress to OS image webserver
   vars:
     utils_os_image_url: http://webserver.local:8080/rhcos-live.x86_64.iso
+    # Optional: skip DNS and pin egress to these addresses
+    # utils_os_image_host_ips:
+    #   - 192.0.2.10
+    #   - 2001:db8::10
   ansible.builtin.include_role:
     name: redhatci.ocp.acm.utils
     tasks_from: allow-ais-http-egress

--- a/roles/acm/utils/README.md
+++ b/roles/acm/utils/README.md
@@ -20,7 +20,7 @@ Brings functionality that is commonly used among those roles.
 | utils_iso_url                       | None                                | disconnect-agent                 | The URL to the ISO image to use in the Assisted Images service.
 | utils_root_fs_url                   | None                                | disconnect-agent                 | The URL to the rootfs image to use in the Assisted Images service.
 | utils_os_image_url                  | None                                | allow-ais-http-egress            | OS/RHCOS image URL used to derive the egress port for assisted-image-service.
-| utils_os_image_host_ips             | []                                  | allow-ais-http-egress            | Optional IPv4/IPv6 list for egress. When empty, resolve in-cluster via openshift-dns.
+| utils_os_image_host_ips             | []                                  | allow-ais-http-egress            | Optional IPv4/IPv6 addresses or CIDRs for egress (e.g. `192.0.2.10/32`). When empty, resolve in-cluster via openshift-dns.
 | utils_policy_retries                | 30                                  | validate-policies                | Number of retries for policy validation.
 | utils_policy_delay                  | 10                                  | validate-policies                | Delay in seconds between retries for policy validation.
 | utils_policy_namespace              | default                             | validate-policies                | The namespace where the ACM policies are deployed.
@@ -136,16 +136,30 @@ Creates a NetworkPolicy so assisted-image-service can reach an OS image URL on p
 other than 443. Runs only when the MultiClusterEngine CR has
 `spec.networkPolicies` set and `enabled: true`. Host addresses come from
 `utils_os_image_host_ips` when set; otherwise they are resolved in-cluster via an
-openshift-dns pod. Egress is limited to those IPv4 (/32) and IPv6 (/128) addresses.
+openshift-dns pod. Egress uses each entry as a CIDR when a prefix is given; otherwise
+DNS-resolved addresses default to /32 (IPv4) or /128 (IPv6).
+
+Resolve the URL hostname in-cluster (default):
 
 ```yaml
 - name: Allow AIS egress to OS image webserver
   vars:
     utils_os_image_url: http://webserver.local:8080/rhcos-live.x86_64.iso
-    # Optional: skip DNS and pin egress to these addresses
-    # utils_os_image_host_ips:
-    #   - 192.0.2.10
-    #   - 2001:db8::10
+  ansible.builtin.include_role:
+    name: redhatci.ocp.acm.utils
+    tasks_from: allow-ais-http-egress
+```
+
+Skip DNS and pin egress to explicit addresses or CIDRs:
+
+```yaml
+- name: Allow AIS egress to OS image webserver with fixed CIDRs
+  vars:
+    utils_os_image_url: http://webserver.local:8080/rhcos-live.x86_64.iso
+    utils_os_image_host_ips:
+      - 192.0.2.10/32
+      - 2600:12:1::10/128
+      - 192.0.2.0/24
   ansible.builtin.include_role:
     name: redhatci.ocp.acm.utils
     tasks_from: allow-ais-http-egress

--- a/roles/acm/utils/defaults/main.yml
+++ b/roles/acm/utils/defaults/main.yml
@@ -11,4 +11,5 @@ utils_policy_retries: 30
 utils_policy_delay: 10
 utils_policy_namespace: default
 utils_policy_strict: true
+utils_os_image_host_ips: []
 ...

--- a/roles/acm/utils/meta/argument_specs.yml
+++ b/roles/acm/utils/meta/argument_specs.yml
@@ -105,7 +105,8 @@ argument_specs:
     description: >
       Create a NetworkPolicy that allows assisted-image-service pods to reach the port
       used by an OS image URL. Host IPs are resolved in-cluster via openshift-dns;
-      egress is limited to those IPv4 (/32) and IPv6 (/128) addresses. Skipped unless
+      egress is limited to those addresses (default /32 for IPv4 and /128 for IPv6),
+      or to explicit CIDR blocks when set in utils_os_image_host_ips. Skipped unless
       the MultiClusterEngine CR has spec.networkPolicies.enabled set to true.
     options:
       utils_os_image_url:
@@ -119,9 +120,10 @@ argument_specs:
         elements: str
         default: []
         description: >
-          Optional list of IPv4/IPv6 addresses to allow in the NetworkPolicy. When set,
-          in-cluster DNS resolution is skipped. When empty, addresses are resolved via
-          openshift-dns from the URL hostname.
+          Optional list of IPv4/IPv6 addresses or CIDR blocks to allow in the NetworkPolicy
+          (e.g. 192.0.2.10/32, 2600:12:1::10/128). When set, in-cluster DNS resolution
+          is skipped. When empty, addresses are resolved via openshift-dns from the URL
+          hostname and use /32 or /128 respectively.
   validate-policies:
     short_description: Validate ACM policies compliance
     description: >

--- a/roles/acm/utils/meta/argument_specs.yml
+++ b/roles/acm/utils/meta/argument_specs.yml
@@ -104,13 +104,24 @@ argument_specs:
     short_description: Allow assisted-image-service egress to an OS image HTTP(S) URL
     description: >
       Create a NetworkPolicy that allows assisted-image-service pods to reach the port
-      used by an OS image URL.
+      used by an OS image URL. Host IPs are resolved in-cluster via openshift-dns;
+      egress is limited to those IPv4 (/32) and IPv6 (/128) addresses. Skipped unless
+      the MultiClusterEngine CR has spec.networkPolicies.enabled set to true.
     options:
       utils_os_image_url:
         type: str
         required: true
         description: >
           URL of the OS/RHCOS image hosted for Assisted Service (e.g. http://webserver:8080/rhcos.iso).
+      utils_os_image_host_ips:
+        type: list
+        required: false
+        elements: str
+        default: []
+        description: >
+          Optional list of IPv4/IPv6 addresses to allow in the NetworkPolicy. When set,
+          in-cluster DNS resolution is skipped. When empty, addresses are resolved via
+          openshift-dns from the URL hostname.
   validate-policies:
     short_description: Validate ACM policies compliance
     description: >

--- a/roles/acm/utils/tasks/allow-ais-http-egress.yml
+++ b/roles/acm/utils/tasks/allow-ais-http-egress.yml
@@ -100,8 +100,9 @@
         pod: "{{ _utils_dns_pods.resources[0].metadata.name }}"
         container: dns
         command: >-
-          /bin/sh -c "dig +short +time=5 +tries=2 A {{ _utils_host | to_json }};
-          dig +short +time=5 +tries=2 AAAA {{ _utils_host | to_json }}"
+          /bin/sh -c 'dig +short +time=5 +tries=2 A "$1";
+          dig +short +time=5 +tries=2 AAAA "$1"'
+          -- {{ _utils_host | quote }}
       register: _utils_host_ips
       changed_when: false
       failed_when: >-
@@ -122,10 +123,7 @@
       {{
         utils_os_image_host_ips
         if (utils_os_image_host_ips | length) > 0
-        else (
-          (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv4') | list)[-1:]
-          + (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv6') | list)[-1:]
-        )
+        else (_utils_host_ips.stdout_lines | default([]))
       }}
     _utils_img_parts: "{{ utils_os_image_url | urlsplit }}"
     _utils_default_port: "{{ (_utils_img_parts.scheme == 'https') | ternary(443, 80) }}"

--- a/roles/acm/utils/tasks/allow-ais-http-egress.yml
+++ b/roles/acm/utils/tasks/allow-ais-http-egress.yml
@@ -1,13 +1,16 @@
 ---
-# Allow HTTP(S) egress to the port used by the OS image URL (e.g. http://host:8080/...).
-# Only applies when MultiClusterEngine has networkPolicies present and enabled.
-# Egress is limited to IPv4 (/32) and IPv6 (/128) addresses of the URL host.
-# IPs come from utils_os_image_host_ips when set; otherwise resolved in-cluster via openshift-dns.
+# Allow assisted-image-service egress when MultiClusterEngine has networkPolicies enabled:
+#   1. Same-namespace TCP 8090 to assisted-service (discovery.ign when serving ISOs).
+#      MCE's default AIS policy only allows DNS, kube API 6443, and HTTPS 443.
+#   2. HTTP(S) to the OS image URL port (e.g. http://host:8080/...).
+#      Egress is limited to IPv4 and IPv6 addresses of the URL host (default /32 and /128).
+#      IPs come from utils_os_image_host_ips when set; otherwise resolved in-cluster via
+#      openshift-dns
 #
 # Required vars:
 #   utils_os_image_url: URL of the RHCOS live ISO (or other OS image) hosted for Assisted Service
 # Optional vars:
-#   utils_os_image_host_ips: list of IPv4/IPv6 addresses to allow (skips in-cluster DNS when set)
+#   utils_os_image_host_ips: list of IPv4/IPv6 addresses or CIDRs (skips in-cluster DNS when set)
 
 - name: "Validate OS image URL for AIS HTTP egress"
   ansible.builtin.assert:
@@ -25,12 +28,11 @@
     that:
       - utils_os_image_host_ips is sequence
       - >-
-          (utils_os_image_host_ips | select('ansible.utils.ipv4') | list | length)
-          + (utils_os_image_host_ips | select('ansible.utils.ipv6') | list | length)
+          (utils_os_image_host_ips | select('ansible.utils.ipaddr') | list | length)
           == (utils_os_image_host_ips | length)
     fail_msg: >-
-      utils_os_image_host_ips must be a list of IPv4 and/or IPv6 addresses
-      (got {{ utils_os_image_host_ips | default([]) }}).
+      utils_os_image_host_ips must be a list of IPv4/IPv6 addresses or CIDR blocks
+      (e.g. 192.0.2.10/32, 2600:12:1::10/128; got {{ utils_os_image_host_ips | default([]) }}).
 
 - name: "Get MultiClusterEngine"
   kubernetes.core.k8s_info:
@@ -38,6 +40,36 @@
     kind: MultiClusterEngine
   register: _utils_mce
   failed_when: false
+
+- name: "Create NetworkPolicy for assisted-image-service to assisted-service"
+  when:
+    - (_utils_mce.resources | default([]) | length) > 0
+    - ((_utils_mce.resources | first).spec | default({})).networkPolicies is defined
+    - ((_utils_mce.resources | first).spec.networkPolicies.enabled | default(false)) | bool
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: assisted-image-service-allow-assisted-service
+        namespace: multicluster-engine
+        labels:
+          app: assisted-image-service
+      spec:
+        podSelector:
+          matchLabels:
+            app: assisted-image-service
+        policyTypes:
+          - Egress
+        egress:
+          - to:
+              - podSelector:
+                  matchLabels:
+                    app: assisted-service
+            ports:
+              - protocol: TCP
+                port: 8090
 
 - name: "Resolve OS image host addresses in-cluster for AIS HTTP egress"
   when:
@@ -62,17 +94,14 @@
       retries: 10
       delay: 5
 
-    - name: "Resolve OS image host via openshift-dns"
-      vars:
-        _utils_dns_pod: "{{ _utils_dns_pods.resources[0].metadata.name }}"
+    - name: "Resolve OS image host A/AAAA via openshift-dns"
       kubernetes.core.k8s_exec:
         namespace: openshift-dns
-        pod: "{{ _utils_dns_pod }}"
+        pod: "{{ _utils_dns_pods.resources[0].metadata.name }}"
         container: dns
-        # k8s_exec expects a string (shlex-split); a YAML list is stringified and breaks exec.
         command: >-
-          /bin/sh -c "dig +short +time=5 +tries=2 A {{ _utils_host }};
-          dig +short +time=5 +tries=2 AAAA {{ _utils_host }}"
+          /bin/sh -c "dig +short +time=5 +tries=2 A {{ _utils_host | to_json }};
+          dig +short +time=5 +tries=2 AAAA {{ _utils_host | to_json }}"
       register: _utils_host_ips
       changed_when: false
       failed_when: >-
@@ -80,6 +109,7 @@
           (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv4') | list | length)
           + (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv6') | list | length)
         ) == 0
+      no_log: true
 
 - name: "Create NetworkPolicy for assisted-image-service OS image HTTP egress"
   when:
@@ -91,10 +121,10 @@
     _utils_egress_ips: >-
       {{
         utils_os_image_host_ips
-        if (utils_os_image_host_ips | default([]) | length) > 0
+        if (utils_os_image_host_ips | length) > 0
         else (
-          (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv4') | list)
-          + (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv6') | list)
+          (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv4') | list)[-1:]
+          + (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv6') | list)[-1:]
         )
       }}
     _utils_img_parts: "{{ utils_os_image_url | urlsplit }}"
@@ -107,8 +137,12 @@
       }}
     _utils_ip_blocks: >-
       {%- set ns = namespace(items=[]) -%}
-      {%- for ip in _utils_egress_ips -%}
-      {%- set cidr = ip ~ ('/128' if (ip is ansible.utils.ipv6) else '/32') -%}
+      {%- for entry in _utils_egress_ips -%}
+      {%- if '/' in (entry | string) -%}
+      {%- set cidr = entry -%}
+      {%- else -%}
+      {%- set cidr = entry ~ ('/128' if (entry is ansible.utils.ipv6) else '/32') -%}
+      {%- endif -%}
       {%- set _ = ns.items.append({'ipBlock': {'cidr': cidr}}) -%}
       {%- endfor -%}
       {{ ns.items }}

--- a/roles/acm/utils/tasks/allow-ais-http-egress.yml
+++ b/roles/acm/utils/tasks/allow-ais-http-egress.yml
@@ -1,22 +1,36 @@
 ---
 # Allow HTTP(S) egress to the port used by the OS image URL (e.g. http://host:8080/...).
 # Only applies when MultiClusterEngine has networkPolicies present and enabled.
+# Egress is limited to IPv4 (/32) and IPv6 (/128) addresses of the URL host.
+# IPs come from utils_os_image_host_ips when set; otherwise resolved in-cluster via openshift-dns.
 #
 # Required vars:
 #   utils_os_image_url: URL of the RHCOS live ISO (or other OS image) hosted for Assisted Service
+# Optional vars:
+#   utils_os_image_host_ips: list of IPv4/IPv6 addresses to allow (skips in-cluster DNS when set)
 
-- name: "Validate OS image URL scheme for AIS HTTP egress"
-  when:
-    - utils_os_image_url is defined
-    - utils_os_image_url | length > 0
-  vars:
-    _utils_img_parts: "{{ utils_os_image_url | urlsplit }}"
+- name: "Validate OS image URL for AIS HTTP egress"
   ansible.builtin.assert:
     that:
-      - _utils_img_parts.scheme in ['http', 'https']
+      - utils_os_image_url is defined
+      - utils_os_image_url | default('') | length > 0
+      - (utils_os_image_url | default('') | urlsplit).scheme in ['http', 'https']
     fail_msg: >-
-      utils_os_image_url must use http or https scheme
-      (got scheme '{{ _utils_img_parts.scheme | default('') }}').
+      utils_os_image_url must be a non-empty http or https URL
+      (got '{{ utils_os_image_url | default('') }}').
+
+- name: "Validate utils_os_image_host_ips when provided"
+  when: (utils_os_image_host_ips | default([]) | length) > 0
+  ansible.builtin.assert:
+    that:
+      - utils_os_image_host_ips is sequence
+      - >-
+          (utils_os_image_host_ips | select('ansible.utils.ipv4') | list | length)
+          + (utils_os_image_host_ips | select('ansible.utils.ipv6') | list | length)
+          == (utils_os_image_host_ips | length)
+    fail_msg: >-
+      utils_os_image_host_ips must be a list of IPv4 and/or IPv6 addresses
+      (got {{ utils_os_image_host_ips | default([]) }}).
 
 - name: "Get MultiClusterEngine"
   kubernetes.core.k8s_info:
@@ -25,14 +39,64 @@
   register: _utils_mce
   failed_when: false
 
-- name: "Create NetworkPolicy for assisted-image-service OS image HTTP egress"
+- name: "Resolve OS image host addresses in-cluster for AIS HTTP egress"
   when:
-    - utils_os_image_url is defined
-    - utils_os_image_url | length > 0
     - (_utils_mce.resources | default([]) | length) > 0
     - ((_utils_mce.resources | first).spec | default({})).networkPolicies is defined
     - ((_utils_mce.resources | first).spec.networkPolicies.enabled | default(false)) | bool
+    - (utils_os_image_host_ips | default([]) | length) == 0
   vars:
+    _utils_host: "{{ (utils_os_image_url | urlsplit).hostname }}"
+  block:
+    - name: "Get openshift-dns pod for in-cluster DNS resolution"
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: openshift-dns
+        label_selectors:
+          - dns.operator.openshift.io/daemonset-dns=default
+        field_selectors:
+          - status.phase=Running
+      register: _utils_dns_pods
+      until: (_utils_dns_pods.resources | default([]) | length) > 0
+      retries: 10
+      delay: 5
+
+    - name: "Resolve OS image host via openshift-dns"
+      vars:
+        _utils_dns_pod: "{{ _utils_dns_pods.resources[0].metadata.name }}"
+      kubernetes.core.k8s_exec:
+        namespace: openshift-dns
+        pod: "{{ _utils_dns_pod }}"
+        container: dns
+        # k8s_exec expects a string (shlex-split); a YAML list is stringified and breaks exec.
+        command: >-
+          /bin/sh -c "dig +short +time=5 +tries=2 A {{ _utils_host }};
+          dig +short +time=5 +tries=2 AAAA {{ _utils_host }}"
+      register: _utils_host_ips
+      changed_when: false
+      failed_when: >-
+        (
+          (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv4') | list | length)
+          + (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv6') | list | length)
+        ) == 0
+
+- name: "Create NetworkPolicy for assisted-image-service OS image HTTP egress"
+  when:
+    - (_utils_mce.resources | default([]) | length) > 0
+    - ((_utils_mce.resources | first).spec | default({})).networkPolicies is defined
+    - ((_utils_mce.resources | first).spec.networkPolicies.enabled | default(false)) | bool
+    - (_utils_egress_ips | length) > 0
+  vars:
+    _utils_egress_ips: >-
+      {{
+        utils_os_image_host_ips
+        if (utils_os_image_host_ips | default([]) | length) > 0
+        else (
+          (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv4') | list)
+          + (_utils_host_ips.stdout_lines | default([]) | select('ansible.utils.ipv6') | list)
+        )
+      }}
     _utils_img_parts: "{{ utils_os_image_url | urlsplit }}"
     _utils_default_port: "{{ (_utils_img_parts.scheme == 'https') | ternary(443, 80) }}"
     _utils_port: >-
@@ -41,6 +105,13 @@
         if (_utils_img_parts.port | default(0) | int) > 0
         else (_utils_default_port | int)
       }}
+    _utils_ip_blocks: >-
+      {%- set ns = namespace(items=[]) -%}
+      {%- for ip in _utils_egress_ips -%}
+      {%- set cidr = ip ~ ('/128' if (ip is ansible.utils.ipv6) else '/32') -%}
+      {%- set _ = ns.items.append({'ipBlock': {'cidr': cidr}}) -%}
+      {%- endfor -%}
+      {{ ns.items }}
     _utils_np_yaml: |
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy
@@ -56,9 +127,7 @@
         policyTypes:
           - Egress
         egress:
-          - to:
-              - ipBlock:
-                  cidr: 0.0.0.0/0
+          - to: {{ _utils_ip_blocks | to_json }}
             ports:
               - protocol: TCP
                 port: {{ _utils_port | int }}

--- a/roles/acm/utils/tasks/allow-ais-http-egress.yml
+++ b/roles/acm/utils/tasks/allow-ais-http-egress.yml
@@ -13,8 +13,8 @@
   ansible.builtin.assert:
     that:
       - utils_os_image_url is defined
-      - utils_os_image_url | default('') | length > 0
-      - (utils_os_image_url | default('') | urlsplit).scheme in ['http', 'https']
+      - utils_os_image_url | length > 0
+      - (utils_os_image_url | urlsplit).scheme in ['http', 'https']
     fail_msg: >-
       utils_os_image_url must be a non-empty http or https URL
       (got '{{ utils_os_image_url | default('') }}').


### PR DESCRIPTION
- Add network policy for webservers with IPv6
- Restrict the CIDR only to the web server IP resolved from the cluster side
- Added missing rule for assisted-service (8090)

Test-Hints: no-check