### PR TITLE
Add some extravars to odf_setup role

### DIFF
--- a/roles/odf_setup/README.md
+++ b/roles/odf_setup/README.md
@@ -20,7 +20,7 @@ Role Variables
 | local_storage_operator           | local-storage-operator        | String       | No          | LSO operator name                                                        |
 | openshift-local-storage          | openshift-local-storage       | String       | No          | LSO namespace                                                            |
 | local_storage_class              | localblock                    | String       | No          | Type of LSO Volume Mode, either filesystem or block                      |
-| local_volume_mode                | localblock                    | String       | No          | Type of LSO Volume Mode, either filesystem or block                      |
+| local_volume_mode                | block                         | String       | No          | Type of LSO Volume Mode, either filesystem or block                      |
 | replica_size                     | 3                             | String       | No          | Replica size                                                             |
 | ocs_storage_operator             | ocs-operator                  | String       | No          | OCS operator name                                                        |
 | ocs_storage_namespace            | openshift-storage             | String       | No          | OCS namespace                                                            |
@@ -35,7 +35,9 @@ Role Variables
 | odf_setup_enable_encryption      | false | Boolean | No          | Whether enable disk cluster-wide encryption for ODF |
 | odf_setup_key_rotation_period    | weekly | String | No          | Period of key rotation: daily, weekly, monthly, etc. |
 | odf_setup_ocs_on_control_plane   | false | Boolean | No          | Set true when ODF storage runs on dedicated control-plane nodes (e.g. MNO masters). Adds master/control-plane tolerations to LSO and StorageCluster storageDeviceSets. |
-
+| odf_setup_deviceset_storage_request | "1" | String | No          | Storage request size for each deviceset in the StorageCluster |
+| odf_setup_storagecluster_resources |                               | Dict         | No          | Resource limits and requests for the StorageCluster components |
+| odf_setup_storagecluster_deviceset_resources |                               | Dict         | No          | Resource limits and requests for the StorageCluster devicesets |
 
 Inventory Groups and Variables
 --------------

--- a/roles/odf_setup/defaults/main.yml
+++ b/roles/odf_setup/defaults/main.yml
@@ -55,3 +55,6 @@ odf_setup_csi_plugin_tolerations: |
 
 # ODF setup on control plane nodes. When true, add control-plane tolerations for LSO workloads.
 odf_setup_ocs_on_control_plane: false
+
+# ODF setup deviceset storage request
+odf_setup_deviceset_storage_request: "1"

--- a/roles/odf_setup/tasks/local-storage-operator.yml
+++ b/roles/odf_setup/tasks/local-storage-operator.yml
@@ -27,13 +27,15 @@
 - name: Gathering result from DaemonSet
   ansible.builtin.shell:
     cmd: >
-      sleep 90;
       {{ odf_setup_oc_tool_path }} logs
       --selector name=ocs-disk-gatherer
       --tail=-1
       --since=10m
       --namespace ocs-disk-gatherer
   register: disk_id
+  retries: 10
+  delay: 30
+  until: disk_id.rc == 0
 
 - name: Configure Local Storage Volumes
   kubernetes.core.k8s:

--- a/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
+++ b/roles/odf_setup/templates/openshift-storage-cluster.yml.j2
@@ -5,6 +5,10 @@ metadata:
   name: {{ ocs_storagecluster_name }}
 spec:
   enableCephTools: {{ odf_setup_enable_ceph_tools | bool }}
+{% if odf_setup_storagecluster_resources is defined %}
+  resources:
+{{ odf_setup_storagecluster_resources | to_nice_yaml(indent=2) | indent(4, first=True) | regex_replace('\\n+$', '') }}
+{% endif %}
 {% if odf_setup_enable_encryption | bool %}
   encryption:
     clusterWide: true
@@ -123,8 +127,8 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: "1"
-        storageClassName: localblock
+            storage: {{ odf_setup_deviceset_storage_request }}
+        storageClassName: {{ local_storage_class }}
         volumeMode: Block
     name: ocs-deviceset
 {% if (odf_setup_ocs_on_control_plane | default(false) | bool) and (ocp_version is version("4.16", ">=")) %}
@@ -144,5 +148,10 @@ spec:
 {% endif %}
     portable: false
     replica: {{ replica_size | int }}
+{% if odf_setup_storagecluster_deviceset_resources is defined %}
+    resources:
+{{ odf_setup_storagecluster_deviceset_resources | to_nice_yaml(indent=2) | indent(6, first=True) | regex_replace('\\n+$', '') }}
+{% else %}
     resources: {}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

Add some extravars to odf_setup role

Allow to provide some extra parameters to the odf_setup role to cover some partners' scenarios where it's required to add more config to the StorageCluster resource.

Also:

- Remove localblock hardcoded values and use local_storage_class instead
- Adding retries to disk gatherer's logs retrieval task, since it failed in a test because we didn't check the resource at the right time

##### ISSUE TYPE

- Enhanced feature

##### Tests

- [x] Partner lab test - https://www.distributed-ci.io/jobs/ffbda119-f7f5-4e49-b32f-ca4302b4768c/jobStates?sort=date&task=15961ea4-90a2-4844-ae76-312541ed1418 (failure is not related to this change)

Vars used in the DCI job:

```
    local_storage_class: local-volume
    odf_setup_deviceset_storage_request: "850Gi"
    odf_setup_storagecluster_resources:
      mds:
        limits:
          cpu: "3"
          memory: "8Gi"
        requests:
          cpu: "3"
          memory: "8Gi"
    odf_setup_storagecluster_deviceset_resources:
      limits:
        cpu: "2"
        memory: "5Gi"
      requests:
        cpu: "2"
        memory: "5Gi"
```

Test-Hints: no-check