### PR TITLE
feat: add oc-mirror v2 manifest validation and schema checks

### DIFF
--- a/docs/manifest-audit-process.md
+++ b/docs/manifest-audit-process.md
@@ -1,0 +1,167 @@
+# Generated Manifest Audit Process
+
+This document describes the checklist and procedure for auditing oc-mirror v2
+output manifests when a serialization defect or data quality issue is discovered.
+
+---
+
+## Background
+
+The oc-mirror v2 tool produces several Kubernetes manifest types when mirroring
+operator catalogs to a disconnected registry. Each manifest type has required
+fields that must be populated for the manifest to be usable by OpenShift. A
+serialization defect in the tool can produce manifests where normally-populated
+fields are absent, empty, or set to empty collection values (e.g. `status: {}`).
+
+Affected manifest types:
+
+| Kind | File pattern | Critical fields |
+|------|-------------|-----------------|
+| `ImageDigestMirrorSet` (IDMS) | `idms-*.yaml` | `spec.imageDigestMirrors` (non-empty list) |
+| `ImageTagMirrorSet` (ITMS) | `itms-*.yaml` | `spec.imageTagMirrors` (non-empty list) |
+| `CatalogSource` | `cs-*.yaml` | `spec.sourceType`, `spec.image` |
+| `ClusterCatalog` | `cc-*.yaml` | `spec.source` |
+| `UpdateService` | `update-service-*.yaml` | `spec.graphDataImage`, `spec.releases` |
+
+---
+
+## Verification Steps
+
+### Step 1 — Run the validation script
+
+```bash
+./hack/validate_manifests.sh <manifest-output-directory>
+```
+
+The script exits 0 if all manifests pass and prints `OK: all N manifest(s)
+passed validation.` Review any `ERROR:` lines printed to stderr before
+proceeding.
+
+### Step 2 — Verify each manifest type
+
+#### ImageDigestMirrorSet (IDMS)
+
+```bash
+# Check spec.imageDigestMirrors is a non-empty list
+python3 -c "
+import yaml, sys
+doc = yaml.safe_load(open(sys.argv[1]))
+mirrors = doc.get('spec', {}).get('imageDigestMirrors', [])
+print(f'imageDigestMirrors entries: {len(mirrors)}')
+assert len(mirrors) > 0, 'EMPTY — defect detected'
+" idms-oc-mirror.yaml
+```
+
+Checklist:
+- [ ] `apiVersion: config.openshift.io/v1`
+- [ ] `kind: ImageDigestMirrorSet`
+- [ ] `metadata.name` non-empty
+- [ ] `status` field absent or non-empty (not `{}`)
+- [ ] `spec.imageDigestMirrors` is a list with at least one entry
+- [ ] Each entry has both `source` and `mirrors` fields
+
+#### ImageTagMirrorSet (ITMS)
+
+Checklist:
+- [ ] `apiVersion: config.openshift.io/v1`
+- [ ] `kind: ImageTagMirrorSet`
+- [ ] `metadata.name` non-empty
+- [ ] `status` field absent or non-empty (not `{}`)
+- [ ] `spec.imageTagMirrors` is a list with at least one entry
+- [ ] Each entry has both `source` and `mirrors` fields
+
+#### CatalogSource
+
+Checklist:
+- [ ] `apiVersion: operators.coreos.com/v1alpha1`
+- [ ] `kind: CatalogSource`
+- [ ] `metadata.name` and `metadata.namespace` non-empty
+- [ ] `spec.sourceType` non-empty (typically `grpc`)
+- [ ] `spec.image` is a fully qualified image reference
+
+#### ClusterCatalog
+
+Checklist:
+- [ ] `apiVersion: catalogd.operatorframework.io/v1`
+- [ ] `kind: ClusterCatalog`
+- [ ] `metadata.name` non-empty
+- [ ] `spec.source` is defined and contains `type` and `image` sub-fields
+- [ ] `spec.source.image.ref` is a fully qualified image reference
+
+#### UpdateService
+
+Checklist:
+- [ ] `apiVersion: updateservice.operator.openshift.io/v1`
+- [ ] `kind: UpdateService`
+- [ ] `metadata.name` non-empty
+- [ ] `spec.graphDataImage` non-empty
+- [ ] `spec.releases` non-empty
+
+---
+
+## GitOps and ACM Policy Compliance Verification
+
+When manifests are consumed by a GitOps pipeline or ACM policy framework,
+incomplete manifests cause silent reconciliation failures. Before committing
+manifests to the policy repository:
+
+1. Run `./hack/validate_manifests.sh <output-dir>` — exit code must be 0.
+2. Verify that each manifest that would be applied by ACM/ArgoCD matches the
+   expected structure for its target cluster version (e.g. classic OLM clusters
+   use `CatalogSource`; OLM v1 clusters use `ClusterCatalog`).
+3. Apply the manifests to a staging cluster and confirm that the relevant
+   operator controller reports no errors:
+   ```bash
+   oc get idms,itms,catalogsource,clustercatalog -A
+   oc describe idms idms-oc-mirror
+   ```
+4. If any field is empty or missing, do **not** commit the manifests. Proceed to
+   the resolution steps below.
+
+---
+
+## Resolution Steps
+
+When a manifest fails validation:
+
+1. **Identify the scope**: run `./hack/validate_manifests.sh` over all output
+   directories produced by the mirroring run to determine which manifest types
+   are affected.
+
+2. **Re-run mirroring**: if the defect is transient (e.g. caused by a partial
+   push or network interruption), rerun the mirroring role with a clean
+   workspace directory.
+
+3. **Check tool version**: confirm the version of oc-mirror in use and compare
+   against the known good version documented in the release notes.
+
+4. **Quarantine the output**: move the defective manifest directory to a
+   quarantine location and record the tool version, workspace path, and error
+   output for further analysis.
+
+5. **Do not propagate**: ensure the defective manifests are not committed to any
+   GitOps repository or ACM policy source until the issue is resolved and all
+   validation checks pass.
+
+6. **Verify after fix**: after applying a fix or upgrading the tool, re-run the
+   full mirroring pipeline and confirm that `./hack/validate_manifests.sh`
+   exits 0 before proceeding.
+
+---
+
+## Automated Validation in the Role
+
+The `oci_mirror` Ansible role runs `tasks/validate-manifests.yml` automatically
+after every mirroring run when `om_validate_manifests: true` (the default).
+This provides early detection of defective manifests before they are used
+downstream.
+
+To disable automatic validation (not recommended for production):
+
+```yaml
+om_validate_manifests: false
+```
+
+---
+
+*See also: `hack/validate_manifests.sh`, `roles/oci_mirror/tasks/validate-manifests.yml`.*

--- a/hack/validate_manifests.sh
+++ b/hack/validate_manifests.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# validate_manifests.sh — validate oc-mirror v2 output manifests
+#
+# Usage: validate_manifests.sh <directory>
+#
+# Validates all *.yaml files in <directory>:
+#   - apiVersion, kind, and metadata.name must be non-empty strings
+#   - status must not be an empty dict ({})
+#   - Kind-specific spec field checks:
+#       ImageDigestMirrorSet  : spec.imageDigestMirrors non-empty list
+#       ImageTagMirrorSet     : spec.imageTagMirrors non-empty list
+#       CatalogSource         : spec.sourceType and spec.image non-empty strings
+#       ClusterCatalog        : spec.source must be defined
+#
+# Exit 0 on success, exit 1 with ERROR lines on stderr on any failure.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <manifest-directory>" >&2
+    exit 1
+fi
+
+MANIFEST_DIR="$1"
+
+if [[ ! -d "${MANIFEST_DIR}" ]]; then
+    echo "ERROR: directory not found: ${MANIFEST_DIR}" >&2
+    exit 1
+fi
+
+python3 - "${MANIFEST_DIR}" <<'PYEOF'
+import sys
+import os
+import glob
+import yaml
+
+def validate_manifest(path):
+    errors = []
+    basename = os.path.basename(path)
+
+    with open(path, "r", encoding="utf-8") as fh:
+        try:
+            doc = yaml.safe_load(fh)
+        except yaml.YAMLError as exc:
+            return [f"{basename}: YAML parse error: {exc}"]
+
+    if not isinstance(doc, dict):
+        return [f"{basename}: top-level document is not a mapping"]
+
+    # --- Common required fields ---
+    for field in ("apiVersion", "kind"):
+        val = doc.get(field)
+        if not val or not str(val).strip():
+            errors.append(f"{basename}: '{field}' is missing or empty")
+
+    metadata = doc.get("metadata")
+    if not isinstance(metadata, dict) or not metadata.get("name", "").strip():
+        errors.append(f"{basename}: 'metadata.name' is missing or empty")
+
+    # --- status must not be an empty dict ---
+    if "status" in doc and doc["status"] == {}:
+        errors.append(
+            f"{basename}: 'status' is an empty dict — this indicates a "
+            "serialization defect in the manifest output"
+        )
+
+    kind = doc.get("kind", "")
+    spec = doc.get("spec", {}) or {}
+
+    # --- Kind-specific checks ---
+    if kind == "ImageDigestMirrorSet":
+        mirrors = spec.get("imageDigestMirrors")
+        if not mirrors or not isinstance(mirrors, list) or len(mirrors) == 0:
+            errors.append(
+                f"{basename}: 'spec.imageDigestMirrors' is missing or empty "
+                "(ImageDigestMirrorSet)"
+            )
+
+    elif kind == "ImageTagMirrorSet":
+        mirrors = spec.get("imageTagMirrors")
+        if not mirrors or not isinstance(mirrors, list) or len(mirrors) == 0:
+            errors.append(
+                f"{basename}: 'spec.imageTagMirrors' is missing or empty "
+                "(ImageTagMirrorSet)"
+            )
+
+    elif kind == "CatalogSource":
+        if not spec.get("sourceType", "").strip():
+            errors.append(
+                f"{basename}: 'spec.sourceType' is missing or empty (CatalogSource)"
+            )
+        if not spec.get("image", "").strip():
+            errors.append(
+                f"{basename}: 'spec.image' is missing or empty (CatalogSource)"
+            )
+
+    elif kind == "ClusterCatalog":
+        if "source" not in spec:
+            errors.append(
+                f"{basename}: 'spec.source' is missing (ClusterCatalog)"
+            )
+
+    return errors
+
+
+manifest_dir = sys.argv[1]
+yaml_files = sorted(glob.glob(os.path.join(manifest_dir, "*.yaml")))
+
+if not yaml_files:
+    print(f"WARNING: no *.yaml files found in {manifest_dir}", file=sys.stderr)
+    sys.exit(0)
+
+all_errors = []
+for manifest_path in yaml_files:
+    file_errors = validate_manifest(manifest_path)
+    for err in file_errors:
+        print(f"ERROR: {err}", file=sys.stderr)
+    all_errors.extend(file_errors)
+
+if all_errors:
+    sys.exit(1)
+
+print(f"OK: all {len(yaml_files)} manifest(s) passed validation.")
+PYEOF

--- a/hack/validate_manifests.sh
+++ b/hack/validate_manifests.sh
@@ -11,6 +11,7 @@
 #       ImageTagMirrorSet     : spec.imageTagMirrors non-empty list
 #       CatalogSource         : spec.sourceType and spec.image non-empty strings
 #       ClusterCatalog        : spec.source must be defined
+#       UpdateService         : spec.graphDataImage and spec.releases non-empty strings
 #
 # Exit 0 on success, exit 1 with ERROR lines on stderr on any failure.
 
@@ -98,6 +99,18 @@ def validate_manifest(path):
         if "source" not in spec:
             errors.append(
                 f"{basename}: 'spec.source' is missing (ClusterCatalog)"
+            )
+
+    elif kind == "UpdateService":
+        if not spec.get("graphDataImage", "").strip():
+            errors.append(
+                f"{basename}: 'spec.graphDataImage' is missing or empty "
+                "(UpdateService)"
+            )
+        if not spec.get("releases", "").strip():
+            errors.append(
+                f"{basename}: 'spec.releases' is missing or empty "
+                "(UpdateService)"
             )
 
     return errors

--- a/hack/validate_manifests.sh
+++ b/hack/validate_manifests.sh
@@ -68,6 +68,21 @@ def validate_manifest(path):
     kind = doc.get("kind", "")
     spec = doc.get("spec", {}) or {}
 
+    # --- kind-to-apiVersion enforcement ---
+    _API_VERSION_MAP = {
+        "ImageDigestMirrorSet": "config.openshift.io/v1",
+        "ImageTagMirrorSet": "config.openshift.io/v1",
+        "CatalogSource": "operators.coreos.com/v1alpha1",
+        "ClusterCatalog": "catalogd.operatorframework.io/v1",
+        "UpdateService": "updateservice.operator.openshift.io/v1",
+    }
+    actual_api = doc.get("apiVersion", "")
+    if kind in _API_VERSION_MAP and actual_api != _API_VERSION_MAP[kind]:
+        errors.append(
+            f"{basename}: 'apiVersion' is '{actual_api}' but expected "
+            f"'{_API_VERSION_MAP[kind]}' for kind '{kind}'"
+        )
+
     # --- Kind-specific checks ---
     if kind == "ImageDigestMirrorSet":
         mirrors = spec.get("imageDigestMirrors")

--- a/hack/validate_manifests.sh
+++ b/hack/validate_manifests.sh
@@ -10,7 +10,7 @@
 #       ImageDigestMirrorSet  : spec.imageDigestMirrors non-empty list
 #       ImageTagMirrorSet     : spec.imageTagMirrors non-empty list
 #       CatalogSource         : spec.sourceType and spec.image non-empty strings
-#       ClusterCatalog        : spec.source must be defined
+#       ClusterCatalog        : spec.source must be a non-empty mapping
 #       UpdateService         : spec.graphDataImage and spec.releases non-empty strings
 #
 # Exit 0 on success, exit 1 with ERROR lines on stderr on any failure.
@@ -39,11 +39,14 @@ def validate_manifest(path):
     errors = []
     basename = os.path.basename(path)
 
-    with open(path, "r", encoding="utf-8") as fh:
-        try:
-            doc = yaml.safe_load(fh)
-        except yaml.YAMLError as exc:
-            return [f"{basename}: YAML parse error: {exc}"]
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            try:
+                doc = yaml.safe_load(fh)
+            except yaml.YAMLError as exc:
+                return [f"{basename}: YAML parse error: {exc}"]
+    except OSError as exc:
+        return [f"{basename}: ERROR: cannot open file: {exc}"]
 
     if not isinstance(doc, dict):
         return [f"{basename}: top-level document is not a mapping"]
@@ -119,9 +122,10 @@ def validate_manifest(path):
             )
 
     elif kind == "ClusterCatalog":
-        if "source" not in spec:
+        _src = spec.get("source")
+        if not isinstance(_src, dict) or not _src:
             errors.append(
-                f"{basename}: 'spec.source' is missing (ClusterCatalog)"
+                f"{basename}: 'spec.source' is missing or not a non-empty mapping (ClusterCatalog)"
             )
 
     elif kind == "UpdateService":

--- a/hack/validate_manifests.sh
+++ b/hack/validate_manifests.sh
@@ -107,11 +107,13 @@ def validate_manifest(path):
             )
 
     elif kind == "CatalogSource":
-        if not spec.get("sourceType", "").strip():
+        _st = spec.get("sourceType", "")
+        if not isinstance(_st, str) or not _st.strip():
             errors.append(
                 f"{basename}: 'spec.sourceType' is missing or empty (CatalogSource)"
             )
-        if not spec.get("image", "").strip():
+        _img = spec.get("image", "")
+        if not isinstance(_img, str) or not _img.strip():
             errors.append(
                 f"{basename}: 'spec.image' is missing or empty (CatalogSource)"
             )
@@ -123,12 +125,14 @@ def validate_manifest(path):
             )
 
     elif kind == "UpdateService":
-        if not spec.get("graphDataImage", "").strip():
+        _gdi = spec.get("graphDataImage", "")
+        if not isinstance(_gdi, str) or not _gdi.strip():
             errors.append(
                 f"{basename}: 'spec.graphDataImage' is missing or empty "
                 "(UpdateService)"
             )
-        if not spec.get("releases", "").strip():
+        _rel = spec.get("releases", "")
+        if not isinstance(_rel, str) or not _rel.strip():
             errors.append(
                 f"{basename}: 'spec.releases' is missing or empty "
                 "(UpdateService)"

--- a/hack/validate_manifests.sh
+++ b/hack/validate_manifests.sh
@@ -51,12 +51,13 @@ def validate_manifest(path):
     # --- Common required fields ---
     for field in ("apiVersion", "kind"):
         val = doc.get(field)
-        if not val or not str(val).strip():
-            errors.append(f"{basename}: '{field}' is missing or empty")
+        if not isinstance(val, str) or not val.strip():
+            errors.append(f"{basename}: '{field}' is missing or empty (must be a non-empty string)")
 
     metadata = doc.get("metadata")
-    if not isinstance(metadata, dict) or not metadata.get("name", "").strip():
-        errors.append(f"{basename}: 'metadata.name' is missing or empty")
+    name = metadata.get("name", "") if isinstance(metadata, dict) else None
+    if not isinstance(name, str) or not name.strip():
+        errors.append(f"{basename}: 'metadata.name' is missing or empty (must be a non-empty string)")
 
     # --- status must not be an empty dict ---
     if "status" in doc and doc["status"] == {}:
@@ -66,7 +67,12 @@ def validate_manifest(path):
         )
 
     kind = doc.get("kind", "")
-    spec = doc.get("spec", {}) or {}
+    if not isinstance(kind, str):
+        kind = ""
+    spec = doc.get("spec", {})
+    if not isinstance(spec, dict):
+        errors.append(f"{basename}: 'spec' is not a mapping (got {type(spec).__name__})")
+        spec = {}
 
     # --- kind-to-apiVersion enforcement ---
     _API_VERSION_MAP = {

--- a/roles/oci_mirror/README.md
+++ b/roles/oci_mirror/README.md
@@ -146,6 +146,8 @@ Each YAML file in that directory is parsed and checked for:
 - **CatalogSource** (`cs-*.yaml`): `spec.sourceType` and `spec.image` must be
   non-empty strings.
 - **ClusterCatalog** (`cc-*.yaml`): `spec.source` must be defined.
+- **UpdateService** (`update-service-*.yaml`): `spec.graphDataImage` and
+  `spec.releases` must be non-empty strings.
 
 Set `om_validate_manifests: false` to skip validation (e.g. when you know the
 mirroring tool produces partial output intentionally).

--- a/roles/oci_mirror/README.md
+++ b/roles/oci_mirror/README.md
@@ -22,6 +22,7 @@ Either you point the role at an existing **ImageSetConfiguration**, or you let i
 | `om_keep_working_dir` | bool | `false` | Keep the temp workspace after the role finishes (useful for debugging). |
 | `om_remove_signatures` | bool | `false` | Pass `--remove-signatures` to `oc-mirror` (needed for some unsigned images). |
 | `om_ignore_errors` | bool | `false` | Sets Ansible `ignore_errors` on the mirror task. |
+| `om_validate_manifests` | bool | `true` | Validate all generated manifests after mirroring. See [Manifest Validation](#manifest-validation). |
 
 ### Standard path only (`om_custom_config` not set)
 
@@ -130,6 +131,31 @@ Some operators stay on `om_source_index`; others use another index via `catalog`
       local-storage-operator:
     om_keep_working_dir: true
 ```
+
+## Manifest Validation
+
+When `om_validate_manifests` is `true` (the default), the role runs
+`tasks/validate-manifests.yml` after copying manifests to `_om_output_dir`.
+Each YAML file in that directory is parsed and checked for:
+
+- `apiVersion`, `kind`, and `metadata.name` must be non-empty strings.
+- `status` must not be an empty dict (`{}`). An empty status field can
+  indicate a serialization defect in the mirroring tool output.
+- **IDMS** (`idms-*.yaml`): `spec.imageDigestMirrors` must be a non-empty list.
+- **ITMS** (`itms-*.yaml`): `spec.imageTagMirrors` must be a non-empty list.
+- **CatalogSource** (`cs-*.yaml`): `spec.sourceType` and `spec.image` must be
+  non-empty strings.
+- **ClusterCatalog** (`cc-*.yaml`): `spec.source` must be defined.
+
+Set `om_validate_manifests: false` to skip validation (e.g. when you know the
+mirroring tool produces partial output intentionally).
+
+### GitOps and ACM Policy Compliance
+
+When using the generated manifests in a GitOps workflow or as ACM policy
+sources, validation failures indicate that one or more manifests are incomplete
+and must not be committed to the policy repository. Resolve the root cause
+before propagating the manifests downstream.
 
 ## Output / facts
 

--- a/roles/oci_mirror/defaults/main.yml
+++ b/roles/oci_mirror/defaults/main.yml
@@ -3,3 +3,4 @@ om_allow_insecure_registries: false
 om_keep_working_dir: false
 om_remove_signatures: false
 om_ignore_errors: false
+om_validate_manifests: true

--- a/roles/oci_mirror/meta/argument_specs.yml
+++ b/roles/oci_mirror/meta/argument_specs.yml
@@ -74,4 +74,5 @@ argument_specs:
           non-empty, that status is not an empty dict (which would indicate a
           serialization defect), and that kind-specific spec fields are present
           and non-empty (imageDigestMirrors for IDMS, imageTagMirrors for ITMS,
-          sourceType+image for CatalogSource, source for ClusterCatalog).
+          sourceType+image for CatalogSource, source for ClusterCatalog,
+          graphDataImage+releases for UpdateService).

--- a/roles/oci_mirror/meta/argument_specs.yml
+++ b/roles/oci_mirror/meta/argument_specs.yml
@@ -64,3 +64,14 @@ argument_specs:
         required: false
         default: false
         description: Ignore errors during mirroring.
+      om_validate_manifests:
+        type: bool
+        required: false
+        default: true
+        description: >
+          When true, validate all generated manifests in the output directory
+          after mirroring. Checks that apiVersion, kind, and metadata.name are
+          non-empty, that status is not an empty dict (which would indicate a
+          serialization defect), and that kind-specific spec fields are present
+          and non-empty (imageDigestMirrors for IDMS, imageTagMirrors for ITMS,
+          sourceType+image for CatalogSource, source for ClusterCatalog).

--- a/roles/oci_mirror/tasks/mirroring.yml
+++ b/roles/oci_mirror/tasks/mirroring.yml
@@ -49,6 +49,14 @@
       - "idms-oc-mirror.yaml"
   register: _om_image_source_manifest
 
+- name: "Find generated ITMS manifests"
+  ansible.builtin.find:
+    paths: "{{ _om_tmp_dir.path }}"
+    recurse: true
+    patterns:
+      - "itms-oc-mirror.yaml"
+  register: _om_itms_manifest
+
 - name: "Create output directory for manifests"
   ansible.builtin.tempfile:
     state: directory
@@ -76,7 +84,20 @@
   when:
     - _om_catalog_manifest.matched > 0
 
+- name: "Copy ITMS to output directory"
+  ansible.builtin.copy:
+    src: "{{ _om_itms_manifest.files[0].path }}"
+    dest: "{{ _om_output_dir.path }}/{{ _om_itms_manifest.files[0].path | basename }}"
+    mode: "0644"
+    remote_src: true
+  when:
+    - _om_itms_manifest.matched > 0
+
 - name: Expose manifests output directory
   ansible.builtin.set_fact:
     om_output_dir: "{{ _om_output_dir.path }}"
   when: _om_output_dir is defined
+
+- name: Validate generated manifests
+  ansible.builtin.include_tasks: validate-manifests.yml
+  when: om_validate_manifests | bool

--- a/roles/oci_mirror/tasks/validate-manifests.yml
+++ b/roles/oci_mirror/tasks/validate-manifests.yml
@@ -1,0 +1,57 @@
+---
+- name: "Find all YAML manifests in the output directory"
+  ansible.builtin.find:
+    paths: "{{ _om_output_dir.path }}"
+    patterns: "*.yaml"
+    recurse: false
+  register: _om_manifest_files
+  changed_when: false
+
+- name: "Parse and validate each manifest"
+  vars:
+    _manifest: "{{ lookup('file', item.path) | from_yaml }}"
+    _path: "{{ item.path }}"
+    _basename: "{{ item.path | basename }}"
+    _idms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'idms-') | list }}"
+    _itms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'itms-') | list }}"
+    _cs_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cs-') | list }}"
+    _cc_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cc-') | list }}"
+  ansible.builtin.assert:
+    that:
+      - _manifest.apiVersion is defined and _manifest.apiVersion | length > 0
+      - _manifest.kind is defined and _manifest.kind | length > 0
+      - _manifest.metadata is defined
+      - _manifest.metadata.name is defined and _manifest.metadata.name | length > 0
+      - not (_manifest.status is defined and _manifest.status == {})
+      - >-
+        not (_basename in (_idms_files | map(attribute='path') | map('basename') | list))
+        or (_manifest.spec is defined
+            and _manifest.spec.imageDigestMirrors is defined
+            and _manifest.spec.imageDigestMirrors | length > 0)
+      - >-
+        not (_basename in (_itms_files | map(attribute='path') | map('basename') | list))
+        or (_manifest.spec is defined
+            and _manifest.spec.imageTagMirrors is defined
+            and _manifest.spec.imageTagMirrors | length > 0)
+      - >-
+        not (_basename in (_cs_files | map(attribute='path') | map('basename') | list))
+        or (_manifest.spec is defined
+            and _manifest.spec.sourceType is defined
+            and _manifest.spec.sourceType | length > 0
+            and _manifest.spec.image is defined
+            and _manifest.spec.image | length > 0)
+      - >-
+        not (_basename in (_cc_files | map(attribute='path') | map('basename') | list))
+        or (_manifest.spec is defined
+            and _manifest.spec.source is defined)
+    fail_msg: >-
+      Manifest validation failed for {{ _basename }}:
+      apiVersion={{ _manifest.apiVersion | default('empty') }},
+      kind={{ _manifest.kind | default('empty') }},
+      name={{ _manifest.metadata.name | default('empty') }},
+      status={{ _manifest.status | default('not set') }}.
+      Check that the manifest is complete and non-empty.
+    success_msg: "Manifest {{ _basename }} passed validation."
+  loop: "{{ _om_manifest_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"

--- a/roles/oci_mirror/tasks/validate-manifests.yml
+++ b/roles/oci_mirror/tasks/validate-manifests.yml
@@ -5,18 +5,12 @@
     patterns: "*.yaml"
     recurse: false
   register: _om_manifest_files
-  changed_when: false
 
 - name: "Parse and validate each manifest"
   vars:
     _manifest: "{{ lookup('file', item.path) | from_yaml }}"
     _path: "{{ item.path }}"
     _basename: "{{ item.path | basename }}"
-    _idms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'idms-') | list }}"
-    _itms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'itms-') | list }}"
-    _cs_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cs-') | list }}"
-    _cc_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cc-') | list }}"
-    _us_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'update-service-') | list }}"
   ansible.builtin.assert:
     that:
       - _manifest.apiVersion is defined and _manifest.apiVersion | length > 0
@@ -25,28 +19,28 @@
       - _manifest.metadata.name is defined and _manifest.metadata.name | length > 0
       - not (_manifest.status is defined and _manifest.status == {})
       - >-
-        not (_basename in (_idms_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('idms-')
         or (_manifest.spec is defined
             and _manifest.spec.imageDigestMirrors is defined
             and _manifest.spec.imageDigestMirrors | length > 0)
       - >-
-        not (_basename in (_itms_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('itms-')
         or (_manifest.spec is defined
             and _manifest.spec.imageTagMirrors is defined
             and _manifest.spec.imageTagMirrors | length > 0)
       - >-
-        not (_basename in (_cs_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('cs-')
         or (_manifest.spec is defined
             and _manifest.spec.sourceType is defined
             and _manifest.spec.sourceType | length > 0
             and _manifest.spec.image is defined
             and _manifest.spec.image | length > 0)
       - >-
-        not (_basename in (_cc_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('cc-')
         or (_manifest.spec is defined
             and _manifest.spec.source is defined)
       - >-
-        not (_basename in (_us_files | map(attribute='path') | map('basename') | list))
+        not _basename.startswith('update-service-')
         or ((_manifest.spec | default({})).graphDataImage is defined
             and (_manifest.spec | default({})).graphDataImage | length > 0
             and (_manifest.spec | default({})).releases is defined

--- a/roles/oci_mirror/tasks/validate-manifests.yml
+++ b/roles/oci_mirror/tasks/validate-manifests.yml
@@ -16,6 +16,7 @@
     _itms_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'itms-') | list }}"
     _cs_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cs-') | list }}"
     _cc_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'cc-') | list }}"
+    _us_files: "{{ _om_manifest_files.files | selectattr('path', 'search', 'update-service-') | list }}"
   ansible.builtin.assert:
     that:
       - _manifest.apiVersion is defined and _manifest.apiVersion | length > 0
@@ -44,6 +45,12 @@
         not (_basename in (_cc_files | map(attribute='path') | map('basename') | list))
         or (_manifest.spec is defined
             and _manifest.spec.source is defined)
+      - >-
+        not (_basename in (_us_files | map(attribute='path') | map('basename') | list))
+        or ((_manifest.spec | default({})).graphDataImage is defined
+            and (_manifest.spec | default({})).graphDataImage | length > 0
+            and (_manifest.spec | default({})).releases is defined
+            and (_manifest.spec | default({})).releases | length > 0)
     fail_msg: >-
       Manifest validation failed for {{ _basename }}:
       apiVersion={{ _manifest.apiVersion | default('empty') }},

--- a/roles/oci_mirror/tasks/validate-manifests.yml
+++ b/roles/oci_mirror/tasks/validate-manifests.yml
@@ -6,34 +6,60 @@
     recurse: false
   register: _om_manifest_files
 
+- name: "Slurp each manifest from the managed host"
+  ansible.builtin.slurp:
+    src: "{{ item.path }}"
+  loop: "{{ _om_manifest_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"
+  register: _om_slurped_manifests
+
 - name: "Parse and validate each manifest"
   vars:
-    _manifest: "{{ lookup('file', item.path) | from_yaml }}"
-    _path: "{{ item.path }}"
-    _basename: "{{ item.path | basename }}"
+    _manifest: "{{ item.content | b64decode | from_yaml }}"
+    _basename: "{{ item.source | basename }}"
   ansible.builtin.assert:
     that:
-      - _manifest.apiVersion is defined and _manifest.apiVersion | length > 0
-      - _manifest.kind is defined and _manifest.kind | length > 0
+      - _manifest.apiVersion is defined and _manifest.apiVersion is string and _manifest.apiVersion | length > 0
+      - _manifest.kind is defined and _manifest.kind is string and _manifest.kind | length > 0
       - _manifest.metadata is defined
-      - _manifest.metadata.name is defined and _manifest.metadata.name | length > 0
+      - _manifest.metadata.name is defined and _manifest.metadata.name is string and _manifest.metadata.name | length > 0
       - not (_manifest.status is defined and _manifest.status == {})
+      - >-
+        not _basename.startswith('idms-')
+        or _manifest.apiVersion == 'config.openshift.io/v1'
+      - >-
+        not _basename.startswith('itms-')
+        or _manifest.apiVersion == 'config.openshift.io/v1'
+      - >-
+        not _basename.startswith('cs-')
+        or _manifest.apiVersion == 'operators.coreos.com/v1alpha1'
+      - >-
+        not _basename.startswith('cc-')
+        or _manifest.apiVersion == 'catalogd.operatorframework.io/v1'
+      - >-
+        not _basename.startswith('update-service-')
+        or _manifest.apiVersion == 'updateservice.operator.openshift.io/v1'
       - >-
         not _basename.startswith('idms-')
         or (_manifest.spec is defined
             and _manifest.spec.imageDigestMirrors is defined
+            and _manifest.spec.imageDigestMirrors is list
             and _manifest.spec.imageDigestMirrors | length > 0)
       - >-
         not _basename.startswith('itms-')
         or (_manifest.spec is defined
             and _manifest.spec.imageTagMirrors is defined
+            and _manifest.spec.imageTagMirrors is list
             and _manifest.spec.imageTagMirrors | length > 0)
       - >-
         not _basename.startswith('cs-')
         or (_manifest.spec is defined
             and _manifest.spec.sourceType is defined
+            and _manifest.spec.sourceType is string
             and _manifest.spec.sourceType | length > 0
             and _manifest.spec.image is defined
+            and _manifest.spec.image is string
             and _manifest.spec.image | length > 0)
       - >-
         not _basename.startswith('cc-')
@@ -42,8 +68,10 @@
       - >-
         not _basename.startswith('update-service-')
         or ((_manifest.spec | default({})).graphDataImage is defined
+            and (_manifest.spec | default({})).graphDataImage is string
             and (_manifest.spec | default({})).graphDataImage | length > 0
             and (_manifest.spec | default({})).releases is defined
+            and (_manifest.spec | default({})).releases is string
             and (_manifest.spec | default({})).releases | length > 0)
     fail_msg: >-
       Manifest validation failed for {{ _basename }}:
@@ -53,6 +81,6 @@
       status={{ _manifest.status | default('not set') }}.
       Check that the manifest is complete and non-empty.
     success_msg: "Manifest {{ _basename }} passed validation."
-  loop: "{{ _om_manifest_files.files }}"
+  loop: "{{ _om_slurped_manifests.results }}"
   loop_control:
-    label: "{{ item.path | basename }}"
+    label: "{{ item.source | basename }}"

--- a/roles/oci_mirror/tasks/validate-manifests.yml
+++ b/roles/oci_mirror/tasks/validate-manifests.yml
@@ -26,34 +26,34 @@
       - _manifest.metadata.name is defined and _manifest.metadata.name is string and _manifest.metadata.name | length > 0
       - not (_manifest.status is defined and _manifest.status == {})
       - >-
-        not _basename.startswith('idms-')
+        _manifest.kind | default('') != 'ImageDigestMirrorSet'
         or _manifest.apiVersion == 'config.openshift.io/v1'
       - >-
-        not _basename.startswith('itms-')
+        _manifest.kind | default('') != 'ImageTagMirrorSet'
         or _manifest.apiVersion == 'config.openshift.io/v1'
       - >-
-        not _basename.startswith('cs-')
+        _manifest.kind | default('') != 'CatalogSource'
         or _manifest.apiVersion == 'operators.coreos.com/v1alpha1'
       - >-
-        not _basename.startswith('cc-')
+        _manifest.kind | default('') != 'ClusterCatalog'
         or _manifest.apiVersion == 'catalogd.operatorframework.io/v1'
       - >-
-        not _basename.startswith('update-service-')
+        _manifest.kind | default('') != 'UpdateService'
         or _manifest.apiVersion == 'updateservice.operator.openshift.io/v1'
       - >-
-        not _basename.startswith('idms-')
+        _manifest.kind | default('') != 'ImageDigestMirrorSet'
         or (_manifest.spec is defined
             and _manifest.spec.imageDigestMirrors is defined
             and _manifest.spec.imageDigestMirrors is list
             and _manifest.spec.imageDigestMirrors | length > 0)
       - >-
-        not _basename.startswith('itms-')
+        _manifest.kind | default('') != 'ImageTagMirrorSet'
         or (_manifest.spec is defined
             and _manifest.spec.imageTagMirrors is defined
             and _manifest.spec.imageTagMirrors is list
             and _manifest.spec.imageTagMirrors | length > 0)
       - >-
-        not _basename.startswith('cs-')
+        _manifest.kind | default('') != 'CatalogSource'
         or (_manifest.spec is defined
             and _manifest.spec.sourceType is defined
             and _manifest.spec.sourceType is string
@@ -62,11 +62,11 @@
             and _manifest.spec.image is string
             and _manifest.spec.image | length > 0)
       - >-
-        not _basename.startswith('cc-')
+        _manifest.kind | default('') != 'ClusterCatalog'
         or (_manifest.spec is defined
             and _manifest.spec.source is defined)
       - >-
-        not _basename.startswith('update-service-')
+        _manifest.kind | default('') != 'UpdateService'
         or ((_manifest.spec | default({})).graphDataImage is defined
             and (_manifest.spec | default({})).graphDataImage is string
             and (_manifest.spec | default({})).graphDataImage | length > 0
@@ -74,13 +74,14 @@
             and (_manifest.spec | default({})).releases is string
             and (_manifest.spec | default({})).releases | length > 0)
     fail_msg: >-
-      Manifest validation failed for {{ _basename }}:
+      Manifest validation failed for {{ _basename }}
+      (kind={{ _manifest.kind | default('empty') }}):
       apiVersion={{ _manifest.apiVersion | default('empty') }},
-      kind={{ _manifest.kind | default('empty') }},
       name={{ _manifest.metadata.name | default('empty') }},
       status={{ _manifest.status | default('not set') }}.
       Check that the manifest is complete and non-empty.
-    success_msg: "Manifest {{ _basename }} passed validation."
+    success_msg: >-
+      Manifest {{ _basename }} (kind={{ _manifest.kind | default('empty') }}) passed validation.
   loop: "{{ _om_slurped_manifests.results }}"
   loop_control:
     label: "{{ item.source | basename }}"

--- a/tests/integration/targets/oci_mirror_manifests/files/bad/cc-empty-source.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/bad/cc-empty-source.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: catalogd.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: cc-redhat-operators
+spec: {}

--- a/tests/integration/targets/oci_mirror_manifests/files/bad/cs-empty-image.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/bad/cs-empty-image.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: cs-redhat-operators
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: ""

--- a/tests/integration/targets/oci_mirror_manifests/files/bad/idms-empty-status.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/bad/idms-empty-status.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: idms-oc-mirror
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - registry.lab.example.com:5000/openshift4
+      source: quay.io/openshift-release-dev/ocp-release
+status: {}

--- a/tests/integration/targets/oci_mirror_manifests/files/bad/itms-empty-imageTagMirrors.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/bad/itms-empty-imageTagMirrors.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: itms-oc-mirror
+spec:
+  imageTagMirrors: []

--- a/tests/integration/targets/oci_mirror_manifests/files/bad/update-service-empty-spec.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/bad/update-service-empty-spec.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: updateservice.operator.openshift.io/v1
+kind: UpdateService
+metadata:
+  name: update-service-empty-spec
+  namespace: openshift-update-service
+spec:
+  graphDataImage: ""
+  releases: ""

--- a/tests/integration/targets/oci_mirror_manifests/files/bad/update-service-wrong-apiversion.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/bad/update-service-wrong-apiversion.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: wrong.api.example.com/v1
+kind: UpdateService
+metadata:
+  name: update-service-wrong-apiversion
+  namespace: openshift-update-service
+spec:
+  graphDataImage: registry.lab.example.com:5000/updateservice/graph-data:latest
+  releases: registry.lab.example.com:5000/openshift-release-dev/ocp-release
+  replicas: 2

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/cc-redhat-operators.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/cc-redhat-operators.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: catalogd.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: cc-redhat-operators
+spec:
+  source:
+    type: Image
+    image:
+      ref: registry.lab.example.com:5000/redhat/redhat-operator-index:v4.17
+      pollInterval: 24h

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/cs-redhat-operators.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/cs-redhat-operators.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: cs-redhat-operators
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: registry.lab.example.com:5000/redhat/redhat-operator-index:v4.14
+  displayName: Red Hat Operators (mirrored)
+  publisher: Red Hat

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/idms-oc-mirror.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/idms-oc-mirror.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: idms-oc-mirror
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - registry.lab.example.com:5000/openshift4
+      source: quay.io/openshift-release-dev/ocp-release
+    - mirrors:
+        - registry.lab.example.com:5000/openshift4
+      source: quay.io/openshift-release-dev/ocp-v4.0-art-dev

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/itms-oc-mirror.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/itms-oc-mirror.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: itms-oc-mirror
+spec:
+  imageTagMirrors:
+    - mirrors:
+        - registry.lab.example.com:5000/ubi8
+      source: registry.access.redhat.com/ubi8

--- a/tests/integration/targets/oci_mirror_manifests/files/valid/update-service-oc-mirror.yaml
+++ b/tests/integration/targets/oci_mirror_manifests/files/valid/update-service-oc-mirror.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: updateservice.operator.openshift.io/v1
+kind: UpdateService
+metadata:
+  name: update-service-oc-mirror
+  namespace: openshift-update-service
+spec:
+  graphDataImage: registry.lab.example.com:5000/updateservice/graph-data:latest
+  releases: registry.lab.example.com:5000/openshift-release-dev/ocp-release
+  replicas: 2

--- a/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
+++ b/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
@@ -1,0 +1,77 @@
+---
+- name: Integration tests for oci_mirror manifest validation
+  hosts: testhost
+  gather_facts: false
+  tasks:
+
+    - name: Create temp directory for valid manifests
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_valid.
+      register: _test_valid_dir
+
+    - name: Create temp directory for bad manifests
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_bad.
+      register: _test_bad_dir
+
+    - name: Copy valid manifest fixtures to temp directory
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ _test_valid_dir.path }}/{{ item | basename }}"
+        mode: "0644"
+      loop:
+        - "files/valid/idms-oc-mirror.yaml"
+        - "files/valid/itms-oc-mirror.yaml"
+        - "files/valid/cs-redhat-operators.yaml"
+        - "files/valid/cc-redhat-operators.yaml"
+
+    - name: Validate valid manifests — should succeed
+      vars:
+        _om_output_dir:
+          path: "{{ _test_valid_dir.path }}"
+      ansible.builtin.include_role:
+        name: redhatci.ocp.oci_mirror
+        tasks_from: validate-manifests.yml
+
+    - name: Copy bad manifest fixture to temp directory
+      ansible.builtin.copy:
+        src: "files/bad/idms-empty-status.yaml"
+        dest: "{{ _test_bad_dir.path }}/idms-oc-mirror.yaml"
+        mode: "0644"
+
+    - name: Validate bad manifests — should fail
+      block:
+        - name: Run validation on bad manifest (expected to fail)
+          vars:
+            _om_output_dir:
+              path: "{{ _test_bad_dir.path }}"
+          ansible.builtin.include_role:
+            name: redhatci.ocp.oci_mirror
+            tasks_from: validate-manifests.yml
+
+        - name: Fail if validation did not raise an error
+          ansible.builtin.fail:
+            msg: "Validation should have failed for manifest with empty status but did not."
+
+      rescue:
+        - name: Confirm that the validation failure mentions empty status
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - "'empty' in (ansible_failed_result.msg | default(''))"
+            fail_msg: >-
+              Validation failed but the error message did not mention 'empty'.
+              Got: {{ ansible_failed_result.msg | default('no message') }}
+
+      always:
+        - name: Clean up valid temp directory
+          ansible.builtin.file:
+            path: "{{ _test_valid_dir.path }}"
+            state: absent
+
+        - name: Clean up bad temp directory
+          ansible.builtin.file:
+            path: "{{ _test_bad_dir.path }}"
+            state: absent

--- a/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
+++ b/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
@@ -26,6 +26,7 @@
         - "files/valid/itms-oc-mirror.yaml"
         - "files/valid/cs-redhat-operators.yaml"
         - "files/valid/cc-redhat-operators.yaml"
+        - "files/valid/update-service-oc-mirror.yaml"
 
     - name: Validate valid manifests — should succeed
       vars:
@@ -34,6 +35,33 @@
       ansible.builtin.include_role:
         name: redhatci.ocp.oci_mirror
         tasks_from: validate-manifests.yml
+
+    - name: "AC4 — Verify apiVersion matches expected schema per kind (GitOps/ACM compliance)"
+      vars:
+        _api_version_map:
+          ImageDigestMirrorSet: "config.openshift.io/v1"
+          ImageTagMirrorSet: "config.openshift.io/v1"
+          CatalogSource: "operators.coreos.com/v1alpha1"
+          ClusterCatalog: "catalogd.operatorframework.io/v1"
+          UpdateService: "updateservice.operator.openshift.io/v1"
+        _manifest: "{{ lookup('file', item.path) | from_yaml }}"
+        _kind: "{{ _manifest.kind | default('') }}"
+        _expected_api: "{{ _api_version_map[_kind] | default('') }}"
+      ansible.builtin.assert:
+        that:
+          - _kind not in _api_version_map or _manifest.apiVersion == _expected_api
+        fail_msg: >-
+          AC4 apiVersion mismatch in {{ item.path | basename }}:
+          kind={{ _kind }},
+          expected apiVersion={{ _expected_api }},
+          got={{ _manifest.apiVersion | default('empty') }}.
+        success_msg: >-
+          AC4 passed for {{ item.path | basename }}:
+          kind={{ _kind }}, apiVersion={{ _manifest.apiVersion | default('empty') }}.
+      loop: "{{ _om_manifest_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+      when: _om_manifest_files.files | length > 0
 
     - name: Copy bad manifest fixture to temp directory
       ansible.builtin.copy:
@@ -74,4 +102,46 @@
         - name: Clean up bad temp directory
           ansible.builtin.file:
             path: "{{ _test_bad_dir.path }}"
+            state: absent
+
+    - name: Create temp directory for bad UpdateService manifest
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_bad_us.
+      register: _test_bad_us_dir
+
+    - name: Validate bad UpdateService manifest — should fail
+      block:
+        - name: Copy bad UpdateService fixture to temp directory
+          ansible.builtin.copy:
+            src: "files/bad/update-service-empty-spec.yaml"
+            dest: "{{ _test_bad_us_dir.path }}/update-service-oc-mirror.yaml"
+            mode: "0644"
+
+        - name: Run validation on bad UpdateService manifest (expected to fail)
+          vars:
+            _om_output_dir:
+              path: "{{ _test_bad_us_dir.path }}"
+          ansible.builtin.include_role:
+            name: redhatci.ocp.oci_mirror
+            tasks_from: validate-manifests.yml
+
+        - name: Fail if UpdateService validation did not raise an error
+          ansible.builtin.fail:
+            msg: "Validation should have failed for UpdateService with empty spec but did not."
+
+      rescue:
+        - name: Confirm that the UpdateService validation failure mentions empty
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - "'empty' in (ansible_failed_result.msg | default(''))"
+            fail_msg: >-
+              UpdateService validation failed but the error message did not mention 'empty'.
+              Got: {{ ansible_failed_result.msg | default('no message') }}
+
+      always:
+        - name: Clean up bad UpdateService temp directory
+          ansible.builtin.file:
+            path: "{{ _test_bad_us_dir.path }}"
             state: absent

--- a/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
+++ b/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
@@ -36,7 +36,7 @@
         name: redhatci.ocp.oci_mirror
         tasks_from: validate-manifests.yml
 
-    - name: "AC4 — Verify apiVersion matches expected schema per kind (GitOps/ACM compliance)"
+    - name: "AC4 — Verify apiVersion matches expected schema per kind"
       vars:
         _api_version_map:
           ImageDigestMirrorSet: "config.openshift.io/v1"
@@ -44,24 +44,24 @@
           CatalogSource: "operators.coreos.com/v1alpha1"
           ClusterCatalog: "catalogd.operatorframework.io/v1"
           UpdateService: "updateservice.operator.openshift.io/v1"
-        _manifest: "{{ lookup('file', item.path) | from_yaml }}"
+        _manifest: "{{ item.content | b64decode | from_yaml }}"
         _kind: "{{ _manifest.kind | default('') }}"
         _expected_api: "{{ _api_version_map[_kind] | default('') }}"
       ansible.builtin.assert:
         that:
           - _kind not in _api_version_map or _manifest.apiVersion == _expected_api
         fail_msg: >-
-          AC4 apiVersion mismatch in {{ item.path | basename }}:
+          AC4 apiVersion mismatch in {{ item.source | basename }}:
           kind={{ _kind }},
           expected apiVersion={{ _expected_api }},
           got={{ _manifest.apiVersion | default('empty') }}.
         success_msg: >-
-          AC4 passed for {{ item.path | basename }}:
+          AC4 passed for {{ item.source | basename }}:
           kind={{ _kind }}, apiVersion={{ _manifest.apiVersion | default('empty') }}.
-      loop: "{{ _om_manifest_files.files }}"
+      loop: "{{ _om_slurped_manifests.results }}"
       loop_control:
-        label: "{{ item.path | basename }}"
-      when: _om_manifest_files.files | length > 0
+        label: "{{ item.source | basename }}"
+      when: _om_slurped_manifests.results | length > 0
 
     - name: Copy bad manifest fixture to temp directory
       ansible.builtin.copy:
@@ -315,4 +315,56 @@
         - name: Clean up bad ClusterCatalog temp directory
           ansible.builtin.file:
             path: "{{ _test_bad_cc_dir.path }}"
+            state: absent
+
+    - name: Create temp directory for bad UpdateService wrong-apiVersion manifest
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_bad_us_api.
+      register: _test_bad_us_api_dir
+
+    - name: Validate bad UpdateService wrong-apiVersion manifest — should fail
+      block:
+        - name: Reset sentinel before wrong-apiVersion validation
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: false
+
+        - name: Copy bad UpdateService wrong-apiVersion fixture to temp directory
+          ansible.builtin.copy:
+            src: "files/bad/update-service-wrong-apiversion.yaml"
+            dest: "{{ _test_bad_us_api_dir.path }}/update-service-oc-mirror.yaml"
+            mode: "0644"
+
+        - name: Run validation on bad UpdateService wrong-apiVersion manifest (expected to fail)
+          vars:
+            _om_output_dir:
+              path: "{{ _test_bad_us_api_dir.path }}"
+          ansible.builtin.include_role:
+            name: redhatci.ocp.oci_mirror
+            tasks_from: validate-manifests.yml
+
+        - name: Mark that wrong-apiVersion validation unexpectedly passed
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: true
+
+        - name: Fail if wrong-apiVersion validation did not raise an error
+          ansible.builtin.fail:
+            msg: >-
+              Validation should have failed for UpdateService with wrong apiVersion but did not.
+
+      rescue:
+        - name: Confirm it was a validation failure, not the sentinel fallback (wrong apiVersion)
+          ansible.builtin.assert:
+            that:
+              - not (_om_validation_unexpectedly_passed | default(false))
+              - ansible_failed_result is defined
+              - "'Manifest validation failed' in (ansible_failed_result.msg | default(''))"
+            fail_msg: >-
+              Expected a wrong-apiVersion validation failure but got an unexpected error.
+              Got: {{ ansible_failed_result.msg | default('no message') }}
+
+      always:
+        - name: Clean up bad UpdateService wrong-apiVersion temp directory
+          ansible.builtin.file:
+            path: "{{ _test_bad_us_api_dir.path }}"
             state: absent

--- a/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
+++ b/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
@@ -71,6 +71,10 @@
 
     - name: Validate bad manifests — should fail
       block:
+        - name: Reset sentinel before validation
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: false
+
         - name: Run validation on bad manifest (expected to fail)
           vars:
             _om_output_dir:
@@ -79,18 +83,23 @@
             name: redhatci.ocp.oci_mirror
             tasks_from: validate-manifests.yml
 
+        - name: Mark that validation unexpectedly passed
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: true
+
         - name: Fail if validation did not raise an error
           ansible.builtin.fail:
             msg: "Validation should have failed for manifest with empty status but did not."
 
       rescue:
-        - name: Confirm that the validation failure mentions empty status
+        - name: Confirm it was a validation failure, not the sentinel fallback
           ansible.builtin.assert:
             that:
+              - not (_om_validation_unexpectedly_passed | default(false))
               - ansible_failed_result is defined
-              - "'empty' in (ansible_failed_result.msg | default(''))"
+              - "'Manifest validation failed' in (ansible_failed_result.msg | default(''))"
             fail_msg: >-
-              Validation failed but the error message did not mention 'empty'.
+              Expected a validation failure but got an unexpected error.
               Got: {{ ansible_failed_result.msg | default('no message') }}
 
       always:
@@ -112,6 +121,10 @@
 
     - name: Validate bad UpdateService manifest — should fail
       block:
+        - name: Reset sentinel before UpdateService validation
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: false
+
         - name: Copy bad UpdateService fixture to temp directory
           ansible.builtin.copy:
             src: "files/bad/update-service-empty-spec.yaml"
@@ -126,18 +139,23 @@
             name: redhatci.ocp.oci_mirror
             tasks_from: validate-manifests.yml
 
+        - name: Mark that UpdateService validation unexpectedly passed
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: true
+
         - name: Fail if UpdateService validation did not raise an error
           ansible.builtin.fail:
             msg: "Validation should have failed for UpdateService with empty spec but did not."
 
       rescue:
-        - name: Confirm that the UpdateService validation failure mentions empty
+        - name: Confirm it was a validation failure, not the sentinel fallback (UpdateService)
           ansible.builtin.assert:
             that:
+              - not (_om_validation_unexpectedly_passed | default(false))
               - ansible_failed_result is defined
-              - "'empty' in (ansible_failed_result.msg | default(''))"
+              - "'Manifest validation failed' in (ansible_failed_result.msg | default(''))"
             fail_msg: >-
-              UpdateService validation failed but the error message did not mention 'empty'.
+              Expected an UpdateService validation failure but got an unexpected error.
               Got: {{ ansible_failed_result.msg | default('no message') }}
 
       always:
@@ -154,6 +172,10 @@
 
     - name: Validate bad ITMS manifest — should fail
       block:
+        - name: Reset sentinel before ITMS validation
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: false
+
         - name: Copy bad ITMS fixture to temp directory
           ansible.builtin.copy:
             src: "files/bad/itms-empty-imageTagMirrors.yaml"
@@ -168,18 +190,23 @@
             name: redhatci.ocp.oci_mirror
             tasks_from: validate-manifests.yml
 
+        - name: Mark that ITMS validation unexpectedly passed
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: true
+
         - name: Fail if ITMS validation did not raise an error
           ansible.builtin.fail:
             msg: "Validation should have failed for ITMS with empty imageTagMirrors but did not."
 
       rescue:
-        - name: Confirm that the ITMS validation failure mentions empty
+        - name: Confirm it was a validation failure, not the sentinel fallback (ITMS)
           ansible.builtin.assert:
             that:
+              - not (_om_validation_unexpectedly_passed | default(false))
               - ansible_failed_result is defined
-              - "'empty' in (ansible_failed_result.msg | default(''))"
+              - "'Manifest validation failed' in (ansible_failed_result.msg | default(''))"
             fail_msg: >-
-              ITMS validation failed but the error message did not mention 'empty'.
+              Expected an ITMS validation failure but got an unexpected error.
               Got: {{ ansible_failed_result.msg | default('no message') }}
 
       always:
@@ -196,6 +223,10 @@
 
     - name: Validate bad CatalogSource manifest — should fail
       block:
+        - name: Reset sentinel before CatalogSource validation
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: false
+
         - name: Copy bad CatalogSource fixture to temp directory
           ansible.builtin.copy:
             src: "files/bad/cs-empty-image.yaml"
@@ -210,18 +241,23 @@
             name: redhatci.ocp.oci_mirror
             tasks_from: validate-manifests.yml
 
+        - name: Mark that CatalogSource validation unexpectedly passed
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: true
+
         - name: Fail if CatalogSource validation did not raise an error
           ansible.builtin.fail:
             msg: "Validation should have failed for CatalogSource with empty image but did not."
 
       rescue:
-        - name: Confirm that the CatalogSource validation failure mentions empty
+        - name: Confirm it was a validation failure, not the sentinel fallback (CatalogSource)
           ansible.builtin.assert:
             that:
+              - not (_om_validation_unexpectedly_passed | default(false))
               - ansible_failed_result is defined
-              - "'empty' in (ansible_failed_result.msg | default(''))"
+              - "'Manifest validation failed' in (ansible_failed_result.msg | default(''))"
             fail_msg: >-
-              CatalogSource validation failed but the error message did not mention 'empty'.
+              Expected a CatalogSource validation failure but got an unexpected error.
               Got: {{ ansible_failed_result.msg | default('no message') }}
 
       always:
@@ -238,6 +274,10 @@
 
     - name: Validate bad ClusterCatalog manifest — should fail
       block:
+        - name: Reset sentinel before ClusterCatalog validation
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: false
+
         - name: Copy bad ClusterCatalog fixture to temp directory
           ansible.builtin.copy:
             src: "files/bad/cc-empty-source.yaml"
@@ -252,18 +292,23 @@
             name: redhatci.ocp.oci_mirror
             tasks_from: validate-manifests.yml
 
+        - name: Mark that ClusterCatalog validation unexpectedly passed
+          ansible.builtin.set_fact:
+            _om_validation_unexpectedly_passed: true
+
         - name: Fail if ClusterCatalog validation did not raise an error
           ansible.builtin.fail:
             msg: "Validation should have failed for ClusterCatalog with empty source but did not."
 
       rescue:
-        - name: Confirm that the ClusterCatalog validation failure mentions empty
+        - name: Confirm it was a validation failure, not the sentinel fallback (ClusterCatalog)
           ansible.builtin.assert:
             that:
+              - not (_om_validation_unexpectedly_passed | default(false))
               - ansible_failed_result is defined
-              - "'empty' in (ansible_failed_result.msg | default(''))"
+              - "'Manifest validation failed' in (ansible_failed_result.msg | default(''))"
             fail_msg: >-
-              ClusterCatalog validation failed but the error message did not mention 'empty'.
+              Expected a ClusterCatalog validation failure but got an unexpected error.
               Got: {{ ansible_failed_result.msg | default('no message') }}
 
       always:

--- a/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
+++ b/tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml
@@ -145,3 +145,129 @@
           ansible.builtin.file:
             path: "{{ _test_bad_us_dir.path }}"
             state: absent
+
+    - name: Create temp directory for bad ITMS manifest
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_bad_itms.
+      register: _test_bad_itms_dir
+
+    - name: Validate bad ITMS manifest — should fail
+      block:
+        - name: Copy bad ITMS fixture to temp directory
+          ansible.builtin.copy:
+            src: "files/bad/itms-empty-imageTagMirrors.yaml"
+            dest: "{{ _test_bad_itms_dir.path }}/itms-oc-mirror.yaml"
+            mode: "0644"
+
+        - name: Run validation on bad ITMS manifest (expected to fail)
+          vars:
+            _om_output_dir:
+              path: "{{ _test_bad_itms_dir.path }}"
+          ansible.builtin.include_role:
+            name: redhatci.ocp.oci_mirror
+            tasks_from: validate-manifests.yml
+
+        - name: Fail if ITMS validation did not raise an error
+          ansible.builtin.fail:
+            msg: "Validation should have failed for ITMS with empty imageTagMirrors but did not."
+
+      rescue:
+        - name: Confirm that the ITMS validation failure mentions empty
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - "'empty' in (ansible_failed_result.msg | default(''))"
+            fail_msg: >-
+              ITMS validation failed but the error message did not mention 'empty'.
+              Got: {{ ansible_failed_result.msg | default('no message') }}
+
+      always:
+        - name: Clean up bad ITMS temp directory
+          ansible.builtin.file:
+            path: "{{ _test_bad_itms_dir.path }}"
+            state: absent
+
+    - name: Create temp directory for bad CatalogSource manifest
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_bad_cs.
+      register: _test_bad_cs_dir
+
+    - name: Validate bad CatalogSource manifest — should fail
+      block:
+        - name: Copy bad CatalogSource fixture to temp directory
+          ansible.builtin.copy:
+            src: "files/bad/cs-empty-image.yaml"
+            dest: "{{ _test_bad_cs_dir.path }}/cs-redhat-operators.yaml"
+            mode: "0644"
+
+        - name: Run validation on bad CatalogSource manifest (expected to fail)
+          vars:
+            _om_output_dir:
+              path: "{{ _test_bad_cs_dir.path }}"
+          ansible.builtin.include_role:
+            name: redhatci.ocp.oci_mirror
+            tasks_from: validate-manifests.yml
+
+        - name: Fail if CatalogSource validation did not raise an error
+          ansible.builtin.fail:
+            msg: "Validation should have failed for CatalogSource with empty image but did not."
+
+      rescue:
+        - name: Confirm that the CatalogSource validation failure mentions empty
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - "'empty' in (ansible_failed_result.msg | default(''))"
+            fail_msg: >-
+              CatalogSource validation failed but the error message did not mention 'empty'.
+              Got: {{ ansible_failed_result.msg | default('no message') }}
+
+      always:
+        - name: Clean up bad CatalogSource temp directory
+          ansible.builtin.file:
+            path: "{{ _test_bad_cs_dir.path }}"
+            state: absent
+
+    - name: Create temp directory for bad ClusterCatalog manifest
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: om_test_bad_cc.
+      register: _test_bad_cc_dir
+
+    - name: Validate bad ClusterCatalog manifest — should fail
+      block:
+        - name: Copy bad ClusterCatalog fixture to temp directory
+          ansible.builtin.copy:
+            src: "files/bad/cc-empty-source.yaml"
+            dest: "{{ _test_bad_cc_dir.path }}/cc-redhat-operators.yaml"
+            mode: "0644"
+
+        - name: Run validation on bad ClusterCatalog manifest (expected to fail)
+          vars:
+            _om_output_dir:
+              path: "{{ _test_bad_cc_dir.path }}"
+          ansible.builtin.include_role:
+            name: redhatci.ocp.oci_mirror
+            tasks_from: validate-manifests.yml
+
+        - name: Fail if ClusterCatalog validation did not raise an error
+          ansible.builtin.fail:
+            msg: "Validation should have failed for ClusterCatalog with empty source but did not."
+
+      rescue:
+        - name: Confirm that the ClusterCatalog validation failure mentions empty
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result is defined
+              - "'empty' in (ansible_failed_result.msg | default(''))"
+            fail_msg: >-
+              ClusterCatalog validation failed but the error message did not mention 'empty'.
+              Got: {{ ansible_failed_result.msg | default('no message') }}
+
+      always:
+        - name: Clean up bad ClusterCatalog temp directory
+          ansible.builtin.file:
+            path: "{{ _test_bad_cc_dir.path }}"
+            state: absent

--- a/tests/integration/targets/oci_mirror_manifests/runme.sh
+++ b/tests/integration/targets/oci_mirror_manifests/runme.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+dir=$(dirname "$0")
+
+exec ansible-playbook -v -i $dir/../../inventory $dir/oci_mirror_manifests.yml
+
+# runme.sh ends here

--- a/tests/integration/targets/oci_mirror_manifests/runme.sh
+++ b/tests/integration/targets/oci_mirror_manifests/runme.sh
@@ -2,6 +2,6 @@
 
 dir=$(dirname "$0")
 
-exec ansible-playbook -v -i $dir/../../inventory $dir/oci_mirror_manifests.yml
+exec ansible-playbook -v -i "$dir"/../../inventory "$dir"/oci_mirror_manifests.yml
 
 # runme.sh ends here


### PR DESCRIPTION
## Summary

This PR adds oc-mirror v2 manifest validation to the `oci_mirror` role, ensuring that generated resources (IDMS, ITMS, UpdateService, CatalogSource, ClusterCatalog) are validated before use.

### What this PR does

- Adds `validate-manifests.yml` task to validate oc-mirror v2 generated resources for all 5 manifest types: IDMS, ITMS, UpdateService, CatalogSource, ClusterCatalog
- Adds ITMS find+copy steps in `mirroring.yml`
- Adds `om_validate_manifests` default, argument spec, and README documentation
- Adds integration test target `oci_mirror_manifests` with valid/bad fixtures for all 5 manifest types (positive and negative-path coverage)
- Adds `hack/validate_manifests.sh` standalone validation script
- Adds `docs/manifest-audit-process.md` serialization bug audit checklist

### Validation improvements

1. **`hack/validate_manifests.sh` — string type enforcement:** `apiVersion` and `kind` now require actual string values (via `isinstance(val, str)`); `metadata.name` uses a separate `name` variable with proper isinstance guards. Error messages say 'must be a non-empty string'.
2. **`hack/validate_manifests.sh` — spec mapping guard:** Added `isinstance(kind, str)` guard; replaced `spec = doc.get('spec', {}) or {}` with an explicit isinstance check that appends an ERROR for non-mapping `spec` values (e.g. `spec: [item]`) before falling back to `{}`.
3. **`hack/validate_manifests.sh` — kind-specific spec field guards:** Added `isinstance(val, str)` guards before `.strip()` on `spec.sourceType` and `spec.image` (CatalogSource), and `spec.graphDataImage` and `spec.releases` (UpdateService). Prevents `AttributeError` when a non-string YAML value is encountered.
4. **`hack/validate_manifests.sh` — OSError guard on `open()`:** Wrapped the outer `with open(...)` in a `try/except OSError` block. When `glob()` returns a directory entry matching `*.yaml`, the script now returns a file-specific error record instead of an unhandled traceback. Validation of remaining manifests continues.
5. **`hack/validate_manifests.sh` — ClusterCatalog `spec.source` non-empty mapping check:** Replaced `"source" not in spec` with an `isinstance(dict) + non-empty` guard. Rejects `spec.source: null`, `spec.source: {}`, and `spec.source: "string"` — all of which would fail when applied to a cluster but previously passed validation.
6. **`roles/oci_mirror/tasks/validate-manifests.yml` — kind-dispatch:** Replaced all 10 `_basename.startswith('xxx-')` conditions with `_manifest.kind | default('') == 'Kind'` comparisons. Validation now fires correctly regardless of filename.
7. **`tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml` — AC4 slurp:** Replaced `lookup('file', item.path) | from_yaml` with `item.content | b64decode | from_yaml` from `_om_slurped_manifests.results`.
8. **Wrong-apiVersion negative test:** Added `files/bad/update-service-wrong-apiversion.yaml` and a full block/rescue/always negative test block.

### Files changed

- `roles/oci_mirror/tasks/validate-manifests.yml` — validates all oc-mirror v2 resource types
- `roles/oci_mirror/tasks/mirroring.yml` — added ITMS find+copy steps
- `roles/oci_mirror/defaults/main.yml` — added `om_validate_manifests` default
- `roles/oci_mirror/meta/argument_specs.yml` — added `om_validate_manifests` spec
- `roles/oci_mirror/README.md` — documented new parameter
- `tests/integration/targets/oci_mirror_manifests/oci_mirror_manifests.yml` — integration test playbook with full positive/negative coverage
- `tests/integration/targets/oci_mirror_manifests/runme.sh` — test runner with hardened quoting
- `tests/integration/targets/oci_mirror_manifests/files/valid/*` — valid IDMS/ITMS/UpdateService/CS/CC fixtures
- `tests/integration/targets/oci_mirror_manifests/files/bad/*` — bad fixtures for all 5 manifest types, including wrong-apiVersion fixture
- `hack/validate_manifests.sh` — standalone manifest validation script
- `docs/manifest-audit-process.md` — reusable serialization bug audit process

---
Generated with the help of [AI Assist](https://github.com/fredericlepied/ai-assist)