### PR TITLE
Fix subtools names in template

### DIFF
--- a/roles/multibench_run/templates/all-in-one.json.j2
+++ b/roles/multibench_run/templates/all-in-one.json.j2
@@ -771,13 +771,8 @@
             },
             { "tool": "sysstat",
               "params": [
-                  { "arg": "subtools", "val": "mpstat", "enabled": "yes" },
-                  { "arg": "subtools", "val": "sar-net", "enabled": "yes" },
-                  { "arg": "subtools", "val": "iostat", "enabled": "yes" },
-                  { "arg": "subtools", "val": "sar-mem", "enabled": "yes" },
-                  { "arg": "subtools", "val": "sar-scheduler", "enabled": "yes" },
-                  { "arg": "subtools", "val": "sar-tasks", "enabled": "yes" }
-            ]
+                  { "arg": "subtools", "val": "mpstat,sar,iostat", "enabled": "yes" }
+              ]
             },
             { "tool": "procstat" }
     ]

--- a/roles/multibench_run/templates/kube-all-in-one.json.j2
+++ b/roles/multibench_run/templates/kube-all-in-one.json.j2
@@ -235,12 +235,7 @@
     {
       "tool": "sysstat",
       "params": [
-        { "arg": "subtools", "val": "mpstat", "enabled": "yes" },
-        { "arg": "subtools", "val": "sar-net", "enabled": "yes" },
-        { "arg": "subtools", "val": "iostat", "enabled": "yes" },
-        { "arg": "subtools", "val": "sar-mem", "enabled": "yes" },
-        { "arg": "subtools", "val": "sar-scheduler", "enabled": "yes" },
-        { "arg": "subtools", "val": "sar-tasks", "enabled": "yes" }
+        { "arg": "subtools", "val": "mpstat,sar,iostat", "enabled": "yes" }
       ]
     },
     { "tool": "kernel",


### PR DESCRIPTION
##### SUMMARY

The invalid subtools values are in the multibench templates
The sysstat subtools in multibench_run were metric source names (sar-net, sar-mem, sar-scheduler, sar-tasks). Crucible only accepts mpstat, sar, iostat, and pidstat

##### ISSUE TYPE

Bug