### PR TITLE
copy_and_render: expanduser source dir to fix ~ path corruption

### DIFF
--- a/roles/copy_and_render/tasks/main.yml
+++ b/roles/copy_and_render/tasks/main.yml
@@ -15,8 +15,10 @@
 
 - name: Render Jinja2 templates to target directory
   vars:
-    # Relative paths starting with "./path/" are handled as "path/"
-    src_dir: "{{ car_source_dir | regex_replace('^./', '') }}"
+    # Match the normalization that "find" applies to the paths it returns:
+    # it expands "~" and strips a leading "./". The dot is escaped so only a
+    # literal "./" prefix is removed (not any character, as "^./" would).
+    src_dir: "{{ car_source_dir | expanduser | regex_replace('^\\./', '') }}"
     target_path: "{{ item.path | replace(src_dir, car_target_dir) | regex_replace('\\.j2$', '') }}"
   ansible.builtin.template:
     src: "{{ item.path }}"
@@ -26,8 +28,10 @@
 
 - name: Remove original .j2 template files from target directory
   vars:
-    # Relative paths starting with "./path/" are handled as "path/"
-    src_dir: "{{ car_source_dir | regex_replace('^./', '') }}"
+    # Match the normalization that "find" applies to the paths it returns:
+    # it expands "~" and strips a leading "./". The dot is escaped so only a
+    # literal "./" prefix is removed (not any character, as "^./" would).
+    src_dir: "{{ car_source_dir | expanduser | regex_replace('^\\./', '') }}"
     target_template: "{{ item.path | replace(src_dir, car_target_dir) }}"
   ansible.builtin.file:
     path: "{{ target_template }}"

--- a/tests/integration/targets/copy_and_render/runme.sh
+++ b/tests/integration/targets/copy_and_render/runme.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+set -eu
+
 dir=$(dirname "$0")
 
-exec ansible-playbook -v -i $dir/../../inventory -e car_source_dir=$dir/files $dir/copy_and_render.yml
+# Case 1: absolute source path
+ansible-playbook -v -i "$dir/../../inventory" -e car_source_dir="$dir/files" "$dir/copy_and_render.yml"
+
+# Case 2: source path using "~" notation (regression test).
+# The find module expands "~" in its paths, so the role must expanduser
+# car_source_dir too, otherwise the derived destination path is corrupted.
+# The "~" is kept literal (quoted) so only the role expands it.
+tilde_src="car_render_tilde_test_$$"
+cleanup() {
+    rm -rf "${HOME:?}/$tilde_src"
+}
+trap cleanup EXIT
+
+mkdir -p "$HOME/$tilde_src"
+cp -a "$dir/files/." "$HOME/$tilde_src/"
+
+ansible-playbook -v -i "$dir/../../inventory" -e car_source_dir="~/$tilde_src" "$dir/copy_and_render.yml"
+
+# Case 3: relative source path using "./" notation (regression test).
+# The find module strips a leading "./" from the paths it returns, so the
+# role must strip it from src_dir too. Run from the target dir so "./files"
+# resolves for both the copy (playbook basedir) and find (process cwd) steps.
+(cd "$dir" && ansible-playbook -v -i "../../inventory" -e car_source_dir="./files" copy_and_render.yml)
 
 # runme.sh ends here


### PR DESCRIPTION
The role derived src_dir with regex_replace('^./', ''), whose unescaped
"." wildcard also matched the "~" in tilde paths. Since the find module
expands "~" in its paths but src_dir kept the tilde stripped, replace()
only matched the suffix after the home dir and produced a corrupted
destination like /home/dci//tmp/.../sites/sno, failing with
"Destination directory does not exist".

Use expanduser so src_dir matches the paths returned by find for all
forms (~/, ./, absolute).

Add a ~-based regression run to the integration test.

Test-Hints: no-check