### PR TITLE
Resolve must-gather images from CSV annotations; omit unresolved hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Name | Description
 [redhatci.ocp.redhat_tests](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/redhat_tests/README.md) | [Openshift End to End tests](https://github.com/openshift/openshift-tests)
 [redhatci.ocp.remove_ztp_gitops_resources](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/remove_ztp_gitops_resources/README.md) | Remove all GitOps related resources for a given spoke cluster, excepting the cluster namespace, which is not deleted because this will imply the spoke cluster is detached from the hub cluster.
 [redhatci.ocp.resources_to_components](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/resources_to_components/README.md) | Creates DCI components based on Kubernetes resources
-[redhatci.ocp.resolve_must_gather_images](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/resolve_must_gather_images/README.md) | Resolves version-independent must-gather image short names to full registry references using cluster CSVs.
+[redhatci.ocp.resolve_must_gather_images](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/resolve_must_gather_images/README.md) | Resolves must-gather image short names to full registry references using CSV annotations and relatedImages.
 [redhatci.ocp.rhoai](roles/rhoai/README.md) | Install the Red Hat OpenShift AI operators
 [redhatci.ocp.setup_gitops](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_gitops/README.md) | Configures GitOps to support Kustomize and PolicyGenerator
 [redhatci.ocp.setup_http_store](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/setup_http_store/README.md) | Sets up a web host which can be used to distribute iso's for `boot_iso` role
@@ -168,7 +168,7 @@ Name | Type | Description
 [redhatci.ocp.cmdline_to_json]() | Filter | Convert a kernel command line string to a JSON object
 [redhatci.ocp.redact]() | Filter | Redact sensitive values from a dictionary
 [redhatci.ocp.regex_diff]() | Filter | Obtain differences between two lists
-[redhatci.ocp.resolve_must_gather](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/plugins/filter/resolve_must_gather.py) | Filter | Resolves must-gather short names to full image references from CSV relatedImages
+[redhatci.ocp.resolve_must_gather](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/plugins/filter/resolve_must_gather.py) | Filter | Resolves must-gather short names to full image references from CSV annotations and relatedImages
 
 ## License
 

--- a/ansible-collection-redhatci-ocp.spec
+++ b/ansible-collection-redhatci-ocp.spec
@@ -3,7 +3,7 @@
 %global forgeurl https://github.com/%{org}/%{repo}
 
 Name:           %{repo}
-Version:        6.2.EPOCH
+Version:        6.3.EPOCH
 Release:        VERS%{?dist}
 Summary:        Red Hat OCP CI Collection for Ansible
 
@@ -55,6 +55,10 @@ find -type f ! -executable -name '*.py' -print -exec sed -i -e '1{\@^#!.*@d}' '{
 
 
 %changelog
+
+* Wed Sep  9 2026 Beto Rdz <josearod@redhat.com> - 6.3.EPOCH-VERS
+- Resolve must-gather images from CSV annotations; omit unresolved hints
+
 * Fri Aug 21 2026 Tony Garcia <tonyg@redhat.com> - 6.2.EPOCH-VERS
 - Default ArgoCD to operator-managed ClusterRole, require explicit AppProject
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ name: ocp
 # Patch version is replaced from commit date in UNIX epoch format
 # Example: 1.3.0 -> 1.3.2147483647
 # Keep in sync with ansible-collection-redhatci-ocp.spec
-version: 6.2.0
+version: 6.3.0
 
 # The path to the Markdown (.md) readme file.
 readme: README.md

--- a/plugins/filter/resolve_must_gather.py
+++ b/plugins/filter/resolve_must_gather.py
@@ -19,189 +19,221 @@ __metaclass__ = type
 DOCUMENTATION = r"""
     name: resolve_must_gather
     version_added: "2.10"
-    short_description: Resolve must-gather image short names from CSV relatedImages
+    short_description: Resolve must-gather image hints from installed CSVs
     description:
-        - Takes a list of must-gather image entries and resolves short names
-          (e.g. "ptp-must-gather") to full image references using the
-          relatedImages from installed ClusterServiceVersion resources.
-        - Entries that already contain a "/" are treated as full image
-          references and passed through unchanged.
-        - Short names are matched against both the relatedImages name
-          field and the image path using substring search. When the
-          entry does not contain "must-gather", matches are restricted
-          to relatedImages whose name or path contains "must-gather",
-          so generic keywords like "openshift-gitops" or "acm" resolve
-          to the correct must-gather image.
-    positional: _input, related_images, fallback_registry
+        - Takes a list of must-gather image hints and resolves short names
+          (e.g. "ptp", "acm", "gitops") to full image references using
+          installed ClusterServiceVersion resources.
+        - Full image references (containing "/") are ignored.
+        - Matching CSVs are identified from the CSV name, displayName,
+          annotations, and relatedImages.
+        - The image is taken first from the
+          operators.openshift.io/must-gather-image annotation, then from
+          other must-gather / mustgather annotations, then from relatedImages.
+        - Duplicate resolved images are returned once.
+        - Hints that cannot be resolved are omitted from the result.
+    positional: _input, csvs
     options:
         _input:
             description: >
-                List of must-gather image entries. Each entry is either a full
-                image reference (containing "/") or a short name to resolve.
+                List of must-gather image hints. Each entry is a short name
+                or keyword to resolve. Full image references (containing "/")
+                are ignored.
             type: list
             elements: str
             required: true
-        related_images:
+        csvs:
             description: >
-                List of relatedImages dicts from ClusterServiceVersion
-                resources. Each dict must have "name" and "image" keys.
+                List of CSV lookup dicts. Each dict may have "name",
+                "display_name", "annotations", and "related_images" keys.
+                related_images is a list of dicts with "name" and "image".
             type: list
             elements: dict
             required: true
-        fallback_registry:
-            description: >
-                Registry prefix used when a short name cannot be resolved from
-                any CSV relatedImages. Core OCP images (e.g. ose-must-gather)
-                are not shipped by any operator CSV and therefore never appear
-                in relatedImages. When non-empty, unresolved short names are
-                prefixed with this value (e.g. "registry.redhat.io/openshift4"
-                resolves "ose-must-gather" to
-                "registry.redhat.io/openshift4/ose-must-gather"). Set to an
-                empty string to restore the original behaviour of keeping the
-                short name as-is.
-            type: str
-            default: ""
 """
 
 EXAMPLES = r"""
-    # Resolve must-gather short names from CSV relatedImages
+    # Resolve must-gather short names from installed CSVs
     - name: Resolve must-gather images
       ansible.builtin.set_fact:
         resolved_images: >-
-          {{ image_list | redhatci.ocp.resolve_must_gather(related_images) }}
+          {{ image_list | redhatci.ocp.resolve_must_gather(csvs) }}
       vars:
         image_list:
-          - "ptp-must-gather"
-          - "registry.redhat.io/openshift4/custom-image:v4.18"
-        related_images:
-          - name: "ptp-must-gather-rhel9"
-            image: "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:abc123"
-
-    # Resolve with fallback registry for core OCP images (not in any CSV)
-    - name: Resolve must-gather images with fallback for core OCP images
-      ansible.builtin.set_fact:
-        resolved_images: >-
-          {{ image_list
-             | redhatci.ocp.resolve_must_gather(related_images,
-                                                'registry.redhat.io/openshift4') }}
-      vars:
-        image_list:
-          - "ose-must-gather"
-          - "ptp-must-gather"
-          - "registry.redhat.io/openshift4/custom-image:v4.18"
-        related_images:
-          - name: "ptp-must-gather-rhel9"
-            image: "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:abc123"
+          - "ptp"
+          - "acm"
+        csvs:
+          - name: "ptp-operator.v4.18.0"
+            display_name: "PTP Operator"
+            annotations:
+              operators.openshift.io/must-gather-image: >-
+                registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:abc
+            related_images: []
 """
 
 RETURN = r"""
     _value:
         description: >
-            List of resolved image references. Short names are replaced with
-            the full image reference from relatedImages. Unresolved short names
-            are kept as-is.
+            List of unique resolved image references. Unresolved short names
+            are omitted.
         type: list
         elements: str
 """
 
+MG_ANNOTATION = "operators.openshift.io/must-gather-image"
+_MIN_TOKEN_LEN = 3
 
-def _extract_rhel_suffix(image_ref):
-    """Extract the RHEL suffix (e.g. '-rhel8', '-rhel9') from an image ref.
 
-    Looks at the image path component (before any @sha256: or :tag) for
-    a '-rhel[0-9]+' pattern.
+def _norm(value):
+    return (value or "").lower().replace("-", "_")
+
+
+def _looks_like_must_gather(text):
+    """True if text looks like a must-gather image name or annotation key."""
+    normalized = _norm(text)
+    return "must_gather" in normalized or "mustgather" in normalized
+
+
+def _hint_tokens(hint):
+    """Build match tokens from a hint.
+
+    "ptp-must-gather" yields {"ptp_must_gather", "ptp"}.
+    Tokens shorter than 3 characters are dropped to avoid accidental matches.
     """
-    import re
-    path = image_ref.split("@")[0].split(":")[0]
-    basename = path.rsplit("/", 1)[-1]
-    m = re.search(r"(-rhel\d+)", basename)
-    return m.group(1) if m else ""
+    normalized = _norm(hint)
+    tokens = {normalized}
+    stripped = (
+        normalized.replace("must_gather", "")
+        .replace("mustgather", "")
+        .strip("_")
+    )
+    if stripped:
+        tokens.add(stripped)
+    return {token for token in tokens if len(token) >= _MIN_TOKEN_LEN}
 
 
-def _find_operator_image(keyword, related_images):
-    """Find a relatedImage whose name or image path contains the keyword."""
-    kw = keyword.lower().replace("-", "_")
-    for ri in related_images:
-        ri_name = ri.get("name", "").lower().replace("-", "_")
-        ri_image = ri.get("image", "")
-        ri_path = ri_image.split("@")[0].split(":")[0].rsplit("/", 1)[-1]
-        ri_path_norm = ri_path.lower().replace("-", "_")
-        if kw in ri_name or kw in ri_path_norm:
-            return ri_image
-    return ""
+def _normalize_csvs(csvs):
+    """Accept CSV lookup dicts or a legacy flat relatedImages list."""
+    if not csvs:
+        return []
+    first = csvs[0]
+    if not isinstance(first, dict):
+        return []
+    if (
+        "related_images" in first
+        or "annotations" in first
+        or "display_name" in first
+    ):
+        return csvs
+    return [
+        {
+            "name": "",
+            "display_name": "",
+            "annotations": {},
+            "related_images": csvs,
+        }
+    ]
 
 
-def resolve_must_gather(image_list, related_images, fallback_registry=""):
-    """Resolve must-gather image short names from CSV relatedImages.
+def _csv_blob(csv):
+    parts = [csv.get("name") or "", csv.get("display_name") or ""]
+    annotations = csv.get("annotations") or {}
+    for key, value in annotations.items():
+        parts.append(str(key))
+        parts.append(str(value))
+    for related in csv.get("related_images") or []:
+        if not isinstance(related, dict):
+            continue
+        parts.append(related.get("name") or "")
+        parts.append(related.get("image") or "")
+    return _norm(" ".join(parts))
+
+
+def _csv_matches(csv, tokens):
+    blob = _csv_blob(csv)
+    return any(token in blob for token in tokens)
+
+
+def _related_must_gather_image(related_images, tokens):
+    related_images = related_images or []
+    hint_match = None
+    any_mg = None
+    for related in related_images:
+        if not isinstance(related, dict):
+            continue
+        name = _norm(related.get("name", ""))
+        path = _norm(related.get("image", ""))
+        image = related.get("image")
+        if not image:
+            continue
+        if not _looks_like_must_gather(name) and not _looks_like_must_gather(path):
+            continue
+        if any_mg is None:
+            any_mg = image
+        if any(token in name or token in path for token in tokens):
+            hint_match = image
+            break
+    return hint_match or any_mg
+
+
+def _image_from_csv(csv, tokens):
+    annotations = csv.get("annotations") or {}
+    official = annotations.get(MG_ANNOTATION)
+    if official:
+        return official
+    for key, value in annotations.items():
+        if key == MG_ANNOTATION:
+            continue
+        if _looks_like_must_gather(key) and value and "/" in str(value):
+            return value
+    return _related_must_gather_image(csv.get("related_images"), tokens)
+
+
+def _has_official_annotation(csv):
+    annotations = csv.get("annotations") or {}
+    return bool(annotations.get(MG_ANNOTATION))
+
+
+def resolve_must_gather(image_list, csvs):
+    """Resolve must-gather image short names from installed CSVs.
 
     Args:
-        image_list (list): List of image entries (short names or full refs).
-        related_images (list): List of dicts with "name" and "image" keys
-            from ClusterServiceVersion relatedImages.
-        fallback_registry (str): Registry prefix used when a short name cannot
-            be resolved from any CSV relatedImages. Core OCP images (e.g.
-            ose-must-gather) are not shipped by any operator CSV and therefore
-            never appear in relatedImages. When non-empty, unresolved short
-            names are prefixed with this value. Defaults to "" (keep as-is).
+        image_list (list): List of short-name hints (full refs are ignored).
+        csvs (list): List of CSV lookup dicts, or a legacy flat relatedImages
+            list of {"name", "image"} dicts.
 
     Returns:
-        list: Resolved image references.
+        list: Unique resolved image references. Unresolved short names are omitted.
     """
     if not isinstance(image_list, list):
         return image_list
 
-    if not isinstance(related_images, list):
-        return image_list
+    if not isinstance(csvs, list):
+        return []
 
+    csv_list = _normalize_csvs(csvs)
     resolved = []
     for entry in image_list:
         if not isinstance(entry, str):
-            resolved.append(entry)
             continue
 
-        # Full image reference: pass through
         if "/" in entry:
-            resolved.append(entry)
             continue
 
-        # Short name: search in relatedImages by name and image path.
-        # When the entry doesn't already contain "must_gather", restrict
-        # matches to relatedImages whose name or image path does — so
-        # generic keywords like "openshift-gitops" or "acm" only match
-        # must-gather images, not arbitrary operator images.
-        entry_normalized = entry.lower().replace("-", "_")
-        is_mg_entry = "must_gather" in entry_normalized
-        match = None
-        for ri in related_images:
-            ri_name = ri.get("name", "").lower().replace("-", "_")
-            ri_image = ri.get("image", "")
-            ri_path = ri_image.split("@")[0].split(":")[0].lower().replace("-", "_")
-            if entry_normalized in ri_name or entry_normalized in ri_path:
-                if is_mg_entry or "must_gather" in ri_name or "must_gather" in ri_path:
-                    match = ri_image
-                    break
+        tokens = _hint_tokens(entry)
+        if not tokens:
+            continue
 
-        if match:
+        matched = [csv for csv in csv_list if _csv_matches(csv, tokens)]
+        matched.sort(key=lambda csv: 0 if _has_official_annotation(csv) else 1)
+        match = None
+        for csv in matched:
+            match = _image_from_csv(csv, tokens)
+            if match:
+                break
+
+        if match and match not in resolved:
             resolved.append(match)
-        elif fallback_registry:
-            # Must-gather images are not in CSV relatedImages.  Try to
-            # infer the RHEL suffix from the operator's own images.
-            # E.g. for "ptp-must-gather", find an operator image containing
-            # "ptp" to discover the "-rhel8" or "-rhel9" suffix.
-            rhel_suffix = ""
-            keyword = (entry_normalized
-                       .replace("must_gather", "")
-                       .replace("ose_", "")
-                       .strip("_"))
-            if keyword:
-                op_image = _find_operator_image(keyword, related_images)
-                if op_image:
-                    rhel_suffix = _extract_rhel_suffix(op_image)
-            resolved.append(
-                "{0}/{1}{2}".format(fallback_registry, entry, rhel_suffix))
-        else:
-            # Keep original so the caller can decide what to do
-            resolved.append(entry)
 
     return resolved
 

--- a/roles/resolve_must_gather_images/README.md
+++ b/roles/resolve_must_gather_images/README.md
@@ -1,45 +1,53 @@
 # Resolve Must-Gather Images
 
-Resolves must-gather image short names to full image references using
-the `relatedImages` from installed operator ClusterServiceVersion (CSV)
-resources.
+Resolves must-gather hints to full image references using installed
+operator ClusterServiceVersion (CSV) resources.
 
-This allows pipeline configurations to specify short image names
-(e.g. `ptp-must-gather`) instead of hardcoding full image references
-with version tags or digests. The role queries the cluster to find the
-exact image reference matching the installed operator version.
+This allows pipeline configurations to specify hints (e.g. `ptp`,
+`acm`, `gitops`) instead of hardcoding full image references with
+version tags or digests. The role queries the cluster to find the
+exact image for the installed operator version.
 
 ## How It Works
 
-1. Queries all installed CSVs on the cluster.
-2. Collects all `relatedImages` entries from the CSVs.
-3. For each entry in `rmgi_images`:
-   - If it contains a `/`, it is treated as a full image reference and
-     passed through unchanged.
-   - Otherwise, it is matched (substring) against the `relatedImages`
-     name field and replaced with the full image reference.
-   - If no CSV match is found and `rmgi_fallback_registry` is non-empty,
-     the short name is prefixed with `rmgi_fallback_registry`. This
-     handles core OCP images (e.g. `ose-must-gather`) that are not
-     shipped by any operator CSV.
-4. Sets the resolved list as `rmgi_resolved_images`.
+1. Queries all installed CSVs on the cluster (`!olm.copiedFrom`).
+2. Identifies CSVs that match each hint using the CSV name, displayName,
+   annotations, and `relatedImages`.
+3. For each matching CSV, takes the image in this order:
+   1. `operators.openshift.io/must-gather-image` annotation
+   2. Other CSV annotations whose key contains `must-gather`
+      (e.g. Service Mesh `images.v1_28_8.must-gather`)
+   3. `spec.relatedImages` entries whose name or image path contains
+      `must-gather` or `mustgather` (e.g. OADP `oadp-mustgather-rhel9`)
+4. Full image references (containing `/`) are ignored; pass those to
+   must-gather separately.
+5. Hints that cannot be resolved are **omitted** from the result. The
+   role does not invent a registry path for missing operators.
+6. Duplicate pullspecs are returned once (e.g. `mce` and
+   `multicluster-engine`).
+7. Sets the resolved list as `rmgi_resolved_images`.
 
 ## Variables
 
-| Variable               | Default                            | Required | Description                                                                                                                                                                   |
-| ---------------------- | ---------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| rmgi_images            | `["ose-must-gather"]`              | No       | List of must-gather image entries to resolve                                                                                                                                  |
-| rmgi_fallback_registry | `"registry.redhat.io/openshift4"` | No       | Registry prefix for short names that cannot be resolved from any CSV. Core OCP images (e.g. `ose-must-gather`) are not in any CSV. Set to `""` to keep unresolved names as-is |
+| Variable    | Default | Required | Description                                                                                         |
+| ----------- | ------- | -------- | --------------------------------------------------------------------------------------------------- |
+| rmgi_images | `[]`    | No       | List of hints that identify operators. Image names and other full references are ignored. Unresolved hints are dropped. |
 
 ## Output
 
-| Variable                | Description                              |
-| ----------------------- | ---------------------------------------- |
-| rmgi_resolved_images    | List of resolved full image references   |
+| Variable             | Description                            |
+| -------------------- | -------------------------------------- |
+| rmgi_resolved_images | List of resolved full image references |
 
 ## Examples
 
-### Resolve PTP and standard must-gather images
+### Resolve common operator must-gather images
+
+`rmgi_images` is a list of hints that identify the operator, not
+image names. Prefer the CSV or package name when a shorter hint is
+ambiguous (for example `oadp-operator` instead of `oadp`). Some
+operators advertise the operator image itself as must-gather (for
+example Lifecycle Agent).
 
 ```yaml
 - name: Resolve must-gather images
@@ -47,61 +55,43 @@ exact image reference matching the installed operator version.
     name: redhatci.ocp.resolve_must_gather_images
   vars:
     rmgi_images:
-      - "ose-must-gather"
-      - "ptp-must-gather"
+      - acm
+      - mce
+      - multicluster-engine
+      - ptp
+      - gitops
+      - lvms
+      - oadp-operator
+      - migration-toolkit-virtualization
+      - istio
+      - lifecycle-agent
+      - kmm
+      - cluster-logging
+      - local-storage
+      - openshift-compliance
 ```
 
 This resolves to something like:
 
 ```yaml
 rmgi_resolved_images:
-  - "registry.redhat.io/openshift4/ose-must-gather@sha256:abc123..."
-  - "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:def456..."
+  - registry.redhat.io/rhacm2/acm-must-gather-rhel9@sha256:...
+  - registry.redhat.io/multicluster-engine/must-gather-rhel9@sha256:...
+  - registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:...
+  - registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:...
+  - registry.redhat.io/lvms4/lvms-must-gather-rhel9@sha256:...
+  - registry.redhat.io/oadp/oadp-mustgather-rhel9@sha256:...
+  - registry.redhat.io/migration-toolkit-virtualization/mtv-must-gather-rhel8@sha256:...
+  - registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel9@sha256:...
+  - registry.redhat.io/openshift4/lifecycle-agent-rhel9-operator@sha256:...
+  - registry.redhat.io/kmm/kernel-module-management-must-gather-rhel9@sha256:...
+  - registry.redhat.io/openshift5/ose-local-storage-mustgather-rhel9@sha256:...
+  - registry.redhat.io/compliance/openshift-compliance-must-gather-rhel8@sha256:...
 ```
 
-### Mix short names with full references
-
-```yaml
-- name: Resolve must-gather images
-  ansible.builtin.include_role:
-    name: redhatci.ocp.resolve_must_gather_images
-  vars:
-    rmgi_images:
-      - "ose-must-gather"
-      - "ptp-must-gather"
-      - "registry.redhat.io/openshift4/custom-must-gather:latest"
-```
-
-### Resolve core OCP images using fallback registry
-
-Core OCP images such as `ose-must-gather` are not shipped by any operator
-CSV, so they cannot be resolved from `relatedImages`. The `rmgi_fallback_registry`
-variable provides a fallback: unresolved short names are prefixed with it.
-
-```yaml
-- name: Resolve must-gather images with fallback for core OCP images
-  ansible.builtin.include_role:
-    name: redhatci.ocp.resolve_must_gather_images
-  vars:
-    rmgi_images:
-      - "ose-must-gather"        # core OCP image — resolved via fallback
-      - "ptp-must-gather"        # operator image — resolved from CSV
-    rmgi_fallback_registry: "registry.redhat.io/openshift4"
-```
-
-This resolves to something like:
-
-```yaml
-rmgi_resolved_images:
-  - "registry.redhat.io/openshift4/ose-must-gather"
-  - "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:def456..."
-```
-
-To disable the fallback and keep unresolved names as-is (original behaviour):
-
-```yaml
-    rmgi_fallback_registry: ""
-```
+`mce` and `multicluster-engine` resolve to the same pullspec and are
+returned once. Hints for operators that are not installed (for example
+`cluster-logging` above) are omitted.
 
 ## Filter Plugin
 
@@ -112,5 +102,5 @@ which can also be used standalone:
 - name: Resolve images inline
   ansible.builtin.set_fact:
     resolved: >-
-      {{ my_images | redhatci.ocp.resolve_must_gather(related_images_list) }}
+      {{ my_images | redhatci.ocp.resolve_must_gather(csv_lookup_list) }}
 ```

--- a/roles/resolve_must_gather_images/defaults/main.yml
+++ b/roles/resolve_must_gather_images/defaults/main.yml
@@ -1,17 +1,5 @@
 ---
-# List of must-gather image entries.
-# Each entry can be:
-#   - A short name (e.g. "ptp-must-gather") resolved from installed
-#     operator CSV relatedImages
-#   - A full image reference (e.g. "registry.redhat.io/openshift4/ose-must-gather:v4.18")
-#     passed through unchanged
-rmgi_images:
-  - "ose-must-gather"
-
-# Fallback registry prefix for short names that cannot be resolved from CSVs.
-# Core OCP images (e.g. ose-must-gather) are not in any CSV relatedImages.
-# When non-empty, unresolved short names are prefixed with this registry.
-# Example: "registry.redhat.io/openshift4" resolves "ose-must-gather" to
-# "registry.redhat.io/openshift4/ose-must-gather"
-rmgi_fallback_registry: "registry.redhat.io/openshift4"
-...
+# List of must-gather image hints (short names or keywords, e.g. "ptp",
+# "acm", "gitops"). Full image references are ignored. Unresolved hints
+# are omitted from the output.
+rmgi_images: []

--- a/roles/resolve_must_gather_images/tasks/main.yml
+++ b/roles/resolve_must_gather_images/tasks/main.yml
@@ -8,20 +8,23 @@
   register: _rmgi_csvs
   no_log: true
 
-- name: Build relatedImages list from all CSVs
+- name: Build CSV lookup data
   ansible.builtin.set_fact:
-    rmgi_related_images: >-
-      {{ _rmgi_csvs.resources
-         | json_query('[*].spec.relatedImages[*]')
-         | flatten }}
+    rmgi_csvs: >-
+      {{ _rmgi_csvs.resources | default([]) | json_query('[].{
+           name: metadata.name,
+           display_name: spec.displayName,
+           annotations: metadata.annotations,
+           related_images: spec.relatedImages
+         }') }}
+  no_log: true
 
 - name: Resolve must-gather image names
   ansible.builtin.set_fact:
     rmgi_resolved_images: >-
-      {{ rmgi_images
-         | redhatci.ocp.resolve_must_gather(rmgi_related_images, rmgi_fallback_registry) }}
+      {{ rmgi_images | redhatci.ocp.resolve_must_gather(rmgi_csvs) | unique | list }}
+  no_log: true
 
 - name: Display resolved must-gather images
   ansible.builtin.debug:
     msg: "Resolved must-gather images: {{ rmgi_resolved_images }}"
-...

--- a/tests/integration/resolve_must_gather/test_resolve_must_gather.yml
+++ b/tests/integration/resolve_must_gather/test_resolve_must_gather.yml
@@ -6,8 +6,8 @@
     KUBECONFIG: "{{ kubeconfig | default('/tmp/kubeconfig') }}"
   vars:
     rmgi_images:
-      - ose-must-gather
-      - ptp-must-gather
+      - ptp
+      - this-operator-is-not-installed
   tasks:
     - name: Display input images
       ansible.builtin.debug:
@@ -23,10 +23,10 @@
       ansible.builtin.debug:
         msg: "Resolved images: {{ rmgi_resolved_images }}"
 
-    - name: Verify all images were resolved to full references
+    - name: Verify unresolved hints were omitted and resolved refs are full images
       ansible.builtin.assert:
         that:
-          - rmgi_resolved_images | length == rmgi_images | length
-          - rmgi_resolved_images | select('match', '.*@sha256:.*') | list | length == rmgi_resolved_images | length
-        fail_msg: "Not all images were resolved to digest references"
-        success_msg: "All {{ rmgi_resolved_images | length }} images resolved successfully"
+          - "'this-operator-is-not-installed' not in rmgi_resolved_images"
+          - rmgi_resolved_images | reject('search', '/') | list | length == 0
+        fail_msg: "Unresolved hints must be omitted; resolved entries must be full image refs"
+        success_msg: "Resolved {{ rmgi_resolved_images | length }} image(s); unresolved hints omitted"

--- a/tests/unit/filter/test_resolve_must_gather.py
+++ b/tests/unit/filter/test_resolve_must_gather.py
@@ -19,221 +19,221 @@ __metaclass__ = type
 from ansible_collections.redhatci.ocp.plugins.filter import resolve_must_gather
 
 
-SAMPLE_RELATED_IMAGES = [
-    {
-        "name": "ose-must-gather",
-        "image": "registry.redhat.io/openshift4/ose-must-gather@sha256:aaa111",
+PTP_CSV = {
+    "name": "ptp-operator.v4.18.0",
+    "display_name": "PTP Operator",
+    "annotations": {
+        "operators.openshift.io/must-gather-image": (
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann"
+        ),
     },
-    {
-        "name": "ptp-must-gather-rhel9",
-        "image": "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222",
+    "related_images": [
+        {
+            "name": "ptp-operator",
+            "image": "registry.redhat.io/openshift5/ptp-operator@sha256:op",
+        },
+        {
+            "name": "ptp-must-gather-rhel9",
+            "image": "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptprel",
+        },
+    ],
+}
+
+ACM_CSV = {
+    "name": "advanced-cluster-management.v2.12.0",
+    "display_name": "Advanced Cluster Management for Kubernetes",
+    "annotations": {
+        "operators.openshift.io/must-gather-image": (
+            "registry.redhat.io/rhacm2/acm-must-gather-rhel9@sha256:acmann"
+        ),
     },
-    {
-        "name": "sriov-network-must-gather-rhel9",
-        "image": "registry.redhat.io/openshift4/sriov-network-must-gather-rhel9@sha256:ccc333",
+    "related_images": [
+        {
+            "name": "acm-operator",
+            "image": "registry.redhat.io/rhacm2/acm-operator@sha256:op",
+        },
+    ],
+}
+
+GITOPS_RELATED_ONLY = {
+    "name": "openshift-gitops-operator.v1.16.0",
+    "display_name": "OpenShift GitOps",
+    "annotations": {},
+    "related_images": [
+        {
+            "name": "must_gather_image",
+            "image": (
+                "registry.redhat.io/openshift-gitops-1/"
+                "must-gather-rhel9@sha256:gitopsrel"
+            ),
+        },
+        {
+            "name": "gitops-operator",
+            "image": (
+                "registry.redhat.io/openshift-gitops-1/"
+                "gitops-rhel9-operator@sha256:op"
+            ),
+        },
+    ],
+}
+
+MESH_OTHER_ANN = {
+    "name": "servicemeshoperator.v2.6.0",
+    "display_name": "OpenShift Service Mesh",
+    "annotations": {
+        "images.v1_28_8.must-gather": (
+            "registry.redhat.io/openshift-service-mesh/"
+            "istio-must-gather-rhel9@sha256:meshann"
+        ),
     },
-    {
-        "name": "ptp-operator",
-        "image": "registry.redhat.io/openshift4/ptp-operator@sha256:ddd444",
-    },
-    {
-        "name": "linuxptp-daemon-rhel9",
-        "image": "registry.redhat.io/openshift4/linuxptp-daemon-rhel9@sha256:eee555",
-    },
-]
+    "related_images": [],
+}
+
+SAMPLE_CSVS = [PTP_CSV, ACM_CSV, GITOPS_RELATED_ONLY]
 
 
 class TestResolveMustGather:
-    def test_resolve_short_name(self):
-        """Test resolving a short name to a full image reference."""
-        result = resolve_must_gather.resolve_must_gather(
-            ["ptp-must-gather"], SAMPLE_RELATED_IMAGES
-        )
+    def test_annotation_preferred_over_related_images(self):
+        result = resolve_must_gather.resolve_must_gather(["ptp"], SAMPLE_CSVS)
         assert result == [
-            "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222"
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann"
         ]
 
-    def test_resolve_multiple_short_names(self):
-        """Test resolving multiple short names."""
-        result = resolve_must_gather.resolve_must_gather(
-            ["ose-must-gather", "ptp-must-gather", "sriov-network-must-gather"],
-            SAMPLE_RELATED_IMAGES,
-        )
+    def test_keyword_identifies_csv_without_hint_in_csv_name(self):
+        """'acm' is not in the CSV name; annotation image path identifies it."""
+        result = resolve_must_gather.resolve_must_gather(["acm"], SAMPLE_CSVS)
         assert result == [
-            "registry.redhat.io/openshift4/ose-must-gather@sha256:aaa111",
-            "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222",
-            "registry.redhat.io/openshift4/sriov-network-must-gather-rhel9@sha256:ccc333",
+            "registry.redhat.io/rhacm2/acm-must-gather-rhel9@sha256:acmann"
         ]
 
-    def test_passthrough_full_reference(self):
-        """Test that full image references are passed through unchanged."""
+    def test_related_images_used_when_annotation_missing(self):
+        result = resolve_must_gather.resolve_must_gather(
+            ["gitops"], SAMPLE_CSVS
+        )
+        assert result == [
+            "registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:gitopsrel"
+        ]
+
+    def test_other_must_gather_annotation(self):
+        result = resolve_must_gather.resolve_must_gather(
+            ["servicemesh"], [MESH_OTHER_ANN]
+        )
+        assert result == [
+            "registry.redhat.io/openshift-service-mesh/"
+            "istio-must-gather-rhel9@sha256:meshann"
+        ]
+
+    def test_full_reference_ignored(self):
         full_ref = "registry.redhat.io/openshift4/custom-image:v4.18"
         result = resolve_must_gather.resolve_must_gather(
-            [full_ref], SAMPLE_RELATED_IMAGES
+            [full_ref], SAMPLE_CSVS
         )
-        assert result == [full_ref]
-
-    def test_mixed_short_and_full(self):
-        """Test mix of short names and full references."""
-        result = resolve_must_gather.resolve_must_gather(
-            [
-                "ose-must-gather",
-                "registry.redhat.io/openshift4/custom-image:latest",
-                "ptp-must-gather",
-            ],
-            SAMPLE_RELATED_IMAGES,
-        )
-        assert result == [
-            "registry.redhat.io/openshift4/ose-must-gather@sha256:aaa111",
-            "registry.redhat.io/openshift4/custom-image:latest",
-            "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222",
-        ]
-
-    def test_unresolved_short_name_kept(self):
-        """Test that unresolved short names are kept as-is."""
-        result = resolve_must_gather.resolve_must_gather(
-            ["nonexistent-must-gather"], SAMPLE_RELATED_IMAGES
-        )
-        assert result == ["nonexistent-must-gather"]
-
-    def test_empty_image_list(self):
-        """Test with an empty image list."""
-        result = resolve_must_gather.resolve_must_gather([], SAMPLE_RELATED_IMAGES)
         assert result == []
 
-    def test_empty_related_images(self):
-        """Test with empty relatedImages list."""
+    def test_mixed_hints_ignore_full_reference(self):
         result = resolve_must_gather.resolve_must_gather(
-            ["ptp-must-gather"], []
+            [
+                "ptp",
+                "registry.redhat.io/openshift4/custom-image:latest",
+                "acm",
+            ],
+            SAMPLE_CSVS,
         )
-        assert result == ["ptp-must-gather"]
+        assert result == [
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann",
+            "registry.redhat.io/rhacm2/acm-must-gather-rhel9@sha256:acmann",
+        ]
+
+    def test_unresolved_hint_omitted(self):
+        result = resolve_must_gather.resolve_must_gather(
+            ["nonexistent", "ptp"], SAMPLE_CSVS
+        )
+        assert result == [
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann"
+        ]
+
+    def test_no_fallback_registry(self):
+        result = resolve_must_gather.resolve_must_gather(
+            ["ose-must-gather"], SAMPLE_CSVS
+        )
+        assert result == []
+
+    def test_empty_image_list(self):
+        result = resolve_must_gather.resolve_must_gather([], SAMPLE_CSVS)
+        assert result == []
+
+    def test_empty_csvs(self):
+        result = resolve_must_gather.resolve_must_gather(["ptp"], [])
+        assert result == []
 
     def test_non_list_input(self):
-        """Test that non-list input is returned as-is."""
         result = resolve_must_gather.resolve_must_gather(
-            "not-a-list", SAMPLE_RELATED_IMAGES
+            "not-a-list", SAMPLE_CSVS
         )
         assert result == "not-a-list"
 
-    def test_non_list_related_images(self):
-        """Test that non-list relatedImages returns input as-is."""
+    def test_non_list_csvs(self):
         result = resolve_must_gather.resolve_must_gather(
-            ["ptp-must-gather"], "not-a-list"
+            ["ptp"], "not-a-list"
         )
-        assert result == ["ptp-must-gather"]
+        assert result == []
 
-    def test_non_string_entry(self):
-        """Test that non-string entries are kept as-is."""
+    def test_non_string_entry_omitted(self):
         result = resolve_must_gather.resolve_must_gather(
-            [42, None, "ptp-must-gather"], SAMPLE_RELATED_IMAGES
+            [42, None, "ptp"], SAMPLE_CSVS
         )
         assert result == [
-            42,
-            None,
-            "registry.redhat.io/openshift4/ptp-must-gather-rhel9@sha256:bbb222",
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann"
         ]
 
-    def test_first_match_wins(self):
-        """Test that the first matching relatedImage is used."""
-        related = [
-            {"name": "ptp-must-gather-rhel8", "image": "rhel8-image@sha256:111"},
-            {"name": "ptp-must-gather-rhel9", "image": "rhel9-image@sha256:222"},
-        ]
-        result = resolve_must_gather.resolve_must_gather(
-            ["ptp-must-gather"], related
-        )
-        # First match wins
-        assert result == ["rhel8-image@sha256:111"]
-
-    def test_fallback_registry_core_ocp_image(self):
-        """Test fallback registry for core OCP images not present in any CSV."""
-        result = resolve_must_gather.resolve_must_gather(
-            ["ose-must-gather"],
-            [],
-            "registry.redhat.io/openshift4",
-        )
-        assert result == ["registry.redhat.io/openshift4/ose-must-gather"]
-
-    def test_fallback_infers_rhel_suffix_from_operator(self):
-        """Test that fallback infers RHEL suffix from operator images.
-
-        When a must-gather short name (e.g. ptp-must-gather) is not in
-        CSV relatedImages, but the operator's own images contain a
-        matching keyword with a RHEL suffix, the fallback should use
-        that suffix.
-        """
-        related = [
+    def test_null_csv_fields_from_json_query(self):
+        """json_query sets missing CSV fields to None, not omitted keys."""
+        csvs = [
             {
-                "name": "ose-ptp-rhel9",
-                "image": "registry.redhat.io/openshift4/ose-ptp-rhel9@sha256:abc",
-            },
-            {
-                "name": "ose-ptp-rhel9-operator",
-                "image": "registry.redhat.io/openshift4/ose-ptp-rhel9-operator@sha256:def",
-            },
+                "name": "ptp-operator.v4.18.0",
+                "display_name": None,
+                "annotations": {
+                    "operators.openshift.io/must-gather-image": (
+                        "registry.redhat.io/openshift5/"
+                        "ptp-must-gather-rhel9@sha256:ptpann"
+                    ),
+                },
+                "related_images": [
+                    {
+                        "name": None,
+                        "image": (
+                            "registry.redhat.io/openshift5/"
+                            "ptp-must-gather-rhel9@sha256:ptprel"
+                        ),
+                    },
+                ],
+            }
         ]
+        result = resolve_must_gather.resolve_must_gather(["ptp"], csvs)
+        assert result == [
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann"
+        ]
+
+    def test_prefers_annotated_csv_when_multiple_match(self):
+        related_only_ptp = {
+            "name": "other-ptp.v1.0.0",
+            "display_name": "Other PTP",
+            "annotations": {},
+            "related_images": [
+                {
+                    "name": "ptp-must-gather-rhel8",
+                    "image": "registry.example/ptp-must-gather-rhel8@sha256:old",
+                },
+            ],
+        }
         result = resolve_must_gather.resolve_must_gather(
-            ["ptp-must-gather"],
-            related,
-            "registry.redhat.io/openshift4",
+            ["ptp"], [related_only_ptp, PTP_CSV]
         )
         assert result == [
-            "registry.redhat.io/openshift4/ptp-must-gather-rhel9"
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann"
         ]
 
-    def test_fallback_infers_rhel8_suffix(self):
-        """Test RHEL 8 suffix inference from operator images."""
-        related = [
-            {
-                "name": "linuxptp-daemon-rhel8",
-                "image": "registry.redhat.io/openshift4/linuxptp-daemon-rhel8@sha256:abc",
-            },
-        ]
-        result = resolve_must_gather.resolve_must_gather(
-            ["ptp-must-gather"],
-            related,
-            "registry.redhat.io/openshift4",
-        )
-        assert result == [
-            "registry.redhat.io/openshift4/ptp-must-gather-rhel8"
-        ]
-
-    def test_fallback_no_rhel_suffix_when_no_operator_match(self):
-        """Test fallback without RHEL suffix when no operator image matches."""
-        related = [
-            {
-                "name": "unrelated-operator",
-                "image": "registry.redhat.io/openshift4/unrelated-rhel9@sha256:abc",
-            },
-        ]
-        result = resolve_must_gather.resolve_must_gather(
-            ["ptp-must-gather"],
-            related,
-            "registry.redhat.io/openshift4",
-        )
-        assert result == ["registry.redhat.io/openshift4/ptp-must-gather"]
-
-    def test_keyword_matches_image_path(self):
-        """Test that a keyword matches the image path, not just the name."""
-        related = [
-            {
-                "name": "must_gather_image",
-                "image": "registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:aaa",
-            },
-            {
-                "name": "gitops-operator",
-                "image": "registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:bbb",
-            },
-        ]
-        result = resolve_must_gather.resolve_must_gather(
-            ["openshift-gitops"], related
-        )
-        assert result == [
-            "registry.redhat.io/openshift-gitops-1/must-gather-rhel9@sha256:aaa"
-        ]
-
-    def test_keyword_matches_acm_by_name(self):
-        """Test that 'acm' matches acm_must_gather in the name field."""
+    def test_legacy_flat_related_images(self):
         related = [
             {
                 "name": "acm_must_gather",
@@ -249,50 +249,101 @@ class TestResolveMustGather:
             "registry.redhat.io/rhacm2/acm-must-gather-rhel9@sha256:aaa"
         ]
 
-    def test_keyword_skips_non_must_gather(self):
-        """Test that a generic keyword doesn't match non-must-gather images."""
-        related = [
+    def test_keyword_skips_non_must_gather_related_image(self):
+        csvs = [
             {
-                "name": "gitops-operator",
-                "image": "registry.redhat.io/openshift-gitops-1/gitops-rhel9-operator@sha256:bbb",
-            },
+                "name": "openshift-gitops-operator.v1.16.0",
+                "display_name": "OpenShift GitOps",
+                "annotations": {},
+                "related_images": [
+                    {
+                        "name": "gitops-operator",
+                        "image": (
+                            "registry.redhat.io/openshift-gitops-1/"
+                            "gitops-rhel9-operator@sha256:bbb"
+                        ),
+                    },
+                ],
+            }
+        ]
+        result = resolve_must_gather.resolve_must_gather(["gitops"], csvs)
+        assert result == []
+
+    def test_mustgather_without_hyphen(self):
+        """OADP ships oadp-mustgather (no hyphen) in relatedImages."""
+        csvs = [
+            {
+                "name": "oadp-operator.v1.6.1",
+                "display_name": "OADP Operator",
+                "annotations": {},
+                "related_images": [
+                    {
+                        "name": "oadp-mustgather-rhel9",
+                        "image": (
+                            "registry.redhat.io/oadp/"
+                            "oadp-mustgather-rhel9@sha256:oadp"
+                        ),
+                    },
+                    {
+                        "name": "oadp-rhel9-operator",
+                        "image": (
+                            "registry.redhat.io/oadp/"
+                            "oadp-rhel9-operator@sha256:op"
+                        ),
+                    },
+                ],
+            }
+        ]
+        result = resolve_must_gather.resolve_must_gather(["oadp"], csvs)
+        assert result == [
+            "registry.redhat.io/oadp/oadp-mustgather-rhel9@sha256:oadp"
+        ]
+
+    def test_duplicate_resolved_images_unique(self):
+        result = resolve_must_gather.resolve_must_gather(
+            ["ptp", "ptp-must-gather", "acm", "acm"], SAMPLE_CSVS
+        )
+        assert result == [
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann",
+            "registry.redhat.io/rhacm2/acm-must-gather-rhel9@sha256:acmann",
+        ]
+
+    def test_different_hints_same_image_unique(self):
+        csvs = [
+            {
+                "name": "multicluster-engine.v5.0.0",
+                "display_name": "Multicluster Engine",
+                "annotations": {
+                    "operators.openshift.io/must-gather-image": (
+                        "registry.redhat.io/multicluster-engine/"
+                        "must-gather-rhel9@sha256:mce"
+                    ),
+                },
+                "related_images": [],
+            }
         ]
         result = resolve_must_gather.resolve_must_gather(
-            ["openshift-gitops"], related
+            ["mce", "multicluster-engine"], csvs
         )
-        assert result == ["openshift-gitops"]
-
-    def test_fallback_registry_empty_string(self):
-        """Test that empty fallback_registry keeps unresolved name as-is (backward compat)."""
-        result = resolve_must_gather.resolve_must_gather(
-            ["nonexistent-must-gather"],
-            [],
-            "",
-        )
-        assert result == ["nonexistent-must-gather"]
-
-    def test_fallback_registry_disabled(self):
-        """Test that omitting fallback_registry keeps unresolved name as-is (backward compat)."""
-        result = resolve_must_gather.resolve_must_gather(
-            ["nonexistent-must-gather"],
-            [],
-        )
-        assert result == ["nonexistent-must-gather"]
+        assert result == [
+            "registry.redhat.io/multicluster-engine/must-gather-rhel9@sha256:mce"
+        ]
 
 
 class TestFilterModule:
     def test_filter_module_exposes_filter(self):
-        """Test that FilterModule properly exposes the filter."""
         fm = resolve_must_gather.FilterModule()
         filters = fm.filters()
         assert "resolve_must_gather" in filters
-        assert filters["resolve_must_gather"] == resolve_must_gather.resolve_must_gather
+        assert (
+            filters["resolve_must_gather"]
+            == resolve_must_gather.resolve_must_gather
+        )
 
     def test_filter_module_callable(self):
-        """Test that the filter can be called through FilterModule."""
         fm = resolve_must_gather.FilterModule()
         func = fm.filters()["resolve_must_gather"]
-        result = func(["ose-must-gather"], SAMPLE_RELATED_IMAGES)
+        result = func(["ptp"], SAMPLE_CSVS)
         assert result == [
-            "registry.redhat.io/openshift4/ose-must-gather@sha256:aaa111"
+            "registry.redhat.io/openshift5/ptp-must-gather-rhel9@sha256:ptpann"
         ]


### PR DESCRIPTION
##### SUMMARY

- Resolve must-gather hints from installed CSVs, preferring operators.openshift.io/must-gather-image, then other must-gather / mustgather annotations, then relatedImages.
- Drop rmgi_fallback_registry
- Role input is hints only; full image refs (containing /) are ignored.
- Return a unique list when several hints map to the same pullspec (mce and multicluster-engine)
- Stop inventing results

Assisted-by: Cursor

Test-hints: no-check