### PR TITLE
Fix regex backreferences reverted to broken YAML

### DIFF
--- a/roles/include_components/tasks/track_git_repo.yml
+++ b/roles/include_components/tasks/track_git_repo.yml
@@ -27,8 +27,8 @@
     type: "{{ repo_url.stdout | basename | regex_replace('[.]git$', '') }}"
     url: >-
       {{ repo_url.stdout
-      | regex_replace('^(.*)@(.*):(.*)', 'https://\\2/\\3')
-      | regex_replace('^ssh://(.*)@(.*)', 'https://\\2')
+      | regex_replace('^(.*)@(.*):(.*)', 'https://\2/\3')
+      | regex_replace('^ssh://(.*)@(.*)', 'https://\2')
       | regex_replace('[.]git$', '')
       }}/commit/{{ last_commit_id.stdout }}
     state: present


### PR DESCRIPTION
##### SUMMARY

The url field in the **include_component** role was reverted in PR #1006 after the fix in #1007.

The reintroduction of the issue inserts double escaping in a scalar block when is not needed. This is causing wrong URLs like: `https://\2/\3/commit/<sha>` instead of `https://github.com/<org>/<repo>/commit/<sha>`

Gitleaks-Sign: OC4zMC4wfDIwMjYtMDgtMjZUMTU6MTY6MTN8Y2MxMGViNGUwOGJkMmY0ODc2NDE1Nzc4MzZjNmJhODI2MzE2ZjY5Mw==
Gitleaks-Hash: 3d944ed9860bbebab9bdf59c81ec4fb94c1db762c2d74ce2e94899e7f203a34a


##### ISSUE TYPE

- Bug

##### Tests

- [x] abi-sno - https://www.distributed-ci.io/jobs/6a59394d-3b1b-46a1-bbed-20dfe3bfc4cd

The component was created successfully forthis change: ansible-collection-redhatci-ocp c409828, URL is: `https://github.com/redhatci/ansible-collection-redhatci-ocp/commit/c409828182d27d75e0829a3877422dade1d534f2`


TestHints: no-check