### PR TITLE
Make use of payload oc library to extract and fix Segmentation fault error

### DIFF
--- a/roles/mirror_ocp_release/tasks/artifacts.yml
+++ b/roles/mirror_ocp_release/tasks/artifacts.yml
@@ -10,16 +10,28 @@
 - name: "Extract the OCP installer and metadata"
   when: mor_force or not _mor_target.stat.exists
   block:
+    - name: "Create temporary directory for payload oc"
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: mor_payload_oc.
+      register: _mor_payload_oc_tmp
+
     - name: "Extract installer and metadata from release image"
       ansible.builtin.shell: >
         flock -x {{ mor_cache_dir }}/{{ mor_version }}/release_extract.lock -c '
         set -e;
         {{ mor_oc }} adm release extract
         --registry-config {{ mor_auths_file }}
+        --command={{ 'oc.rhel8' if mor_version is version('4.16', '>=') else 'oc' }}
+        --from {{ mor_pull_url }}
+        --to "{{ _mor_payload_oc_tmp.path }}";
+        chmod +x "{{ _mor_payload_oc_tmp.path }}/oc";
+        "{{ _mor_payload_oc_tmp.path }}/oc" adm release extract
+        --registry-config {{ mor_auths_file }}
         --command={{ mor_installer }}
         --from {{ mor_pull_url }}
         --to "{{ mor_cache_dir }}/{{ mor_version }}";
-        {{ mor_oc }} adm release extract
+        "{{ _mor_payload_oc_tmp.path }}/oc" adm release extract
         --registry-config {{ mor_auths_file }}
         --tools
         --from {{ mor_pull_url }}
@@ -94,4 +106,10 @@
       ansible.builtin.file:
         path: "{{ mor_cache_dir }}/{{ mor_version }}/release_extract.lock"
         state: absent
+
+    - name: "Remove temporary payload oc"
+      ansible.builtin.file:
+        path: "{{ _mor_payload_oc_tmp.path }}"
+        state: absent
+      when: _mor_payload_oc_tmp.path is defined
 ...


### PR DESCRIPTION
## Summary
For GA builds, "extract rhcos.json" task is failing with "segmentation fault" like [here](https://www.distributed-ci.io/jobs/2813293c-d568-4cf9-8fae-428e6e91d021/jobStates?sort=date&task=e10ec52e-d1f9-4566-96c1-8d9895a0dc16).
This issue seems caused, by incomplete "openshift-install" binary extracted from incomplete [previous](https://www.distributed-ci.io/jobs/2813293c-d568-4cf9-8fae-428e6e91d021/jobStates?sort=date&task=3b50f9fc-f9cd-419c-9dd5-167c779cd634) ansible task.
```
[dci@server01 ~]$ ls -ltrh releases/4.20.36/
total 687M
-rwxr-xr-x. 1 dci dci  42M Aug 26 09:22 openshift-client-linux-4.20.36.tar.gz
-rwxr-xr-x. 1 dci dci  48M Aug 26 09:41 ccoctl-linux-rhel9-4.20.36.tar.gz
-rwxr-xr-x. 1 dci dci  48M Aug 26 09:43 ccoctl-linux-rhel8-4.20.36.tar.gz
-rwxr-xr-x. 1 dci dci  48M Aug 26 09:43 ccoctl-linux-4.20.36.tar.gz
-rwxr-xr-x. 1 dci dci  42M Aug 26 09:52 openshift-client-linux-amd64-rhel8-4.20.36.tar.gz
-rwxr-xr-x. 1 dci dci  42M Aug 26 09:58 openshift-client-linux-amd64-rhel9-4.20.36.tar.gz
-rwxr-xr-x. 1 dci dci 396M Aug 26 10:57 openshift-install-linux-4.20.36.tar.gz
-rwxr-xr-x. 1 dci dci  25M Aug 26 10:57 openshift-install
-rw-r--r--. 1 dci dci  813 Sep  1 07:06 sha256sum.txt
-rw-r--r--. 1 dci dci  33K Sep  1 07:06 release.txt
-rw-rw-r--. 1 dci dci    0 Sep  1 07:06 rhcos.json
[dci@server01 ~]$
```

This PR is to make use of correct oc binary to "extract rhcos.json" .


##### ISSUE TYPE
 Enhanced Feature

