### PR TITLE
Default ArgoCD to operator-managed ClusterRole and scoped AppProject

### DIFF
--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        6.1.EPOCH
+Version:        6.2.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,9 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+* Fri Aug 21 2026 Tony Garcia <tonyg@redhat.com> - 6.2.EPOCH-VERS
+- Default ArgoCD to operator-managed ClusterRole, require explicit AppProject
+
 * Mon Aug 17 2026 Ramon Perez <raperez@redhat.com> - 6.1.EPOCH-VERS
 - Include Two-Node with Fencing (TNF) OCP support in generate_manifests and installer roles
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 6.1.0
+version: 6.2.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/roles/argocd_config/README.md
+++ b/roles/argocd_config/README.md
@@ -4,30 +4,31 @@ A role to manage ArgoCD projects, repositories and applications.
 
 ## Variables
 
-| Variable           | Default                         | Required by                                     | Description
-| ------------------ | ------------------------------- | ----------------------------------------------- | -----------
-| ac_action          | None                            | config-app                                      | The action to perform on the ArgoCD application (create, delete, delete-cascade, sync-on, sync-off).
-| ac_app_dir_recurse | false                           | config-app-create                               | Whether to scan a directory recursively for manifests.
-| ac_app_name        | None                            | config-app-create, wait-for-healthy             | The name of the ArgoCD application to create.
-| ac_app_namespace   | None                            | config-app-create, config-repo                  | The namespace where the ArgoCD application will be created.
-| ac_app_path        | None                            | config-app-create                               | The path in the Git repository where application is located.
-| ac_server_api      | https://kubernetes.default.svc  | config-project                                  | The OpenShift server API URL, where ArgoCD will interact with.
-| ac_scm_token       | None                            | config-repo                                     | The token to use for accessing the Git repository.
-| ac_scm_username    | None                            | config-repo                                     | The username to use for accessing the Git repository.
-| ac_hide_secrets    | True                            | config-repo                                     | Whether to hide sensitive information in logs.
-| ac_namespace       | openshift-gitops                | config-app-create, config-repo, wait-for-healty | The namespace where ArgoCD is installed.
-| ac_permissions_def | <sup>2</sup>                    | config-permissions                              | The ArgoCD permissions definition.
-| ac_project_def     | <sup>1</sup>                    | config-project                                  | The ArgoCD project definition.
-| ac_project         | project                         | config-app-create                               | The ArgoCD project to use. 
-| ac_repo_revision   | main                            | config-app-create                               | The branch or commit hash of the Git repository to use.
-| ac_repo            | None                            | config-app-create, config-repo                  | The Git repository URL for the application. For SSH repositories, don't include the scheme or port. See ac_ssh_port.
-| ac_ssh_key         | None                            | config-app-create, config-repo                  | The SSH key to use for accessing the Git repository.
-| ac_ssh_port        | 22                              | config-repo                                     | The SSH port to use for the repository connection.
-| ac_wait_retries    | 30                              | wait-for-healthy                                | The number of retries to wait for the application to become healthy.
-| ac_wait_delay      | 10                              | wait-for-healthy                                | The time to wait between retries for the application to become healthy.
+| Variable           | Default                                                           | Required by                                      | Description
+| ------------------ | -------                                                           | -----------                                      | -----------
+| ac_cluster_role    | openshift-gitops-{{ ac_namespace }}-argocd-application-controller | config-permissions                               | ClusterRole to bind to the ArgoCD application controller. The default follows the operator-generated naming pattern `<argocd_name>-<argocd_namespace>-argocd-application-controller`, and comes from [GitOps ZTP Reference CR](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-hub-ref-design-specs#gitops-ztp-crs_telco-hub).
+| ac_action          | None                                                              | config-app                                       | The action to perform on the ArgoCD application (create, delete, delete-cascade, sync-on, sync-off).
+| ac_app_dir_recurse | false                                                             | config-app-create                                | Whether to scan a directory recursively for manifests.
+| ac_app_name        | None                                                              | config-app-create, wait-for-healthy              | The name of the ArgoCD application to create.
+| ac_app_namespace   | None                                                              | config-app-create, config-project, config-repo   | The namespace where the ArgoCD application will be created.
+| ac_app_path        | None                                                              | config-app-create                                | The path in the Git repository where application is located.
+| ac_server_api      | https://kubernetes.default.svc                                    | config-project                                   | The OpenShift server API URL, where ArgoCD will interact with.
+| ac_scm_token       | None                                                              | config-repo                                      | The token to use for accessing the Git repository.
+| ac_scm_username    | None                                                              | config-repo                                      | The username to use for accessing the Git repository.
+| ac_hide_secrets    | True                                                              | config-repo                                      | Whether to hide sensitive information in logs.
+| ac_namespace       | openshift-gitops                                                  | config-app-create, config-repo, wait-for-healthy | The namespace where ArgoCD is installed.
+| ac_permissions_def | <sup>1</sup>                                                      | config-permissions                               | The ArgoCD permissions definition.
+| ac_project_def     | <sup>2</sup>                                                      | config-project                                   | The ArgoCD project definition. Default scopes to `ac_app_namespace`, `ac_server_api`, and `ac_repo`.
+| ac_project         | project                                                           | config-app-create                                | The ArgoCD project to use.
+| ac_repo_revision   | main                                                              | config-app-create                                | The branch or commit hash of the Git repository to use.
+| ac_repo            | None                                                              | config-app-create, config-project, config-repo   | The Git repository URL for the application. For SSH repositories, don't include the scheme or port. See ac_ssh_port.
+| ac_ssh_key         | None                                                              | config-app-create, config-repo                   | The SSH key to use for accessing the Git repository.
+| ac_ssh_port        | 22                                                                | config-repo                                      | The SSH port to use for the repository connection.
+| ac_wait_retries    | 30                                                                | wait-for-healthy                                 | The number of retries to wait for the application to become healthy.
+| ac_wait_delay      | 10                                                                | wait-for-healthy                                 | The time to wait between retries for the application to become healthy.
 
-<sup>1</sup> See [defaults](defaults/main.yml) for the default project definition.
-<sup>2</sup> See [defaults](defaults/main.yml) for the default permissions definition.
+<sup>1</sup> See [defaults](defaults/main.yml) for the default permissions definition.
+<sup>2</sup> See [defaults](defaults/main.yml) for the default project definition.
 
 > [!IMPORTANT]
 > When using a custom port, do not include it in the `ac_repo`, it will be added
@@ -46,7 +47,15 @@ A role to manage ArgoCD projects, repositories and applications.
   ansible.builtin.include_role:
     name: redhatci.ocp.argocd_config
     tasks_from: config-project
+  vars:
+    ac_app_namespace: my-namespace
+    ac_repo: git@git.example.com/org/repo.git
 ```
+
+> [!NOTE]
+> The default `ac_project_def` scopes the project to `ac_app_namespace`,
+> `ac_server_api`, and `ac_repo`, so `ac_app_namespace` and `ac_repo` must be
+> provided (or a custom `ac_project_def` supplied).
 
 ### Set Permissions
 

--- a/roles/argocd_config/defaults/main.yml
+++ b/roles/argocd_config/defaults/main.yml
@@ -3,6 +3,7 @@ ac_server_api: https://kubernetes.default.svc
 ac_namespace: openshift-gitops
 ac_app_dir_recurse: false
 ac_hide_secrets: true
+ac_cluster_role: "openshift-gitops-{{ ac_namespace }}-argocd-application-controller"
 ac_permissions_def:
   apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
@@ -11,7 +12,7 @@ ac_permissions_def:
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: cluster-admin
+    name: "{{ ac_cluster_role }}"
   subjects:
     - kind: ServiceAccount
       name: openshift-gitops-argocd-application-controller
@@ -25,16 +26,16 @@ ac_project_def:
     namespace: "{{ ac_namespace }}"
   spec:
     clusterResourceWhitelist:
-      - group: '*'
-        kind: '*'
+      - group: ''
+        kind: Namespace
     namespaceResourceWhitelist:
       - group: '*'
         kind: '*'
     destinations:
-      - namespace: '*'
-        server: '*'
+      - namespace: "{{ ac_app_namespace }}"
+        server: "{{ ac_server_api }}"
     sourceRepos:
-      - '*'
+      - "{{ ac_repo }}"
 ac_repo_revision: main
 ac_ssh_port: 22
 ac_wait_retries: 30

--- a/roles/argocd_config/meta/argument_specs.yml
+++ b/roles/argocd_config/meta/argument_specs.yml
@@ -13,12 +13,28 @@ argument_specs:
       ac_project_def:
         type: dict
         required: false
-        description: The definition of an ArgoCD project to create.
+        description: >
+          The definition of an ArgoCD project to create.
+          Default scopes to ac_app_namespace, ac_server_api, and ac_repo.
+      ac_app_namespace:
+        type: str
+        required: false
+        description: The target namespace for the project destinations. Required by the default ac_project_def.
+      ac_repo:
+        type: str
+        required: false
+        description: The source repository for the project. Required by the default ac_project_def.
   config-permissions:
     short_description: Configure ArgoCD permissions
     description: >
       Configure permissions for ArgoCD applications and projects.
     options:
+      ac_cluster_role:
+        type: str
+        required: false
+        description: >
+          ClusterRole to bind to the ArgoCD application controller.
+          Defaults to the operator-managed ClusterRole.
       ac_permissions_def:
         type: dict
         required: false

--- a/roles/argocd_config/tasks/config-permissions.yml
+++ b/roles/argocd_config/tasks/config-permissions.yml
@@ -1,4 +1,11 @@
 ---
+- name: Remove existing ArgoCD ClusterRoleBinding
+  kubernetes.core.k8s:
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    name: "{{ ac_permissions_def.metadata.name }}"
+    state: absent
+
 - name: Grant ArgoCD Default Permissions
   kubernetes.core.k8s:
     definition: "{{ ac_permissions_def }}"

--- a/roles/setup_gitops/README.md
+++ b/roles/setup_gitops/README.md
@@ -10,13 +10,14 @@ Also, openshift-gitops operator must be installed in the clusters via OLM.
 
 ## Variables
 
-| Variable                            | Default                             | Description
-| ----------------------------------- | ----------------------------------- | -----------
-| sg_ztp_tag                          | v4.22                               | Tag for ZTP site generator image
-| sg_mce_tag                          | v2.17                               | Tag for Multicluster Engine subscription image
-| sg_local_registry                   | ""                                  | Local registry \<address\>[:\<port\>]  if the images need to be mirrored to a local registry
-| sg_pullsecret_file                  | None                                | Registry pull/push secret file. Required if `sg_local_registry` is set
-| sg_namespace                        | openshift-gitops                    | Namespace where ArgoCD is installed
+| Variable             | Default                                                           | Description
+| --------             | -------                                                           | -----------
+| sg_ztp_tag           | v4.22                                                             | Tag for ZTP site generator image
+| sg_mce_tag           | v2.17                                                             | Tag for Multicluster Engine subscription image
+| sg_local_registry    | ""                                                                | Local registry \<address\>[:\<port\>]  if the images need to be mirrored to a local registry
+| sg_pullsecret_file   | None                                                              | Registry pull/push secret file. Required if `sg_local_registry` is set
+| sg_namespace         | openshift-gitops                                                  | Namespace where ArgoCD is installed
+| sg_cluster_role      | openshift-gitops-{{ sg_namespace }}-argocd-application-controller | ClusterRole to bind to the ArgoCD application controller. The default follows the operator-generated naming pattern `<argocd_name>-<argocd_namespace>-argocd-application-controller`, and comes from [GitOps ZTP Reference CR](https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/scalability_and_performance/telco-hub-ref-design-specs#gitops-ztp-crs_telco-hub).
 
 ## Usage example
 

--- a/roles/setup_gitops/defaults/main.yml
+++ b/roles/setup_gitops/defaults/main.yml
@@ -3,4 +3,5 @@ sg_ztp_tag: v4.22
 sg_mce_tag: v2.17
 sg_local_registry: ""
 sg_namespace: openshift-gitops
+sg_cluster_role: "openshift-gitops-{{ sg_namespace }}-argocd-application-controller"
 ...

--- a/roles/setup_gitops/tasks/main.yml
+++ b/roles/setup_gitops/tasks/main.yml
@@ -72,7 +72,7 @@
             - name: KUSTOMIZE_PLUGIN_HOME
               value: "/.config/kustomize/plugin"
 
-- name: Bind GitOps controller to cluster-admin role
+- name: Bind GitOps controller to ClusterRole {{ sg_cluster_role }}
   kubernetes.core.k8s:
     definition:
       apiVersion: rbac.authorization.k8s.io/v1
@@ -82,7 +82,7 @@
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
-        name: cluster-admin
+        name: "{{ sg_cluster_role }}"
       subjects:
         - kind: ServiceAccount
           name: openshift-gitops-argocd-application-controller


### PR DESCRIPTION
##### SUMMARY

Replace the hardcoded cluster-admin ClusterRoleBinding with the operator-managed ClusterRole in both setup_gitops and argocd_config. The default ClusterRole is derived from the namespace, matching the naming convention used by the OpenShift GitOps operator as documented in the GitOps ZTP Reference CR.

Scope the default AppProject definition to the caller's repository, target namespace, and local cluster API. Cluster-scoped resources are disallowed by default. Both the ClusterRole and AppProject definition can be overridden via role variables if needed.

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDgtMjBUMjI6MjU6MzZ8NGVkOThhZjgyYWNjMDc2ZDY1YTYwNDk5ZmNlM2E2MjlkM2U4YzI2NA==
Gitleaks-Hash: 77420f2aad6166ac3cca2197e5ac21951f3c15a2a0b308c8bb4185da38d4bccc

##### ISSUE TYPE

- Enhanced Feature

##### Tests

- [x] - https://www.distributed-ci.io/jobs/b3d89bad-7198-42bd-868d-88fef5aea41e
- [x] -  https://www.distributed-ci.io/jobs/f8854d3f-09f7-47a8-848e-3bd72e973cb4

Test-hints: no-check