### PR TITLE
Use uniq node names and fix loop variable

### DIFF
--- a/roles/efi_boot_mgr/files/rm-efiboot
+++ b/roles/efi_boot_mgr/files/rm-efiboot
@@ -12,7 +12,7 @@ boot_current=$(efibootmgr --verbose | sed -n -e 's,BootCurrent: \(.*\),\1,p')
 boot_list=($(efibootmgr --verbose | sed -n -e 's/,/ /g' -e 's,BootOrder: \(.*\),\1,p'))
 
 for bootnum in ${boot_list[*]}; do
-    if [[ "${boot_id}" == "${boot_current}" ]]; then
+    if [[ "${bootnum}" == "${boot_current}" ]]; then
         continue
     fi
     efibootmgr --bootnum ${bootnum} --delete-bootnum

--- a/roles/efi_boot_mgr/tasks/main.yml
+++ b/roles/efi_boot_mgr/tasks/main.yml
@@ -17,7 +17,7 @@
   async: 120
   poll: 0
   register: _ebm_rm
-  loop: "{{ ebm_nodes }}"
+  loop: "{{ ebm_nodes | unique | list }}"
   loop_control:
     loop_var: node_name
   changed_when: true


### PR DESCRIPTION
##### SUMMARY

For SNO deployments, node will be labeled both worker and master, so dci_compute_hosts + dci_control_plane_hosts list same node_name twice. efi_boot_mgr then started two async oc debug jobs on that node. One would fail always. Eg: [failure](https://www.distributed-ci.io/jobs/23b9f4f9-cbb8-4664-b867-3b14c987dbc9/jobStates?sort=date&task=27322e19-64b8-487b-8e58-d5e55c3dfa92)

This PR is to :
- pass uniq node names for "delete UEFI boot entries" task
- fix incorrect loop variable used in for loop. loop variable is bootnum, and boot_id was never set, so the skip never fired and it would try to delete the active entry too

##### ISSUE TYPE
-Bug

Test-Hints: no-check