### PR TITLE
Use correct status fields and extra conditions for OCS health status check

### DIFF
--- a/roles/odf_setup/tasks/openshift-storage-operator.yml
+++ b/roles/odf_setup/tasks/openshift-storage-operator.yml
@@ -63,9 +63,13 @@
   until:
     - ocs_health_status.resources is defined
     - ocs_health_status.resources[0].status is defined
-    - ("'Connected' in ocs_health_status.resources[0].status.state") or ("'Ready' in ocs_health_status.resources[0].status.state")
+    - ocs_health_status.resources[0].status.phase is defined
+    - ocs_health_status.resources[0].status.phase in ['Ready', 'Connected']
+    - ocs_health_status.resources[0].status.state is defined
+    - ocs_health_status.resources[0].status.state in ['Created', 'Connected']
     - ocs_health_status.resources[0].status.ceph is defined
-    - "'HEALTH_ERR' not in ocs_health_status.resources[0].status.ceph.health"
+    - ocs_health_status.resources[0].status.ceph.health is defined
+    - ocs_health_status.resources[0].status.ceph.health != 'HEALTH_ERR'
 
 - name: Deploy the Rook-Ceph toolbox pod
   kubernetes.core.k8s:


### PR DESCRIPTION
##### SUMMARY
This PR is to fix incorrect "status" fields used for OCS health status check task

- Wait on CephCluster status.phase and status.state instead of a quoted substring check on status.state.
- Internal ODF reports phase: Ready and state: Created. External ODF reports Connected on both. 
- The old condition looked for Ready/Connected in state, which internal clusters never set.
- Require status.ceph.health to be defined and not HEALTH_ERR.

##### ISSUE TYPE
- Bug

Test-Hints: no-check
